### PR TITLE
Serve the docs site (incl. KG browser) via a GitHub Actions Pages build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,67 @@
+name: Deploy docs site to Pages
+
+# Builds and deploys the kg-bioportal docs site (Jekyll) to GitHub Pages.
+#
+# Unlike the old "deploy from a branch" mode, this actually runs
+# docs/build_site.sh first, which:
+#   - fetches the latest transform stats from the release,
+#   - regenerates _config.yml + the plotly figures (make_viz.py), and
+#   - generates the KG-Registry-driven browser under docs/graphs/.
+# Then Jekyll builds the site and it is deployed to Pages.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress one.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install Python deps for site generation
+        run: pip install pandas plotly pyyaml
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: docs
+      - uses: actions/configure-pages@v5
+      - name: Assemble site (stats, figures, KG browser)
+        run: bash build_site.sh
+      - name: Build with Jekyll
+        run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/_config_header.yml
+++ b/docs/_config_header.yml
@@ -31,24 +31,18 @@ remote_theme: pages-themes/slate@v0.2.0
 plugins:
 - jekyll-remote-theme
 
-# Exclude from processing.
-# The following items will not be processed, by default.
-# Any item listed under the `exclude:` key here will be automatically added to
-# the internal "default list".
-#
-# Excluded items can be processed by explicitly listing the directories or
-# their entries' file path in the `include:` list.
-#
-# exclude:
-#   - .sass-cache/
-#   - .jekyll-cache/
-#   - gemfiles/
-#   - Gemfile
-#   - Gemfile.lock
-#   - node_modules/
-#   - vendor/bundle/
-#   - vendor/cache/
-#   - vendor/gems/
-#   - vendor/ruby/
+# Exclude from processing so build inputs/scripts are not published to the site.
+# (The generated docs/graphs/ browser is NOT excluded — it is meant to be served.)
+exclude:
+  - .sass-cache/
+  - .jekyll-cache/
+  - Gemfile
+  - Gemfile.lock
+  - vendor/
+  - build_site.sh
+  - make_viz.py
+  - kg_site/
+  - onto_stats.yaml
+  - total_stats.yaml
 
 # Ontology status table goes under here.

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,9 +3,17 @@ layout: default
 title: KG-Bioportal
 ---
 
-<div class="content">    
+<div class="content">
     <div class="col-md-12">
-      
+
+      <h3>Browse the knowledge graphs</h3>
+      <p>
+        <a href="{{ '/graphs/' | relative_url }}"><strong>Open the KG-Bioportal browser &rarr;</strong></a>
+        &mdash; a BioPortal-style interface over the knowledge graphs, generated from
+        <a href="https://kghub.org/kg-registry/">KG-Registry</a> <em>(prototype)</em>.
+      </p>
+      <br>
+
       <h3>Learn more about KG-Bioportal</h3>
         <li><a href="https://ncbo.github.io/kg-bioportal/about">Learn more about KG-Bioportal</a></li>
         <li><a href="https://bioportal.bioontology.org/">Visit BioPortal</a></li>


### PR DESCRIPTION
## Why

The site at https://ncbo.github.io/kg-bioportal/ builds in **legacy "deploy from a branch"** mode, which only runs `jekyll build` — it never runs `docs/build_site.sh`. But that script is what generates `_config.yml`, the plotly figures, **and** the KG-Registry browser under `docs/graphs/`. So the browser (added in #107) is gitignored and never published, and the stats/figures only ever updated when someone ran the script by hand.

## What

A proper Pages workflow that runs the build the way it was designed:

1. `docs/build_site.sh` — fetch latest transform stats from the release → regenerate `_config.yml` + figures (`make_viz.py`) → generate `docs/graphs/`.
2. `jekyll build`.
3. deploy to Pages.

- **`.github/workflows/pages.yml`** (new) — build + deploy.
- **`docs/_config_header.yml`** — active `exclude:` so build scripts and the ~30 MB `kgs.jsonld` aren't published (the generated `graphs/` browser **is** served).
- **`docs/index.html`** — a link to the browser at `/graphs/`.

## Required settings change (one-time)

This needs the repo's **Pages source flipped to "GitHub Actions"** (Settings → Pages, or via API). Until then the deploy step can't publish. Once flipped, the browser lands at **https://ncbo.github.io/kg-bioportal/graphs/**.

Note: the site's stats will reflect the latest release — right now that's the 3-ontology dry-run (`data-2026.07`); a full transform run will populate the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)