### PR TITLE
Implement node merge and checking

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,7 +114,10 @@ pipeline {
             steps {
                 dir('./gitrepo') {
 			        sh '. venv/bin/activate && python3.8 run.py catmerge --merge_all'
-                    sh 'tar -rvfz data/merged/merged-kg.tar.gz data/merged/qc/'
+                    sh 'gunzip data/merged/merged-kg.tar.gz'
+                    sh 'tar -rvf data/merged/merged-kg.tar data/merged/qc/'
+                    sh 'tar -rvf data/merged/merged-kg.tar data/merged/merged-kg_nodes.tsv'
+                    sh 'gzip data/merged/merged-kg.tar'
                     //sh '. venv/bin/activate && python3.8 run.py catmerge --include_only $ONTOSET'
                     //sh 'cp merged_graph_stats.yaml merged_graph_stats_$BUILDSTARTDATE.yaml'
                     //sh 'tar -rvfz data/merged/merged-kg.tar.gz merged_graph_stats_$BUILDSTARTDATE.yaml'

--- a/kg_bioportal/merge_utils/merge_kg.py
+++ b/kg_bioportal/merge_utils/merge_kg.py
@@ -101,8 +101,19 @@ def merge_with_cat_merge(merge_all: bool, include_only: list, exclude: list) -> 
 
     """
     
+
+
     nodepaths = []
     edgepaths = []
+
+    # Prepare a blank header edgefile so we can ensure we have the correct
+    # column headings
+    blank_header_path = "blank_header.tsv"
+    if not os.path.exists(blank_header_path):
+        with open(blank_header_path, "w") as outfile:
+            outstring = "id\tobject\tsubject\tpredicate\tcategory\n"
+            outfile.write(outstring)
+    edgepaths.append(blank_header_path)
 
     # Need to know ontology names and filepaths
     # Keys in onto_paths are short names, values are lists of filepaths.
@@ -124,7 +135,7 @@ def merge_with_cat_merge(merge_all: bool, include_only: list, exclude: list) -> 
     # Separate out node vs. edgelist
     # Do a check to verify that none of the files are empty, or the merge will fail
     # also verify the header in each contains an 'id' field
-    # and validate the values in the 
+    # (it's invalid without it)
     ignore_paths = []
     for onto_name in onto_paths:
         print(f"Validating {onto_name}...")

--- a/kg_bioportal/merge_utils/merge_kg.py
+++ b/kg_bioportal/merge_utils/merge_kg.py
@@ -90,6 +90,11 @@ def load_and_merge(yaml_file: str, processes: int = 1) -> nx.MultiDiGraph:
 
 def merge_with_cat_merge(merge_all: bool, include_only: list, exclude: list) -> None:
     """Load and merge sources with cat-merge.
+    Cat-merge does not merge values based on their ids,
+    it just concatenates and drops exact duplicates.
+    A subsequent step here performs further merging
+    on identical IDs and concatenates other values,
+    delimiting with pipe symbols.
 
     Args:
         merge_all: if True, merge all ontology node and edges.
@@ -101,8 +106,6 @@ def merge_with_cat_merge(merge_all: bool, include_only: list, exclude: list) -> 
 
     """
     
-
-
     nodepaths = []
     edgepaths = []
 

--- a/kg_bioportal/merge_utils/merge_kg.py
+++ b/kg_bioportal/merge_utils/merge_kg.py
@@ -207,11 +207,15 @@ def merge_with_cat_merge(merge_all: bool, include_only: list, exclude: list) -> 
 
     with open(nodefile_path, 'r') as infile:
         with open(temp_nodefile_path, 'w') as outfile:
+            seen_ids = []
             for line in infile:
                 splitline = line.split("\t")
                 if splitline[0] in uniq_ids:
+                    if splitline[0] in seen_ids:
+                        continue
                     outrow = uniq_df.loc[uniq_df['id'] == splitline[0]]
-                    outline = outrow.to_csv(header=None, index=False, sep='\t').rstrip('\n')
+                    outline = outrow.to_csv(header=None, index=False, sep='\t')
+                    seen_ids.append(splitline[0])
                     outfile.write(outline)
                 else:
                     outfile.write(line)

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         'compress_json',
         'click==8.0.4',
         'pyyaml',
-        'kgx==1.5.7',
+        'kgx==1.5.9',
         'sphinx',
         'sphinx_rtd_theme',
         'recommonmark',
@@ -72,7 +72,7 @@ setup(
         'networkx',
         'kghub-downloader',
         'koza',
-        'cat-merge==0.1.7'
+        'cat-merge==0.1.15'
     ],
     extras_require=extras,
 )

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ setup(
         'pandas',
         'networkx',
         'kghub-downloader',
-        'koza',
         'cat-merge==0.1.15'
     ],
     extras_require=extras,


### PR DESCRIPTION
The merged KG contains numerous redundancies due to the strategy used by `cat-merge`, so we need to merge those redundant nodes while accounting for identical fields.
e.g., if we have three copies of a protein node with the same CURIE, ensure it becomes one node with a category of `biolink:Protein` rather than `biolink:Protein biolink:Protein biolink:Protein`.