### PR TITLE
Another attempted Jenkins fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
                 dir('./gitrepo') {
                     git(
                             url: 'https://github.com/ncbo/kg-bioportal',
-                            branch: env.GIT_BRANCH
+                            branch: 'main'
                     )
                     sh '/usr/bin/python3.8 -m venv venv'
                     sh '. venv/bin/activate'


### PR DESCRIPTION
Hard-code the branch, so it doesn't end up with an extra `origin/` in it