### PR TITLE
Add Agent Skills for working with KG-Bioportal data

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,19 @@
+# KG-Bioportal Agent Skills
+
+Skills for AI agents (Claude Code and compatible tools) to work with KG-Bioportal data. Each skill
+is a directory with a `SKILL.md` (instructions + trigger description), optional `references/`
+(detailed docs the skill points to), and `scripts/` (runnable helpers). They are discovered
+automatically when working in this repository.
+
+| Skill | What it does |
+|-------|--------------|
+| [`kg-bioportal-data`](kg-bioportal-data/SKILL.md) | Find, download, and load the KGX graphs (releases, `onto_stats`, node/edge TSVs). The foundation. |
+| [`kg-bioportal-merge`](kg-bioportal-merge/SKILL.md) | Merge a set of graphs with cat-merge (QC report) or KGX merge. |
+| [`bioportal-for-kg-building`](bioportal-for-kg-building/SKILL.md) | Use BioPortal's Annotator / Recommender / Mappings / API to build, enrich, and align KGs. |
+
+Typical loop: **Recommender** picks ontologies → **kg-bioportal-data** fetches their KGX graphs →
+**kg-bioportal-merge** combines them and reports gaps → **Mappings** resolves dangling/duplicate
+nodes → **Annotator** extends the graph from your own text.
+
+The `scripts/` helpers use only the Python standard library except where noted (`pyyaml` for reading
+`onto_stats.yaml`; `cat-merge` / `kgx` for merging).

