### PR TITLE
Raise source-size gate to 100 MB; make finalize stats incremental

### DIFF
--- a/.github/scripts/merge_stats.py
+++ b/.github/scripts/merge_stats.py
@@ -34,20 +34,33 @@ def main():
     # Site-wide transform date (shared by all artifacts in this build), passed by
     # the workflow. Optional so the script stays runnable locally.
     transform_date = sys.argv[3] if len(sys.argv) > 3 else ""
+    # Optional existing onto_stats.yaml to seed from, so a targeted re-run of a
+    # subset of ontologies updates those entries without discarding the rest.
+    base_path = sys.argv[4] if len(sys.argv) > 4 else ""
     repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
     os.makedirs(output_dir, exist_ok=True)
 
-    # Collect entries from every shard fragment. Keyed by id so a later shard
-    # can't duplicate an ontology (each appears in exactly one shard anyway).
     by_id = {}
+
+    # Seed from the existing stats first (incremental / targeted re-runs).
+    if base_path and os.path.exists(base_path):
+        with open(base_path) as f:
+            base = yaml.safe_load(f) or {}
+        for entry in base.get("ontologies", []):
+            by_id[entry["id"]] = entry
+        print(f"Seeded {len(by_id)} entries from existing {base_path}.")
+
+    # Overlay this run's shard fragments (they win over the seeded entries).
     fragment_files = sorted(glob.glob(os.path.join(fragments_dir, "**", "onto_stats.yaml"), recursive=True))
+    fresh = 0
     for path in fragment_files:
         with open(path) as f:
             data = yaml.safe_load(f) or {}
         for entry in data.get("ontologies", []):
             by_id[entry["id"]] = entry
-    print(f"Merged {len(fragment_files)} fragments -> {len(by_id)} ontologies.")
+            fresh += 1
+    print(f"Merged {len(fragment_files)} fragments ({fresh} entries) -> {len(by_id)} ontologies total.")
 
     # Ensure the skiplisted giants are represented (they are removed before
     # sharding, so no shard reports them).

--- a/.github/workflows/transform.yml
+++ b/.github/workflows/transform.yml
@@ -24,7 +24,7 @@ on:
       max_source_mb:
         description: "Skip ontologies whose source exceeds this many MB"
         required: false
-        default: "50"
+        default: "100"
       timeout_min:
         description: "Per-ontology wall-clock cap (minutes)"
         required: false
@@ -42,7 +42,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MAX_SOURCE_MB: ${{ github.event.inputs.max_source_mb || '50' }}
+  MAX_SOURCE_MB: ${{ github.event.inputs.max_source_mb || '100' }}
   TIMEOUT_MIN: ${{ github.event.inputs.timeout_min || '30' }}
   NUM_SHARDS: ${{ github.event.inputs.num_shards || '20' }}
 
@@ -147,8 +147,12 @@ jobs:
         with:
           pattern: stats-*
           path: fragments
+      - name: Fetch existing stats to merge into (keeps prior results on a targeted re-run)
+        run: gh release download "${{ needs.prepare.outputs.tag }}" -p onto_stats.yaml -D base || echo "No existing stats to seed from."
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Merge stats
-        run: python .github/scripts/merge_stats.py fragments docs "$(date -u +%Y-%m-%d)"
+        run: python .github/scripts/merge_stats.py fragments docs "$(date -u +%Y-%m-%d)" base/onto_stats.yaml
       - name: Attach stats to release
         # The release is the single source of truth for stats; main is a
         # protected branch, so we do NOT commit them back to the repo. The docs

--- a/src/kg_bioportal/config.py
+++ b/src/kg_bioportal/config.py
@@ -11,7 +11,7 @@ import os
 
 # Skip an ontology whose downloaded source file exceeds this many megabytes.
 # Big source files mean big memory use in ROBOT and big output artifacts.
-MAX_SOURCE_MB: float = float(os.environ.get("KGBP_MAX_SOURCE_MB", 50))
+MAX_SOURCE_MB: float = float(os.environ.get("KGBP_MAX_SOURCE_MB", 100))
 
 # Hard wall-clock cap for transforming a single ontology, in minutes. If a
 # transform runs longer it is killed and recorded as skipped (too_slow), so one


### PR DESCRIPTION
Follow-up to the first full run (969 OK / 261 Failed / 62 Skipped). Of the 62 skipped, **46 were `too_large`** at the 50 MB gate — including ones people want: CHEBI, EFO, FMA, CL, MONDO, ORDO, UBERON, HGNC, GO-PLUS. They transformed fine on the old Jenkins host, so:

- **Raise the gate 50 → 100 MB** (config default + workflow input/env default).
- **Make `finalize` incremental**: it now seeds `merge_stats` from the release's existing `onto_stats.yaml` and overlays only this run's shard fragments. This lets a **targeted re-run of a subset** (e.g. just the `too_large` ontologies) update those entries *without discarding the other ~1,000*. `merge_stats.py` gains an optional base-stats arg.

Verified locally: seeding from a base with AGRO(OK)+CHEBI(too_large), overlaying a fragment where CHEBI now succeeds → AGRO preserved, CHEBI updated to OK, skiplist giants still injected.

Next: merge, then a targeted re-run of the 46 `too_large` ontologies at 100 MB to rescue the ones that fit, then redeploy Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)