### PR TITLE
Version-skip in prepare: only re-transform changed ontologies

### DIFF
--- a/.github/workflows/transform.yml
+++ b/.github/workflows/transform.yml
@@ -64,17 +64,27 @@ jobs:
         run: kgbioportal get-ontology-list -o data/raw -k "$NCBO_API_KEY"
         env:
           NCBO_API_KEY: ${{ secrets.NCBO_API_KEY }}
+      - name: Fetch the current index (for version-skip on a full run)
+        if: ${{ github.event.inputs.ontologies == '' }}
+        run: gh release download -p onto_stats.yaml -D prev || echo "No index yet; will transform all."
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Compute shards
         id: shard
+        # Explicit ontologies input: transform exactly those (no version-skip).
+        # Full list: version-skip against the current index — only new/changed
+        # BioPortal submissions are (re)transformed; unchanged graphs carry forward.
         run: |
           if [ -n "${{ github.event.inputs.ontologies }}" ]; then
             SHARDS=$(kgbioportal shard-list -d "${{ github.event.inputs.ontologies }}" -n "$NUM_SHARDS")
           else
-            SHARDS=$(kgbioportal shard-list -f data/raw/ontologylist.tsv -n "$NUM_SHARDS")
+            SHARDS=$(kgbioportal shard-list -f data/raw/ontologylist.tsv -n "$NUM_SHARDS" --index prev/onto_stats.yaml)
           fi
           echo "shards=$SHARDS" >> "$GITHUB_OUTPUT"
       - name: Create release
         id: rel
+        # Skip entirely when version-skip found nothing changed (empty shard set).
+        if: ${{ steps.shard.outputs.shards != '[]' }}
         # Each run gets its own release holding only the ontologies it transforms
         # (releases are incremental; a release holds <=1000 assets). NOT marked
         # --latest here — finalize marks it latest after publishing the full index,
@@ -91,6 +101,8 @@ jobs:
 
   transform:
     needs: prepare
+    # Nothing to do when version-skip produced an empty shard set.
+    if: ${{ needs.prepare.outputs.shards != '[]' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -136,7 +148,8 @@ jobs:
 
   finalize:
     needs: [prepare, transform]
-    if: always()
+    # Run whenever there was work (even if some shards failed); skip a no-op run.
+    if: ${{ always() && needs.prepare.outputs.shards != '[]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/src/kg_bioportal/cli.py
+++ b/src/kg_bioportal/cli.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 
 import click
 
@@ -29,6 +30,46 @@ def _read_acronyms(ontology_file: str) -> list:
             if line:
                 acronyms.append(line.split("\t")[0])
     return acronyms
+
+
+def _read_ontology_submissions(ontology_file: str) -> dict:
+    """Read {acronym: submission_id} from the ontology list TSV.
+
+    Columns are: id, name, current_version, submission_id.
+    """
+    subs = {}
+    with open(ontology_file, "r") as f:
+        f.readline()  # Skip the header
+        for line in f:
+            line = line.rstrip("\n")
+            if not line.strip():
+                continue
+            cols = line.split("\t")
+            acr = cols[0].strip()
+            sub = cols[3].strip() if len(cols) > 3 else ""
+            subs[acr] = sub
+    return subs
+
+
+def _load_index_submissions(index_path: str) -> dict:
+    """Read {acronym: submission_id} from an onto_stats.yaml index.
+
+    Only entries with a concrete submission_id are returned (skiplisted / no-
+    submission entries use 'NA' and are excluded), so a later run always treats
+    those as needing a transform.
+    """
+    import yaml
+
+    if not index_path or not os.path.exists(index_path):
+        return {}
+    with open(index_path) as f:
+        data = yaml.safe_load(f) or {}
+    out = {}
+    for entry in data.get("ontologies", []):
+        sub = str(entry.get("submission_id") or "").strip()
+        if sub and sub != "NA":
+            out[entry["id"]] = sub
+    return out
 
 
 @click.group()
@@ -281,19 +322,46 @@ def transform(input_dir, output_dir, compress, timeout_min) -> None:
     show_default=True,
     help="Drop ontologies on the static known-giants skiplist before sharding.",
 )
-def shard_list(ontology_file, ontologies, num_shards, use_skiplist) -> None:
+@click.option(
+    "--index",
+    "index_path",
+    required=False,
+    type=click.Path(),
+    help="Path to the current onto_stats.yaml index. If given (with --ontology_file), "
+    "only ontologies whose BioPortal submission_id differs from the index are sharded "
+    "(version-skip); unchanged ones carry forward via the finalize seed.",
+)
+def shard_list(ontology_file, ontologies, num_shards, use_skiplist, index_path) -> None:
     """Splits the ontology list into N shards and prints them as JSON.
 
     Emits a JSON array of strings, each a space-separated group of acronyms,
     suitable for a GitHub Actions matrix. Prints ONLY the JSON to stdout so it
     can be captured as a job output.
     """
+    current_subs = {}
     if ontologies:
-        acronyms = ontologies.split()
+        acronyms = ontologies.split()  # explicit list: never version-skipped
     elif ontology_file:
-        acronyms = _read_acronyms(ontology_file)
+        current_subs = _read_ontology_submissions(ontology_file)
+        acronyms = list(current_subs)
     else:
         raise click.UsageError("Provide --ontologies or --ontology_file.")
+
+    # Version-skip: only (re)transform ontologies that are new or whose BioPortal
+    # submission changed vs the current index. Applies only to the full list.
+    if index_path and current_subs:
+        index_subs = _load_index_submissions(index_path)
+        if index_subs:
+            before = len(acronyms)
+            acronyms = [
+                a for a in acronyms
+                if index_subs.get(a) != current_subs.get(a)
+            ]
+            click.echo(
+                f"version-skip: {before - len(acronyms)} unchanged skipped, "
+                f"{len(acronyms)} to transform.",
+                err=True,
+            )
 
     if use_skiplist:
         acronyms = [a for a in acronyms if not is_skiplisted(a)]


### PR DESCRIPTION
Closes #123. Follow-up to the index-driven multi-release hosting (#122).

## Why
A full run transformed **every** OK ontology into a single release, which exceeds GitHub's **1000-asset-per-release** cap. This makes a full run only (re)transform ontologies whose BioPortal `submission_id` is **new or changed** vs the current index. Unchanged graphs carry forward via the finalize seed (their index entry + `download_url` are preserved). Each run's release stays small — and the monthly cron (#119) becomes safe to enable.

## Changes
- **`cli.py`** — `shard-list` gains `--index <onto_stats.yaml>`. With `--ontology_file`, it keeps only acronyms whose `submission_id` differs from the index (new/changed). New helpers `_read_ontology_submissions` + `_load_index_submissions`. An explicit `--ontologies` list is never version-skipped (you asked for exactly those).
- **`transform.yml`** — `prepare` downloads the current index (`gh release download -p onto_stats.yaml`, no tag = latest) and passes `--index` on the full-list path. If nothing changed (empty shard set), the create-release step and the `transform`/`finalize` jobs are skipped, so a no-change run is a clean no-op instead of an empty-matrix error.

## Verified locally
`shard-list --index`: given a list where one submission changed (PO 30→31) and one is new (NEWONT), with AGRO/AERO unchanged → emits `["PO", "NEWONT"]` and logs `2 unchanged skipped, 2 to transform`. Without `--index`, all four.

## Next
This unblocks re-enabling the monthly cron (#119).

🤖 Generated with [Claude Code](https://claude.com/claude-code)