--- a/.claude/skills/bioportal-for-kg-building/SKILL.md
+++ b/.claude/skills/bioportal-for-kg-building/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: bioportal-for-kg-building
+description: >
+  Use BioPortal (bioportal.bioontology.org / data.bioontology.org API) to build, enrich,
+  or align knowledge graphs. Use this skill when the user asks how to turn text into ontology
+  terms (Annotator), pick which ontologies to use for a corpus (Recommender), find cross-ontology
+  term mappings to align or merge KGs (Mappings), fetch ontology classes / hierarchies / properties
+  via the API, or understand how BioPortal ontologies become KG-Bioportal KGX graphs. Covers the
+  KG-builder's view of BioPortal's services.
+---
+
+# BioPortal for knowledge-graph building
+
+[BioPortal](https://bioportal.bioontology.org/) hosts 1,000+ biomedical ontologies with a REST API
+at `https://data.bioontology.org`. Beyond being the *source* KG-Bioportal transforms into KGX, its
+services map neatly onto knowledge-graph construction tasks. This skill is the KG-builder's guide to
+them. Endpoint details, params, and auth are in `references/bioportal-api.md`.
+
+## When this skill applies
+
+- "How do I turn this text/abstract into ontology terms (nodes/edges)?"
+- "Which ontologies should I use for a corpus about X?"
+- "Find mappings between these two ontologies so I can align/merge my KGs"
+- "Fetch the class hierarchy / children / properties of a BioPortal term"
+- "How does BioPortal relate to the KGX graphs in KG-Bioportal?"
+
+## Setup
+Almost every endpoint needs an **API key** (free): create an account at bioportal.bioontology.org,
+find the key on your account page, and send it as `Authorization: apikey token=<KEY>` (or
+`?apikey=<KEY>`). The same key drives the pattern already used in `src/kg_bioportal/downloader.py`.
+
+## Services, mapped to KG tasks
+
+### Annotator — text → ontology-class URIs (build nodes & edges from text)
+`POST/GET /annotator?text=...` returns the ontology classes mentioned in a span of text, with the
+matched term, ontology, and character offsets. **KG use:** entity recognition — turn documents,
+abstracts, or field values into candidate nodes (the matched classes) and candidate edges
+(class ↔ document, or co-mention edges between classes). Restrict with `ontologies=`, expand with
+`expand_mappings=true`.
+
+### Recommender — corpus → which ontologies to ingest
+`GET /recommender?input=...` ranks ontologies by how well they cover a text or keyword set.
+**KG use:** decide *which* BioPortal ontologies to pull into your KG for a given domain before you
+transform/merge them (then fetch those graphs via the kg-bioportal-data skill).
+
+### Mappings — cross-ontology term equivalences (align & merge KGs)
+`GET /ontologies/{acronym}/mappings` and `GET /mappings?...` return mappings (e.g. `SAME_URI`,
+`LOOM`, `CUI`, manual) between classes across ontologies. **KG use:** align nodes that mean the same
+thing across source graphs, and **resolve dangling edges** from the kg-bioportal-merge QC report
+(a dangling `CHEBI:x` might map to a term already in your graph). Mappings are how you collapse
+duplicate entities when integrating multiple ontology graphs.
+
+### Search & class/hierarchy — fetch structured node/edge data
+- `GET /search?q=...` — find classes across (or within) ontologies.
+- `GET /ontologies/{acronym}/classes/{URI-encoded class id}` — a class, its `prefLabel`, synonyms,
+  definitions, parents/children links.
+- `.../classes/{id}/children`, `/parents`, `/ancestors`, `/descendants` — the hierarchy, i.e.
+  subclass edges for your KG.
+- `GET /ontologies/{acronym}/properties` — object/annotation properties (candidate edge types).
+
+**KG use:** build nodes (classes + labels + synonyms) and structural edges (subclass/part-of) for a
+specific ontology or subtree without a full transform.
+
+### Ontology download & submissions — the source graphs
+- `GET /ontologies/{acronym}/latest_submission` — version, submission id, release date.
+- `GET /ontologies/{acronym}/download` — the source ontology file.
+- `GET /ontologies/{acronym}/metrics` — class/individual/property counts (size before you commit).
+
+**KG use:** this is exactly what KG-Bioportal's pipeline consumes to produce the KGX graphs. If a
+graph you want is Failed/Skipped in KG-Bioportal, you can still pull its source here and transform it
+yourself (ROBOT → KGX).
+
+## How this connects to KG-Bioportal
+The KGX graphs in KG-Bioportal **are** these BioPortal ontologies, already transformed. Typical loop:
+**Recommender** (pick ontologies) → **kg-bioportal-data** (fetch their KGX graphs) →
+**kg-bioportal-merge** (combine, get QC) → **Mappings** (resolve dangling/duplicate nodes) →
+**Annotator** (extend the graph with terms found in your own text).
+
+## Notes
+- Be mindful of rate limits; batch and cache. The API returns JSON with `links` for pagination
+  (`nextPage`) and related resources.
+- `references/bioportal-api.md` has concrete URLs, parameters, auth, and example responses.

--- a/.claude/skills/bioportal-for-kg-building/references/bioportal-api.md
+++ b/.claude/skills/bioportal-for-kg-building/references/bioportal-api.md
@@ -1,0 +1,76 @@
+# BioPortal API cheatsheet (data.bioontology.org)
+
+Base URL: `https://data.bioontology.org`. Web UI: `https://bioportal.bioontology.org`.
+
+## Auth
+Every call needs an API key (free; from your BioPortal account page). Either header or query param:
+```bash
+curl -H "Authorization: apikey token=$NCBO_API_KEY" "https://data.bioontology.org/ontologies"
+curl "https://data.bioontology.org/ontologies?apikey=$NCBO_API_KEY"
+```
+Responses are JSON. Collections paginate via a `links.nextPage` URL and a `page`/`pageCount` object.
+Most resources embed `@id`, `@type`, and a `links` block to related endpoints.
+
+## Endpoints by KG task
+
+### Annotator — text → ontology classes
+```
+GET /annotator?text=<TEXT>&ontologies=GO,CHEBI&longest_only=true&expand_mappings=true
+```
+Returns a list of annotations; each has `annotatedClass` (`@id` = class URI, plus `links.ontology`)
+and `annotations[]` with `text`, `from`, `to`, `matchType`. Use `ontologies=` to scope; POST for
+long text.
+
+### Recommender — corpus → ranked ontologies
+```
+GET /recommender?input=<TEXT or comma keywords>&input_type=1   # 1=text, 2=keyword list
+```
+Returns ranked entries with `ontologies[]` and coverage/specialization scores.
+
+### Mappings — cross-ontology equivalences
+```
+GET /ontologies/{ACR}/mappings?page=1                  # all mappings for an ontology
+GET /mappings?class=<URI-encoded class URI>&ontologies=A,B
+```
+Each mapping has `classes[]` (the two mapped class `@id`s + their ontologies) and `source`
+(`SAME_URI`, `LOOM`, `CUI`, `REST`/manual, …).
+
+### Search
+```
+GET /search?q=<TERM>&ontologies=GO&require_exact_match=false&pagesize=50
+```
+Returns matching classes with `prefLabel`, `ontology`, `@id`.
+
+### Classes & hierarchy (nodes + structural edges)
+```
+GET /ontologies/{ACR}/classes?page=1                                  # all classes (paged)
+GET /ontologies/{ACR}/classes/{URI-encoded class id}                  # one class
+GET /ontologies/{ACR}/classes/{id}/children | /parents | /ancestors | /descendants
+GET /ontologies/{ACR}/properties                                      # object/annotation properties
+```
+A class carries `prefLabel`, `synonym[]`, `definition[]`, and `links` to `children`, `parents`,
+`ancestors`, `tree`. `{id}` must be the **URL-encoded full class URI**
+(e.g. `http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FGO_0008150`).
+
+### Ontology metadata, size, and source
+```
+GET /ontologies                                # list all ontologies (acronym, name, links)
+GET /ontologies/{ACR}                           # one ontology's metadata
+GET /ontologies/{ACR}/latest_submission         # version, submissionId, released, hasOntologyLanguage
+GET /ontologies/{ACR}/metrics                   # numberOfClasses, numberOfIndividuals, numberOfProperties, maxDepth …
+GET /ontologies/{ACR}/download                  # the source ontology file (Content-Disposition names it)
+GET /analytics                                  # all ontology acronyms (used to enumerate)
+```
+These four (`latest_submission`, `metrics`, `download`, `analytics`) are exactly what
+`src/kg_bioportal/downloader.py` uses to enumerate and pull ontologies for the KGX transform. Check
+`metrics.numberOfClasses` before ingesting to gauge size.
+
+## Practical notes
+- **Rate limits:** batch requests, cache responses, and page politely (`pagesize` up to a few
+  hundred). The downloader wraps calls with retry/backoff on 429/504 — mirror that for bulk work.
+- **URIs vs acronyms:** ontologies are addressed by acronym (`GO`); classes by their full URI
+  (URL-encoded) within an ontology.
+- **From API to KG:** for one ontology, `classes` + `children`/`parents` already give you a
+  node+edge set. For the whole ontology as a graph, prefer the pre-built KGX artifact from
+  KG-Bioportal (kg-bioportal-data skill) rather than crawling the API.
+- Docs: https://data.bioontology.org/documentation

--- a/.claude/skills/kg-bioportal-data/SKILL.md
+++ b/.claude/skills/kg-bioportal-data/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: kg-bioportal-data
+description: >
+  Find, download, and load KG-Bioportal knowledge graphs — BioPortal ontologies
+  transformed to KGX (node/edge TSVs), published as GitHub Release assets. Use this
+  skill whenever the user wants to list which ontology graphs are available, download
+  a specific ontology's KGX graph, load KG-Bioportal nodes/edges into pandas / DuckDB /
+  networkx / kgx, or understand the KG-Bioportal data model (releases, onto_stats,
+  node/edge columns, provenance). Also the foundation for merging graphs (see the
+  kg-bioportal-merge skill).
+---
+
+# Working with KG-Bioportal graph data
+
+KG-Bioportal transforms BioPortal ontologies into [KGX](https://github.com/biolink/kgx)
+graphs (nodes + edges as Biolink-typed TSVs) and publishes them as **GitHub Release
+assets**. This skill covers finding, fetching, and loading those graphs.
+
+## When this skill applies
+
+- "What KG-Bioportal graphs are available?" / "list the ontologies with the most nodes"
+- "Download the GO (or AGRO, CHEBI, …) graph"
+- "Load the KG-Bioportal edges into pandas / a dataframe / DuckDB / networkx"
+- Any task that needs the KG-Bioportal node/edge data as a starting point.
+
+## Background — the data model
+
+Everything lives on the latest release of `ncbo/kg-bioportal`, reachable at stable URLs:
+
+- **Per-graph artifact:** `https://github.com/ncbo/kg-bioportal/releases/latest/download/<ID>.tar.gz`
+  — contains `<ID>_nodes.tsv` and `<ID>_edges.tsv`. `<ID>` is the BioPortal acronym (uppercase),
+  e.g. `GO`, `AGRO`, `UBERON`. Only successfully-transformed (status `OK`) ontologies have an asset.
+- **Inventory:** `.../releases/latest/download/onto_stats.yaml` — one entry per ontology with
+  `id, name, version, status (OK/Failed/Skipped), reason, nodecount, edgecount, submission_id`.
+- **Totals:** `.../releases/latest/download/total_stats.yaml` — `totalcount, skippedcount,
+  failedcount, totalnodecount, totaledgecount, transform_date`.
+
+Provenance: nodes have a `provided_by` column and edges a `knowledge_source` column; both currently
+hold the source file name (`<ID>_relaxed.owl`), which identifies the source ontology. A couple of
+quirks to know: edge `id` is usually empty and edge `category` is often blank. See
+`references/data-model.md` for the exact columns and example rows.
+
+## Workflow
+
+### 1. See what's available
+```bash
+python scripts/list_graphs.py                 # OK graphs, by name
+python scripts/list_graphs.py --sort nodes    # biggest first
+python scripts/list_graphs.py --all           # include Failed/Skipped (with reasons)
+python scripts/list_graphs.py --json          # machine-readable, incl. download_url
+```
+This reads `onto_stats.yaml` from the release. To browse visually instead, the same data is at
+https://ncbo.github.io/kg-bioportal/graphs/ .
+
+### 2. Download one or more graphs
+```bash
+python scripts/fetch_graph.py GO AGRO             # -> ./GO/GO_nodes.tsv, ./AGRO/AGRO_nodes.tsv …
+python scripts/fetch_graph.py GO -o data/graphs   # into a directory
+```
+Or by hand: `curl -L .../releases/latest/download/GO.tar.gz | tar xz`.
+
+### 3. Load the data
+KGX TSVs are plain tab-separated files — load them however suits the task:
+```python
+import pandas as pd
+nodes = pd.read_csv("GO/GO_nodes.tsv", sep="\t", dtype=str)
+edges = pd.read_csv("GO/GO_edges.tsv", sep="\t", dtype=str)
+# nodes: id, category, name, provided_by, …   edges: subject, predicate, object, relation, knowledge_source
+```
+Other good options: **DuckDB** (`SELECT ... FROM read_csv_auto('GO_edges.tsv', delim='\t')`) for
+SQL over big edge tables; **networkx** for graph algorithms; **kgx** itself
+(`kgx.transformer`) to convert to RDF / JSON-L / Neo4j. See `references/data-model.md`.
+
+### 4. To combine multiple graphs
+Fetch the ones you want, then use the **kg-bioportal-merge** skill — it wraps cat-merge / KGX
+merge and produces a QC report over the combined graph.
+
+## Notes
+- A graph you expected may be missing because its transform Failed or was Skipped (too large / too
+  slow). `list_graphs.py --all` shows the status and reason; its BioPortal source is still available
+  at `https://bioportal.bioontology.org/ontologies/<ID>`.
+- Counts and `transform_date` reflect the latest transform run recorded in `total_stats.yaml`.

--- a/.claude/skills/kg-bioportal-data/references/data-model.md
+++ b/.claude/skills/kg-bioportal-data/references/data-model.md
@@ -1,0 +1,115 @@
+# KG-Bioportal data model reference
+
+## Where the data lives
+
+All artifacts are assets on the **latest GitHub Release** of `ncbo/kg-bioportal`, at stable URLs:
+
+| What | URL |
+|------|-----|
+| A graph | `https://github.com/ncbo/kg-bioportal/releases/latest/download/<ID>.tar.gz` |
+| Inventory | `.../releases/latest/download/onto_stats.yaml` |
+| Totals | `.../releases/latest/download/total_stats.yaml` |
+
+`<ID>` is the BioPortal acronym in **uppercase** (`GO`, `AGRO`, `UBERON`, `CHEBI`). Only ontologies
+with `status: OK` in `onto_stats.yaml` have a downloadable `<ID>.tar.gz`. Each tarball contains two
+files: `<ID>_nodes.tsv` and `<ID>_edges.tsv`.
+
+The release tag is `data-YYYY.MM` (marked "latest"); a full run replaces the month's assets and a
+targeted re-run updates a subset in place.
+
+## `onto_stats.yaml`
+
+```yaml
+ontologies:
+- id: AGRO                # BioPortal acronym (also the asset name <ID>.tar.gz)
+  name: AGRonomy Ontology # human name from BioPortal
+  version: '2023-08-14'   # BioPortal submission version string ('NA' if none)
+  status: OK              # OK | Failed | Skipped
+  reason: ''              # why non-OK: transform_error | too_large | too_slow |
+                          #   skiplist | not_downloadable | no_submission
+  nodecount: 5102         # 0 unless status OK
+  edgecount: 8691
+  submission_id: '6'      # BioPortal submission id
+  source_bytes: 7501012   # size of the source ontology file
+```
+
+`total_stats.yaml`:
+```yaml
+totalcount: 987       # OK
+skippedcount: 43
+failedcount: 262
+totalnodecount: 3988318
+totaledgecount: 7354869
+transform_date: 2026-07-31
+```
+
+## KGX TSV columns (as produced by KG-Bioportal)
+
+**Nodes** — `<ID>_nodes.tsv`:
+
+| column | meaning | example |
+|--------|---------|---------|
+| `id` | node CURIE | `OBO:AGRO_00000002` |
+| `category` | Biolink category | `biolink:NamedThing` |
+| `name` | label | `tillage process` |
+| `description` | definition | `A planned process in which soil is …` |
+| `provided_by` | source (see note) | `AGRO_relaxed.owl` |
+| `synonym`, `exact_synonym`, `broad_synonym`, `narrow_synonym`, `related_synonym` | synonyms | (often blank) |
+
+**Edges** — `<ID>_edges.tsv`:
+
+| column | meaning | example |
+|--------|---------|---------|
+| `id` | edge id | *(usually empty)* |
+| `subject` | source node CURIE | `OBO:AGRO_00000002` |
+| `predicate` | Biolink predicate | `biolink:subclass_of` |
+| `object` | target node CURIE | `OBO:AGRO_00000108` |
+| `category` | Biolink edge category | *(often empty)* |
+| `relation` | original relation CURIE | `rdfs:subClassOf` |
+| `knowledge_source` | source (see note) | `AGRO_relaxed.owl` |
+
+### Provenance note (important)
+Both `provided_by` (nodes) and `knowledge_source` (edges) currently contain the **relaxed OWL file
+name** (`<ID>_relaxed.owl`), an artifact of the ROBOT→KGX step, rather than the acronym or an
+`infores:` CURIE. It still uniquely identifies the source ontology (strip `_relaxed.owl`). If you
+need clean per-source provenance in a merged graph, rewrite this column to the acronym or
+`infores:bioportal` before/after merging.
+
+### Other characteristics
+- Node ids are CURIEs; prefixes vary by ontology (`OBO:`, ontology-specific prefixes, etc.).
+- `predicate` is Biolink-normalized (e.g. `biolink:subclass_of`); `relation` keeps the original
+  (e.g. `rdfs:subClassOf`).
+- Edge `id` is frequently empty — cat-merge and KGX handle this, but if you need stable edge ids,
+  synthesize them (e.g. `subject|predicate|object`).
+- These are single-ontology graphs; cross-ontology references appear as edges whose `object` (or
+  `subject`) is a CURIE not present as a node in this graph — i.e. **dangling** until you merge in
+  the referenced ontology. This is the main signal the merge QC report surfaces.
+
+## Loading recipes
+
+```python
+import pandas as pd
+nodes = pd.read_csv("GO/GO_nodes.tsv", sep="\t", dtype=str, keep_default_na=False)
+edges = pd.read_csv("GO/GO_edges.tsv", sep="\t", dtype=str, keep_default_na=False)
+```
+
+```sql
+-- DuckDB, good for large edge tables
+SELECT predicate, count(*) FROM read_csv_auto('GO_edges.tsv', delim='\t', header=true)
+GROUP BY predicate ORDER BY 2 DESC;
+```
+
+```python
+# networkx
+import networkx as nx, pandas as pd
+e = pd.read_csv("GO_edges.tsv", sep="\t", dtype=str, keep_default_na=False)
+G = nx.from_pandas_edgelist(e, "subject", "object", edge_attr=["predicate"], create_using=nx.MultiDiGraph)
+```
+
+```python
+# kgx — convert to other formats (RDF, JSON-L, Neo4j)
+from kgx.transformer import Transformer
+t = Transformer()
+t.transform({"filename": ["GO_nodes.tsv", "GO_edges.tsv"], "format": "tsv"})
+t.save({"filename": "GO.json", "format": "json"})
+```

--- a/.claude/skills/kg-bioportal-data/scripts/fetch_graph.py
+++ b/.claude/skills/kg-bioportal-data/scripts/fetch_graph.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Download and extract KG-Bioportal KGX graphs from the latest release.
+
+Each <ID>.tar.gz contains <ID>_nodes.tsv and <ID>_edges.tsv (KGX TSV).
+
+Usage:
+  python fetch_graph.py AGRO SEPIO            # -> ./AGRO/AGRO_nodes.tsv, etc.
+  python fetch_graph.py AGRO -o data/graphs   # into a directory
+  python fetch_graph.py AGRO --flat -o inbox  # extract straight into the output dir
+"""
+import argparse
+import os
+import socket
+import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+
+socket.setdefaulttimeout(180)  # don't hang forever on a stalled connection
+
+ASSET = "https://github.com/ncbo/kg-bioportal/releases/latest/download/{id}.tar.gz"
+
+
+def _safe_extract(tar, dest):
+    # Content is our own trusted release asset; use the 'data' filter where available.
+    try:
+        tar.extractall(dest, filter="data")
+    except TypeError:
+        tar.extractall(dest)
+
+
+def fetch(acr, outdir, flat):
+    url = ASSET.format(id=acr)
+    dest = outdir if flat else os.path.join(outdir, acr)
+    os.makedirs(dest, exist_ok=True)
+    tmp = os.path.join(tempfile.gettempdir(), f"{acr}.tar.gz")
+    try:
+        urllib.request.urlretrieve(url, tmp)
+    except urllib.error.HTTPError as e:
+        print(f"  {acr}: download failed (HTTP {e.code}). "
+              f"Only successfully-transformed (OK) graphs have an asset. {url}")
+        return False
+    with tarfile.open(tmp, "r:gz") as t:
+        _safe_extract(t, dest)
+    os.remove(tmp)
+    got = sorted(f for f in os.listdir(dest) if f.startswith(acr))
+    print(f"  {acr}: {', '.join(got)} -> {dest}/")
+    return True
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("acronyms", nargs="+")
+    ap.add_argument("-o", "--output-dir", default=".")
+    ap.add_argument("--flat", action="store_true", help="extract into output dir without per-graph subdirs")
+    a = ap.parse_args()
+    ok = sum(fetch(x.upper(), a.output_dir, a.flat) for x in a.acronyms)
+    print(f"{ok}/{len(a.acronyms)} graphs fetched into {a.output_dir}/")
+    if ok < len(a.acronyms):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/kg-bioportal-data/scripts/list_graphs.py
+++ b/.claude/skills/kg-bioportal-data/scripts/list_graphs.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""List KG-Bioportal graphs from the latest release.
+
+Fetches onto_stats.yaml from the latest GitHub release and prints the graphs.
+By default shows only those successfully transformed (status OK), with node/edge
+counts and download URLs.
+
+Usage:
+  python list_graphs.py                  # OK graphs, sorted by name
+  python list_graphs.py --all            # include Failed / Skipped
+  python list_graphs.py --status Failed  # only a given status
+  python list_graphs.py --sort nodes     # sort by node count (desc)
+  python list_graphs.py --json           # machine-readable JSON
+"""
+import argparse
+import json
+import sys
+import urllib.request
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("PyYAML required: pip install pyyaml")
+
+RELEASE = "https://github.com/ncbo/kg-bioportal/releases/latest/download"
+ASSET = RELEASE + "/{id}.tar.gz"
+
+
+def load_stats():
+    with urllib.request.urlopen(RELEASE + "/onto_stats.yaml", timeout=60) as r:
+        return (yaml.safe_load(r.read()) or {}).get("ontologies", [])
+
+
+def fmt(n):
+    return f"{n:,}" if isinstance(n, int) and n else "-"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--all", action="store_true", help="include Failed/Skipped")
+    ap.add_argument("--status", help="only this status (OK/Failed/Skipped)")
+    ap.add_argument("--sort", choices=["name", "nodes", "edges"], default="name")
+    ap.add_argument("--json", action="store_true")
+    a = ap.parse_args()
+
+    onts = load_stats()
+    if a.status:
+        onts = [o for o in onts if o.get("status") == a.status]
+    elif not a.all:
+        onts = [o for o in onts if o.get("status") == "OK"]
+
+    keys = {
+        "name": lambda o: (o.get("name") or o["id"]).lower(),
+        "nodes": lambda o: -(o.get("nodecount") or 0),
+        "edges": lambda o: -(o.get("edgecount") or 0),
+    }
+    onts.sort(key=keys[a.sort])
+
+    if a.json:
+        for o in onts:
+            o["download_url"] = ASSET.format(id=o["id"]) if o.get("status") == "OK" else None
+        print(json.dumps(onts, indent=2))
+        return
+
+    print(f"{'ID':24} {'STATUS':8} {'NODES':>11} {'EDGES':>11}  NAME")
+    for o in onts:
+        print(f"{o['id']:24} {o.get('status', ''):8} "
+              f"{fmt(o.get('nodecount')):>11} {fmt(o.get('edgecount')):>11}  {o.get('name') or ''}")
+    print(f"\n{len(onts)} graphs. Download an OK graph from: {ASSET.format(id='<ID>')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/kg-bioportal-merge/SKILL.md
+++ b/.claude/skills/kg-bioportal-merge/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: kg-bioportal-merge
+description: >
+  Merge a set of KG-Bioportal knowledge graphs (BioPortal ontologies as KGX) into one
+  combined graph, using cat-merge (recommended, with a QC report) or KGX merge. Use this
+  skill whenever the user wants to combine / merge / integrate multiple ontology graphs,
+  build a unified KG from several BioPortal ontologies, deduplicate nodes across ontologies,
+  or find dangling cross-ontology edges. Builds on the kg-bioportal-data skill for fetching
+  the source graphs.
+---
+
+# Merging KG-Bioportal graphs
+
+Each KG-Bioportal graph is a single ontology in KGX. Because ontologies cross-reference each
+other (an edge in one whose target lives in another), merging a chosen set produces a richer,
+connected graph — and the merge's **QC report** tells you where the seams are.
+
+## When this skill applies
+
+- "Merge AGRO, PO and ENVO into one graph"
+- "Combine these ontologies and tell me what's dangling / duplicated"
+- "Build a single KG from the plant-related ontologies"
+- "Deduplicate nodes shared across these ontologies"
+
+## Background — two merge tools
+
+- **[cat-merge](https://github.com/monarch-initiative/cat-merge)** (recommended): the Monarch
+  merge tool. Concatenates the node/edge sets, **deduplicates nodes by id**, and writes a **QC
+  report** that flags duplicate nodes, duplicate edges, and **dangling edges** (edges whose
+  `subject` or `object` node is not present in the merged set). Dangling edges are the key signal:
+  they usually point at a term in an ontology you didn't include.
+- **[KGX](https://github.com/biolink/kgx) merge**: KGX's own merge, driven by a YAML config
+  (see the repo's `/merge.yaml` for the shape). Produces a merged TSV and graph stats via
+  `kgx.graph_operations.summarize_graph`. Use when you want KGX-native output/stats or a
+  declarative source list rather than a QC report.
+
+Both consume the same input: `<ID>_nodes.tsv` + `<ID>_edges.tsv` files (from the
+kg-bioportal-data skill). See `references/cat-merge-vs-kgx.md` for details, the QC-report fields,
+and an annotated `merge.yaml` template.
+
+## Workflow
+
+### 1. Choose the ontologies
+By acronym. To discover options, use the **kg-bioportal-data** skill
+(`list_graphs.py`) — only `status: OK` graphs can be merged.
+
+### 2. Merge with cat-merge (recommended)
+`scripts/merge_kgs.py` fetches the graphs from the release and runs cat-merge in one step:
+```bash
+pip install cat-merge
+python scripts/merge_kgs.py AGRO PO ENVO --name plant-merge
+#   -> merge_output/plant-merge.tar.gz  and  merge_output/qc_report.yaml
+```
+`--all-ok` merges every OK graph (large and slow — hundreds of graphs, millions of edges).
+
+If you already have the TSVs locally (e.g. via `fetch_graph.py --flat -o merge_input`), call
+cat-merge directly. Its `merge()` takes explicit node/edge file **lists** (not an input dir):
+```python
+import glob
+from cat_merge.merge import merge
+nodes = sorted(glob.glob("merge_input/*_nodes.tsv"))
+edges = sorted(glob.glob("merge_input/*_edges.tsv"))
+merge(name="plant-merge", nodes=nodes, edges=edges, output_dir="merge_output")
+```
+
+### 3. Read the QC report
+Open `merge_output/qc_report.yaml`. Focus on:
+- **dangling edges** — a reference to a node not in the set. Grouped by source, this tells you
+  *which ontology to add next* (e.g. lots of edges pointing at `CHEBI:*` → add CHEBI). Fetch it and
+  re-merge.
+- **duplicate nodes** — the same CURIE contributed by more than one ontology. Usually expected
+  (shared upper-level terms); confirms the ontologies actually connect.
+- **duplicate edges** — identical subject/predicate/object from multiple sources; typically fine.
+
+### 4. (Alternative) KGX merge
+When you want KGX-native output: generate a `merge.yaml` (one `source` block per graph, following
+`/merge.yaml`) and run:
+```bash
+pip install kgx
+kgx merge --merge-config merge.yaml
+```
+See `references/cat-merge-vs-kgx.md` for a ready-to-edit template.
+
+## Notes
+- Provenance columns hold the source file name (`<ID>_relaxed.owl`); if you want clean per-source
+  provenance in the merged graph, normalize `provided_by` / `knowledge_source` to the acronym or
+  `infores:bioportal` before merging (see the kg-bioportal-data data-model reference).
+- The dormant `merge` / `catmerge` commands in `src/kg_bioportal/cli.py` are the CLI equivalents of
+  this workflow; this skill calls the tools directly rather than depending on that (unrevived) code.
+- Merging the full corpus is heavy; prefer a purposeful subset unless you truly need everything.

--- a/.claude/skills/kg-bioportal-merge/references/cat-merge-vs-kgx.md
+++ b/.claude/skills/kg-bioportal-merge/references/cat-merge-vs-kgx.md
@@ -1,0 +1,104 @@
+# cat-merge vs KGX merge, and how to read the results
+
+## Which to use
+
+| | cat-merge | KGX merge |
+|---|---|---|
+| Input | node/edge TSVs in a directory | node/edge TSVs listed in a YAML config |
+| Dedup | dedupes nodes by id | merges by id |
+| Output | `<name>.tar.gz` (merged KGX) | merged TSV (+ other formats) |
+| QC | **QC report**: duplicate nodes/edges, **dangling edges** | graph stats (counts, facets) |
+| Best for | understanding connectivity / gaps between ontologies | KGX-native output + summary stats |
+| Install | `pip install cat-merge` | `pip install kgx` |
+
+Rule of thumb: **cat-merge first** — the QC report tells you whether the ontologies you picked
+actually connect, and which ontology to add next. Use KGX merge when you specifically want KGX
+output formats or `generate_graph_stats` facets.
+
+## cat-merge
+
+`merge()` signature (verified):
+`merge(name='merged-kg', source=None, nodes=None, edges=None, mappings=None,
+output_dir='merged-output', qc_report=True)`. Pass explicit **file lists** — glob them yourself:
+
+```python
+import glob
+from cat_merge.merge import merge
+nodes = sorted(glob.glob("merge_input/*_nodes.tsv"))
+edges = sorted(glob.glob("merge_input/*_edges.tsv"))
+merge(name="my-merge", nodes=nodes, edges=edges, output_dir="merge_output")
+```
+- Writes `merge_output/my-merge.tar.gz` (merged nodes+edges), a `qc/` dir, and a **QC report**
+  `merge_output/qc_report.yaml`.
+- `mappings=[...]` lets you supply mapping TSVs so cat-merge collapses equivalent nodes during the
+  merge (see the bioportal-for-kg-building skill for getting BioPortal mappings).
+
+### Reading `qc_report.yaml`
+Top-level keys: `nodes`, `edges` (summary counts), `duplicate_nodes`, `duplicate_edges`,
+`dangling_edges`.
+- **`dangling_edges`** — edges whose `subject` or `object` node id isn't present among the merged
+  nodes. The single most useful signal. Group the missing ids by prefix to see which ontology to
+  pull in next (e.g. many missing `CHEBI:*` → add the CHEBI graph and re-merge). Some dangling
+  edges are unavoidable (references to terms that live in ontologies you don't need).
+- **`duplicate_nodes`** — the same node id from more than one source. Expected when ontologies
+  share upper-level terms; it's evidence the graphs overlap/connect.
+- **`duplicate_edges`** — identical subject/predicate/object seen in more than one source. Usually
+  harmless.
+
+## KGX merge — annotated `merge.yaml` template
+
+One `source` block per graph. Fill in the node/edge TSV paths (e.g. from
+`fetch_graph.py -o merge_input`, files land at `merge_input/<ID>/<ID>_nodes.tsv`). Based on the
+repo's `/merge.yaml`.
+
+```yaml
+---
+configuration:
+  output_directory: merge_output
+  checkpoint: false
+
+merged_graph:
+  name: my-merge
+  source:
+    agro:
+      name: "AGRO"
+      input:
+        format: tsv
+        filename:
+          - merge_input/AGRO/AGRO_nodes.tsv
+          - merge_input/AGRO/AGRO_edges.tsv
+    po:
+      name: "PO"
+      input:
+        format: tsv
+        filename:
+          - merge_input/PO/PO_nodes.tsv
+          - merge_input/PO/PO_edges.tsv
+  # optional: emit summary stats over the merged graph
+  operations:
+    - name: kgx.graph_operations.summarize_graph.generate_graph_stats
+      args:
+        graph_name: my-merge
+        filename: merged_graph_stats.yaml
+        node_facet_properties:
+          - provided_by
+        edge_facet_properties:
+          - provided_by
+          - knowledge_source
+  destination:
+    merged-kg-tsv:
+      format: tsv
+      compression: tar.gz
+      filename: my-merge
+```
+
+Run:
+```bash
+kgx merge --merge-config merge.yaml
+```
+
+## Provenance caveat
+KG-Bioportal `provided_by` (nodes) and `knowledge_source` (edges) currently hold the source file
+name `<ID>_relaxed.owl`. If you want facets/provenance keyed by ontology acronym or
+`infores:bioportal`, rewrite that column in the TSVs before merging (a one-line pandas `.replace`
+per file), or post-process the merged output.

--- a/.claude/skills/kg-bioportal-merge/scripts/merge_kgs.py
+++ b/.claude/skills/kg-bioportal-merge/scripts/merge_kgs.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Merge a set of KG-Bioportal KGX graphs with cat-merge.
+
+Downloads each <ID>.tar.gz from the latest release, extracts the node/edge TSVs
+into one input dir, then runs cat-merge to produce a single merged KGX graph plus
+a QC report (duplicate nodes/edges, dangling edges).
+
+Requires: pip install cat-merge   (and pyyaml for --all-ok)
+
+Usage:
+  python merge_kgs.py AGRO SEPIO PO --name plant-merge
+  python merge_kgs.py --all-ok --name kg-bioportal-full     # every OK graph (large, slow)
+  python merge_kgs.py GO UBERON --input-dir in --output-dir out
+"""
+import argparse
+import glob
+import os
+import socket
+import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+
+socket.setdefaulttimeout(180)  # don't hang forever on a stalled connection
+
+RELEASE = "https://github.com/ncbo/kg-bioportal/releases/latest/download"
+ASSET = RELEASE + "/{id}.tar.gz"
+
+
+def all_ok_ids():
+    import yaml
+    with urllib.request.urlopen(RELEASE + "/onto_stats.yaml", timeout=60) as r:
+        onts = (yaml.safe_load(r.read()) or {}).get("ontologies", [])
+    return [o["id"] for o in onts if o.get("status") == "OK"]
+
+
+def fetch_tsvs(acr, indir):
+    tmp = os.path.join(tempfile.gettempdir(), f"{acr}.tar.gz")
+    try:
+        urllib.request.urlretrieve(ASSET.format(id=acr), tmp)
+    except urllib.error.HTTPError as e:
+        print(f"  skip {acr}: no asset (HTTP {e.code}) — only OK graphs are downloadable")
+        return False
+    with tarfile.open(tmp, "r:gz") as t:
+        try:
+            t.extractall(indir, filter="data")
+        except TypeError:
+            t.extractall(indir)
+    os.remove(tmp)
+    return True
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("acronyms", nargs="*", help="BioPortal acronyms to merge")
+    ap.add_argument("--all-ok", action="store_true", help="merge every OK graph (large)")
+    ap.add_argument("--name", default="kg-bioportal-merge", help="name for the merged graph")
+    ap.add_argument("--input-dir", default="merge_input")
+    ap.add_argument("--output-dir", default="merge_output")
+    a = ap.parse_args()
+
+    ids = all_ok_ids() if a.all_ok else [x.upper() for x in a.acronyms]
+    if not ids:
+        sys.exit("Provide one or more acronyms, or --all-ok.")
+
+    try:
+        from cat_merge.merge import merge
+    except ImportError:
+        sys.exit("cat-merge is required: pip install cat-merge")
+
+    os.makedirs(a.input_dir, exist_ok=True)
+    got = [x for x in ids if fetch_tsvs(x, a.input_dir)]
+    print(f"Fetched {len(got)}/{len(ids)} graphs into {a.input_dir}/")
+    if not got:
+        sys.exit("Nothing to merge.")
+
+    # cat-merge takes explicit node/edge file lists; dedupes nodes and writes
+    # <name>.tar.gz + a QC report to output_dir.
+    nodes = sorted(glob.glob(os.path.join(a.input_dir, "*_nodes.tsv")))
+    edges = sorted(glob.glob(os.path.join(a.input_dir, "*_edges.tsv")))
+    merge(name=a.name, nodes=nodes, edges=edges, output_dir=a.output_dir)
+
+    print(f"\nMerged graph + QC report written to {a.output_dir}/:")
+    for f in sorted(os.listdir(a.output_dir)):
+        print("  ", f)
+    print("\nRead qc_report.yaml for duplicate nodes/edges and dangling edges "
+          "(edges whose subject/object node isn't in the merged set).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds three **Agent Skills** under `.claude/skills/` so an agent (Claude Code and compatible tools) can *act* on the KGX graphs, not just browse them. They're discovered automatically when working in this repo.

## Skills
- **`kg-bioportal-data`** — find / download / load the graphs. Covers the release layout, `onto_stats`, and the exact KGX node/edge columns + provenance quirks. Scripts: `list_graphs.py`, `fetch_graph.py`. *Verified live against the release.*
- **`kg-bioportal-merge`** — merge a chosen set of graphs with **cat-merge** (QC report: dangling / duplicate edges & nodes) or **KGX merge**. `merge_kgs.py` fetches + merges in one step. *Verified end-to-end: AGRO+SEPIO → merged `.tar.gz` + `qc_report.yaml`.*
- **`bioportal-for-kg-building`** — how to use BioPortal's **Annotator / Recommender / Mappings / API** to build, enrich, and align KGs, with a `data.bioontology.org` endpoint cheatsheet.

Typical loop: Recommender → kg-bioportal-data (fetch) → kg-bioportal-merge (combine + QC) → Mappings (resolve dangling/dupes) → Annotator (extend from text).

## Accuracy notes
Docs reflect **verified** behavior, not the upstream READMEs:
- Real KGX columns — `provided_by`/`knowledge_source` currently hold `<ID>_relaxed.owl`, edge `id` is usually empty (documented as quirks).
- The actual cat-merge `merge(name=, nodes=[...], edges=[...], output_dir=)` signature — the README's `input_dir` argument doesn't exist in the installed package.

Scripts are stdlib-only except `pyyaml` (reading stats) and `cat-merge` (merging), with network timeouts so they never hang. No changes to the pipeline, site, or workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)