### PR TITLE
Pass PAGES_REPO_NWO so jekyll-github-metadata can build the site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -55,6 +55,11 @@ jobs:
         run: bundle exec jekyll build
         env:
           JEKYLL_ENV: production
+          # jekyll-github-metadata (bundled in the github-pages gem) needs to
+          # know the repo; GitHub's native Pages build sets these automatically,
+          # a custom Actions build must pass them.
+          PAGES_REPO_NWO: ${{ github.repository }}
+          JEKYLL_GITHUB_TOKEN: ${{ github.token }}
       - uses: actions/upload-pages-artifact@v3
         with:
           path: docs/_site


### PR DESCRIPTION
Second Pages build failure: `Liquid Exception: No repo name found` from jekyll-github-metadata (in the github-pages gem). GitHub's native Pages build injects the repo identity; a custom Actions build must set `PAGES_REPO_NWO` (and a token to avoid API rate limits). 🤖 Generated with [Claude Code](https://claude.com/claude-code)