### PR TITLE
Pin Pages build to Ruby 3.1 (github-pages gem needs String#tainted?)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,7 +42,10 @@ jobs:
         run: pip install pandas plotly pyyaml
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          # Ruby 3.1: the github-pages gem pins an old Liquid that calls
+          # String#tainted?, which Ruby removed in 3.2. This matches GitHub's
+          # own Pages build environment.
+          ruby-version: "3.1"
           bundler-cache: true
           working-directory: docs
       - uses: actions/configure-pages@v5


### PR DESCRIPTION
The first Pages deploy ([run 30650970241](https://github.com/ncbo/kg-bioportal/actions/runs/30650970241)) generated the site fine via build_site.sh but failed at `jekyll build` with `undefined method 'tainted?' for an instance of String`. The github-pages gem pins an old Liquid that calls `String#tainted?`, which Ruby removed in 3.2 — so it crashed under Ruby 3.3. Pinning to Ruby 3.1 (GitHub's own Pages build environment) fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)