### PR TITLE
Split not_downloadable by HTTP status, count licensed ontologies apart

### DIFF
--- a/.github/scripts/merge_stats.py
+++ b/.github/scripts/merge_stats.py
@@ -24,13 +24,17 @@ import sys
 import yaml
 
 
-def load_known_giants(repo_root):
-    """Import KNOWN_GIANTS from src/kg_bioportal/config.py without installing the package."""
+def load_config(repo_root):
+    """Import src/kg_bioportal/config.py without installing the package.
+
+    Keeps the skiplist and the license-restricted reason string in one place
+    rather than duplicating them here.
+    """
     config_path = os.path.join(repo_root, "src", "kg_bioportal", "config.py")
     spec = importlib.util.spec_from_file_location("kgbp_config", config_path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    return sorted(module.KNOWN_GIANTS)
+    return module
 
 
 def main():
@@ -47,6 +51,7 @@ def main():
     # download_url they already have (which release they actually live in).
     release_tag = sys.argv[5] if len(sys.argv) > 5 else ""
     repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    config = load_config(repo_root)
 
     def asset_url(tag, onto_id):
         return f"https://github.com/ncbo/kg-bioportal/releases/download/{tag}/{onto_id}.tar.gz"
@@ -81,7 +86,7 @@ def main():
 
     # Ensure the skiplisted giants are represented (they are removed before
     # sharding, so no shard reports them).
-    for acr in load_known_giants(repo_root):
+    for acr in sorted(config.KNOWN_GIANTS):
         by_id.setdefault(
             acr,
             {
@@ -104,17 +109,23 @@ def main():
 
     ok = sum(1 for o in ontologies if o.get("status") == "OK")
     skipped = sum(1 for o in ontologies if o.get("status") == "Skipped")
-    failed = sum(1 for o in ontologies if o.get("status") == "Failed")
+    # License-restricted entries stay status Failed (no artifact exists) but are
+    # counted separately and excluded from failedcount — see transformer.py.
+    licensed = sum(
+        1 for o in ontologies if o.get("reason") == config.LICENSE_RESTRICTED_REASON
+    )
+    failed = sum(1 for o in ontologies if o.get("status") == "Failed") - licensed
     with open(os.path.join(output_dir, "total_stats.yaml"), "w") as f:
         f.write(f"totalcount: {ok}\n")
         f.write(f"skippedcount: {skipped}\n")
         f.write(f"failedcount: {failed}\n")
+        f.write(f"licensedcount: {licensed}\n")
         f.write(f"totalnodecount: {sum(o.get('nodecount', 0) for o in ontologies)}\n")
         f.write(f"totaledgecount: {sum(o.get('edgecount', 0) for o in ontologies)}\n")
         if transform_date:
             f.write(f"transform_date: {transform_date}\n")
 
-    print(f"OK={ok} Skipped={skipped} Failed={failed} -> {output_dir}/")
+    print(f"OK={ok} Skipped={skipped} Failed={failed} Licensed={licensed} -> {output_dir}/")
 
 
 if __name__ == "__main__":

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 data
 __pycache__/
 .DS_Store
+# BioPortal / NCBO API key — the transform reads it from the NCBO_API_KEY
+# secret in CI; a local copy must never be committed.
+ncbo_key

--- a/README.md
+++ b/README.md
@@ -33,12 +33,39 @@ the stats with a reason, rather than failing the build:
   (e.g. NCBITAXON, SNOMEDCT, RXNORM, GAZ, PR, NCIT, …). See `KNOWN_GIANTS` in
   [`src/kg_bioportal/config.py`](src/kg_bioportal/config.py).
 - **`too_large`** — the downloaded source exceeded the size gate
-  (`--max_source_mb`, default 50 MB).
+  (`--max_source_mb`, default 100 MB).
 - **`too_slow`** — the transform exceeded the per-ontology wall-clock cap
   (`--timeout_min`, default 30 min).
 
 These thresholds are tunable via config, CLI flags, or the environment
 (`KGBP_MAX_SOURCE_MB`, `KGBP_TIMEOUT_MIN`).
+
+## What BioPortal won't give us, and why
+
+Some ontologies never reach the transform because BioPortal doesn't serve a
+source file. The download endpoint's status code says which case it is, and
+each gets its own reason:
+
+- **`license_restricted`** (HTTP 401/403) — the ontology is only available
+  under a license we don't hold, typically UMLS. **Not a failure**: there is
+  nothing to fix and nothing to retry.
+- **`no_download_file`** (HTTP 404) — BioPortal has a record and a submission,
+  but no source file is attached to it.
+- **`download_http_error`** (any other non-2xx) — an unexpected response; the
+  code is recorded so it can be told apart from the above.
+- **`not_downloadable`** (2xx, no `Content-Disposition`) — BioPortal answered,
+  but not with a file. The genuinely ambiguous remainder.
+- **`no_submission`** — the ontology record exists but has no submission.
+- **`metadata_http_error`** — the ontology's metadata couldn't be retrieved.
+
+The response code is kept in the `http_status` field of both
+`download_report.tsv` and the affected `onto_stats.yaml` entries.
+
+`total_stats.yaml` counts license-restricted ontologies on their own
+`licensedcount` line, and **excludes them from `failedcount`** — they are
+unavailable by design, so counting them as failures overstates how much of the
+pipeline is broken. Their `onto_stats.yaml` entries still read `status: Failed`,
+since no KGX artifact exists for them either way.
 
 ## How the build runs
 

--- a/docs/kg_site/build_site.py
+++ b/docs/kg_site/build_site.py
@@ -133,8 +133,13 @@ def onto_to_item(o, transform_date):
     ver = "" if ver in ("NA", "") else ver
     nodes = o.get("nodecount") if ok and isinstance(o.get("nodecount"), int) else None
     edges = o.get("edgecount") if ok and isinstance(o.get("edgecount"), int) else None
+    # License-restricted entries are stored as Failed (there is no artifact) but
+    # nothing about them is broken, so don't call them failed to a reader.
+    licensed = o.get("reason") == "license_restricted"
     if ok:
         blurb = "BioPortal ontology transformed to KGX"
+    elif licensed:
+        blurb = "BioPortal ontology — not available under our license"
     else:
         blurb = "BioPortal ontology — " + (status.lower() or "not transformed") + (
             f" ({o.get('reason')})" if o.get("reason") else "")
@@ -143,7 +148,8 @@ def onto_to_item(o, transform_date):
         "id": oid, "acr": oid.upper(), "name": name, "ok": ok,
         "blurb": blurb,
         "nodes": nodes, "edges": edges, "fmts": ["kgx"] if ok else [], "domains": [],
-        "status_label": status or "—", "status_cls": "ok" if ok else "warn",
+        "status_label": "Licensed" if licensed else (status or "—"),
+        "status_cls": "ok" if ok else "warn",
         "updated": transform_date or "",
         # Every transformed-ontology entry now gets a page — OK ones with the KGX
         # download, non-OK ones collecting the metadata we do have + why there's no artifact.
@@ -166,6 +172,13 @@ REASON_MSG = {
                 "skipped up front.",
     "transform_error": "The transform did not complete — ROBOT or the KGX conversion reported an error.",
     "not_downloadable": "No downloadable source is currently available from BioPortal.",
+    "license_restricted": "This ontology is only available under a license we do not hold "
+                          "(typically a UMLS licence), so BioPortal does not serve its source "
+                          "file to the pipeline. It is not transformed by design, and there is "
+                          "nothing to retry.",
+    "no_download_file": "BioPortal has a record for this ontology but no source file is attached "
+                        "to its latest submission.",
+    "download_http_error": "The source download from BioPortal returned an unexpected response.",
     "no_submission": "No submission is currently available for this ontology on BioPortal.",
     "metadata_http_error": "BioPortal metadata for this ontology could not be retrieved.",
     "download_error": "The source download from BioPortal failed.",
@@ -465,7 +478,11 @@ def render_summary(totals, kg_count, onto_items):
     skipped = totals.get("skippedcount")
     if not isinstance(failed, int) or not isinstance(skipped, int):
         failed, skipped = len(onto_items) - onto_ok, 0
-    attempted = onto_ok + failed + skipped
+    # Ontologies BioPortal won't serve us for licensing reasons. Absent from
+    # stats written before that distinction existed, hence the default.
+    licensed = totals.get("licensedcount")
+    licensed = licensed if isinstance(licensed, int) else 0
+    attempted = onto_ok + failed + skipped + licensed
     nodes = totals.get("totalnodecount")
     edges = totals.get("totaledgecount")
     if not isinstance(nodes, int):
@@ -493,11 +510,12 @@ def render_summary(totals, kg_count, onto_items):
     status_block = f"""
         <section class="block">
           <p class="eyebrow">Transform status <span class="eb-count">{commafy(attempted)} ontologies</span></p>
-          <div class="stack">{seg('ok', onto_ok)}{seg('fail', failed)}{seg('skip', skipped)}</div>
+          <div class="stack">{seg('ok', onto_ok)}{seg('fail', failed)}{seg('skip', skipped)}{seg('lic', licensed)}</div>
           <div class="keys">{key('ok', onto_ok, 'Transformed')}{key('fail', failed, 'Failed')}
-            {key('skip', skipped, 'Skipped')}</div>
-          <p class="muted mt">Failed and skipped ontologies are still listed in the
-            <a href="../index.html">browser</a>, each with the reason it has no KGX artifact.</p>
+            {key('skip', skipped, 'Skipped')}{key('lic', licensed, 'Licensed') if licensed else ''}</div>
+          <p class="muted mt">Failed, skipped and license-restricted ontologies are still listed in
+            the <a href="../index.html">browser</a>, each with the reason it has no KGX artifact.
+            Licensed ones are counted apart from failures: they are unavailable by design, not broken.</p>
         </section>"""
 
     def top_rows(field):
@@ -1263,11 +1281,13 @@ padding:3px 5px;border-radius:7px;color:var(--ink)}
 .stack{display:flex;gap:2px;height:16px;border-radius:4px;overflow:hidden;background:var(--panel-2)}
 .stack .seg{display:block;height:100%}
 .seg.ok{background:var(--prod)}.seg.fail{background:var(--warn)}.seg.skip{background:var(--ink-faint)}
+.seg.lic{background:var(--primary)}
 .keys{display:flex;flex-wrap:wrap;gap:16px;margin-top:10px;font-size:12.5px;color:var(--ink-soft)}
 .key{display:inline-flex;align-items:center;gap:6px}
 .key b{color:var(--ink)}
 .sw{width:9px;height:9px;border-radius:2px;flex:none}
 .sw.ok{background:var(--prod)}.sw.fail{background:var(--warn)}.sw.skip{background:var(--ink-faint)}
+.sw.lic{background:var(--primary)}
 .cloud{display:flex;flex-wrap:wrap;gap:6px}
 .tok{font-size:12px;padding:4px 9px;border-radius:6px;border:1px solid var(--border);background:var(--panel)}
 .tok.cat{color:var(--c-chem);border-color:color-mix(in srgb,var(--c-chem) 30%,transparent)}

--- a/src/kg_bioportal/config.py
+++ b/src/kg_bioportal/config.py
@@ -61,3 +61,17 @@ KNOWN_GIANTS: frozenset = frozenset(
 def is_skiplisted(acronym: str) -> bool:
     """True if the ontology is on the static skiplist of known giants."""
     return acronym.strip().upper() in KNOWN_GIANTS
+
+
+# --- Download outcomes ----------------------------------------------------- #
+
+# Recorded when BioPortal declines to serve the source file because the
+# ontology is under a license we don't hold (UMLS-derived terminologies and
+# friends). This is not a failure of the pipeline: there is nothing to fix and
+# nothing to retry, so it is counted separately from the ontologies that broke.
+LICENSE_RESTRICTED_REASON: str = "license_restricted"
+
+# HTTP statuses on the download endpoint that mean "you may not have this file"
+# rather than "this file does not exist". 401 is included because a request
+# without sufficient credentials is the same situation from our side.
+LICENSE_STATUSES: frozenset = frozenset({401, 403})

--- a/src/kg_bioportal/downloader.py
+++ b/src/kg_bioportal/downloader.py
@@ -3,11 +3,17 @@
 import csv
 import logging
 import os
+from typing import Union
 
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
-from kg_bioportal.config import MAX_SOURCE_MB, is_skiplisted
+from kg_bioportal.config import (
+    LICENSE_RESTRICTED_REASON,
+    LICENSE_STATUSES,
+    MAX_SOURCE_MB,
+    is_skiplisted,
+)
 
 ONTOLOGY_LIST_NAME = "ontologylist.tsv"
 
@@ -71,9 +77,14 @@ class Downloader:
 
     def _record(
         self, acronym, submission_id, source_bytes, path, status, reason,
-        name="", version="",
+        name="", version="", http_status: Union[int, str] = "",
     ):
-        """Append a per-ontology outcome to the results list."""
+        """Append a per-ontology outcome to the results list.
+
+        ``http_status`` is the response code from BioPortal, recorded for the
+        outcomes that hinge on it so the reason can be audited later without
+        re-running the download.
+        """
         self.results.append(
             {
                 "id": acronym,
@@ -84,8 +95,23 @@ class Downloader:
                 "path": path,
                 "status": status,
                 "reason": reason,
+                "http_status": http_status,
             }
         )
+
+    @staticmethod
+    def _body_snippet(response) -> str:
+        """First line of an error response body, for the log.
+
+        BioPortal explains itself in the body ("You must accept the license
+        terms..."), which is the quickest way to tell a licensing refusal from
+        anything else. Best effort only — never let this raise.
+        """
+        try:
+            text = " ".join(response.text[:200].split())
+        except Exception:  # noqa: BLE001 - diagnostics must not break the download
+            return ""
+        return text
 
     def download(self, onto_list: list = []) -> list:
         """Downloads data files from list of ontologies into data directory.
@@ -125,7 +151,8 @@ class Downloader:
                 logging.error(
                     f"Failed to fetch metadata for {ontology}: HTTP {metadata_resp.status_code}"
                 )
-                self._record(ontology, "NA", 0, "", "error", "metadata_http_error")
+                self._record(ontology, "NA", 0, "", "error", "metadata_http_error",
+                             http_status=metadata_resp.status_code)
                 continue
             metadata = metadata_resp.json()
             onto_name = str(metadata.get("name") or ontology)
@@ -156,6 +183,30 @@ class Downloader:
                              name=onto_name, version=onto_version)
                 continue
 
+            # Why we didn't get a file matters, and the status code is the only
+            # thing that distinguishes the cases. Without this check every one of
+            # them looks like "not_downloadable", which lumps licensed
+            # terminologies (working as intended) in with broken records.
+            code = download_onto.status_code
+            if not download_onto.ok:
+                if code in LICENSE_STATUSES:
+                    reason = LICENSE_RESTRICTED_REASON
+                    note = "license does not cover this API key"
+                elif code == 404:
+                    reason = "no_download_file"
+                    note = "no source file attached to the submission"
+                else:
+                    reason = "download_http_error"
+                    note = "unexpected response"
+                logging.warning(
+                    f"Not downloading {ontology}: HTTP {code} ({note}). "
+                    f"{self._body_snippet(download_onto)}"
+                )
+                download_onto.close()
+                self._record(ontology, submission_id, 0, "", "error", reason,
+                             name=onto_name, version=onto_version, http_status=code)
+                continue
+
             try:
                 onto_filename = (
                     download_onto.headers["Content-Disposition"]
@@ -163,12 +214,14 @@ class Downloader:
                     .replace('"', "")
                 )
             except KeyError:
+                # A 2xx with no filename: BioPortal answered, but not with a file.
                 logging.warning(
-                    f"Could not download {ontology}. Check if the ontology is downloadable."
+                    f"Could not download {ontology}: HTTP {code} with no Content-Disposition. "
+                    f"Check if the ontology is downloadable."
                 )
                 download_onto.close()
                 self._record(ontology, submission_id, 0, "", "error", "not_downloadable",
-                             name=onto_name, version=onto_version)
+                             name=onto_name, version=onto_version, http_status=code)
                 continue
 
             # Size gate 1: trust Content-Length if present.
@@ -231,11 +284,19 @@ class Downloader:
 
         skipped = [r for r in self.results if r["status"] == "skipped"]
         errored = [r for r in self.results if r["status"] == "error"]
+        licensed = [r for r in errored if r["reason"] == LICENSE_RESTRICTED_REASON]
         if skipped:
             logging.warning(f"Skipped {len(skipped)} ontologies (too large / skiplist).")
-        if errored:
+        if licensed:
+            # Not a failure: we simply aren't licensed for these. Reported apart
+            # from the errors so a run's real problems stay visible.
+            logging.info(
+                f"{len(licensed)} ontologies are license-restricted: {[r['id'] for r in licensed]}"
+            )
+        if len(errored) > len(licensed):
             logging.warning(
-                f"Encountered errors downloading: {[r['id'] for r in errored]}"
+                "Encountered errors downloading: "
+                f"{[r['id'] for r in errored if r['reason'] != LICENSE_RESTRICTED_REASON]}"
             )
 
         return self.results
@@ -243,7 +304,8 @@ class Downloader:
     def _write_report(self) -> None:
         """Write per-ontology download outcomes to a TSV in the output dir."""
         report_path = os.path.join(self.output_dir, DOWNLOAD_REPORT_NAME)
-        fieldnames = ["id", "name", "version", "submission_id", "source_bytes", "status", "reason", "path"]
+        fieldnames = ["id", "name", "version", "submission_id", "source_bytes", "status", "reason",
+                      "http_status", "path"]
         with open(report_path, "w", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter="\t")
             writer.writeheader()

--- a/src/kg_bioportal/transformer.py
+++ b/src/kg_bioportal/transformer.py
@@ -14,7 +14,7 @@ from typing import Tuple
 import yaml
 from kgx.transformer import Transformer as KGXTransformer
 
-from kg_bioportal.config import PER_ONTOLOGY_TIMEOUT_MIN
+from kg_bioportal.config import LICENSE_RESTRICTED_REASON, PER_ONTOLOGY_TIMEOUT_MIN
 from kg_bioportal.downloader import DOWNLOAD_REPORT_NAME, ONTOLOGY_LIST_NAME
 from kg_bioportal.robot_utils import initialize_robot, robot_convert, robot_relax
 
@@ -81,6 +81,37 @@ def strip_imports(path: str) -> str:
         f.write(cleaned)
     logging.info(f"Stripped {removed} import declaration(s) from {os.path.basename(path)}.")
     return new_path
+
+
+def summarize(onto_log: dict) -> dict:
+    """Roll a per-ontology log up into the fields of total_stats.yaml.
+
+    License-restricted ontologies get their own count and are *excluded* from
+    ``failedcount``. They keep ``status: Failed`` in onto_stats (no artifact
+    exists for them either way), but nothing about them is broken and no rerun
+    will change that, so counting them as failures overstates how much of the
+    pipeline needs fixing.
+
+    Args:
+        onto_log: {acronym: entry} as built by ``transform_all``.
+
+    Returns:
+        Ordered mapping of total_stats.yaml field name to value.
+    """
+    def by_status(status):
+        return sum(1 for e in onto_log.values() if e["status"] == status)
+
+    licensed = sum(
+        1 for e in onto_log.values() if e.get("reason") == LICENSE_RESTRICTED_REASON
+    )
+    return {
+        "totalcount": by_status("OK"),
+        "skippedcount": by_status("Skipped"),
+        "failedcount": by_status("Failed") - licensed,
+        "licensedcount": licensed,
+        "totalnodecount": sum(e["nodecount"] for e in onto_log.values()),
+        "totaledgecount": sum(e["edgecount"] for e in onto_log.values()),
+    }
 
 
 class TransformTimeout(Exception):
@@ -197,7 +228,7 @@ class Transformer:
         # time (they have no file on disk to walk).
         for onto_id, row in download_report.items():
             if row.get("status") in ("skipped", "error"):
-                onto_log[onto_id] = {
+                entry = {
                     "status": "Skipped" if row["status"] == "skipped" else "Failed",
                     "reason": row.get("reason", ""),
                     "name": row.get("name", ""),
@@ -207,6 +238,12 @@ class Transformer:
                     "submission_id": row.get("submission_id", "NA"),
                     "source_bytes": int(row.get("source_bytes") or 0),
                 }
+                # Only download outcomes have a status code; don't clutter the
+                # other entries with an empty field.
+                http_status = row.get("http_status") or ""
+                if http_status:
+                    entry["http_status"] = int(http_status)
+                onto_log[onto_id] = entry
 
         filepaths = []
         for root, _dirs, files in os.walk(self.input_dir):
@@ -258,23 +295,10 @@ class Transformer:
 
         # Write total stats to a yaml
         logging.info("Writing total stats to total_stats.yaml.")
-        success_count = sum(1 for o in onto_log if onto_log[o]["status"] == "OK")
-        skipped_count = sum(1 for o in onto_log if onto_log[o]["status"] == "Skipped")
-        failed_count = sum(1 for o in onto_log if onto_log[o]["status"] == "Failed")
+        totals = summarize(onto_log)
         with open(os.path.join(self.output_dir, "total_stats.yaml"), "w") as f:
-            f.write("totalcount: " + str(success_count) + "\n")
-            f.write("skippedcount: " + str(skipped_count) + "\n")
-            f.write("failedcount: " + str(failed_count) + "\n")
-            f.write(
-                "totalnodecount: "
-                + str(sum(onto_log[o]["nodecount"] for o in onto_log))
-                + "\n"
-            )
-            f.write(
-                "totaledgecount: "
-                + str(sum(onto_log[o]["edgecount"] for o in onto_log))
-                + "\n"
-            )
+            for key, value in totals.items():
+                f.write(f"{key}: {value}\n")
 
         # Dump onto_log to a yaml
         logging.info("Writing ontology stats to onto_stats.yaml.")

--- a/tests/test_download_outcomes.py
+++ b/tests/test_download_outcomes.py
@@ -1,0 +1,191 @@
+"""Tests for how download outcomes are classified and counted.
+
+Covers the split of the old catch-all ``not_downloadable`` into reasons driven
+by the download endpoint's status code, and the separate accounting for
+license-restricted ontologies.
+"""
+
+import csv
+import os
+import tempfile
+from unittest import TestCase
+
+from kg_bioportal.downloader import DOWNLOAD_REPORT_NAME, Downloader
+from kg_bioportal.transformer import summarize
+
+METADATA = {"name": "Test Ontology"}
+SUBMISSION = {"submissionId": "3", "version": "1.0", "released": "2026-01-01"}
+
+
+class FakeResponse:
+    """Minimal stand-in for a requests.Response."""
+
+    def __init__(self, status_code=200, headers=None, payload=None, text="", chunks=()):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._payload = payload
+        self.text = text
+        self._chunks = chunks
+        self.closed = False
+
+    @property
+    def ok(self):
+        return 200 <= self.status_code < 300
+
+    def json(self):
+        return self._payload
+
+    def iter_content(self, chunk_size=None):
+        return iter(self._chunks)
+
+    def close(self):
+        self.closed = True
+
+
+class FakeSession:
+    """Answers the three GETs Downloader.download makes, in order."""
+
+    def __init__(self, download_response, metadata_response=None, submission_payload=SUBMISSION):
+        self.download_response = download_response
+        self.metadata_response = metadata_response or FakeResponse(payload=METADATA)
+        self.submission_payload = submission_payload
+
+    def get(self, url, **kwargs):
+        if url.endswith("/download"):
+            return self.download_response
+        if url.endswith("/latest_submission"):
+            return FakeResponse(payload=self.submission_payload)
+        return self.metadata_response
+
+
+def run_download(download_response, **session_kwargs):
+    """Run one ontology through Downloader.download with a faked session."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dl = Downloader(output_dir=tmpdir, api_key="fake-key")
+        dl.requests_session = FakeSession(download_response, **session_kwargs)
+        results = dl.download(["TESTONTO"])
+        with open(os.path.join(tmpdir, DOWNLOAD_REPORT_NAME), newline="") as f:
+            report = list(csv.DictReader(f, delimiter="\t"))
+    return results[0], report[0]
+
+
+class TestDownloadOutcomeReasons(TestCase):
+    """The status code, not the missing header, decides the reason."""
+
+    def test_403_is_license_restricted(self):
+        result, _ = run_download(
+            FakeResponse(status_code=403, text="You must accept the license terms.")
+        )
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["reason"], "license_restricted")
+        self.assertEqual(result["http_status"], 403)
+
+    def test_401_is_also_license_restricted(self):
+        # From our side, "not authorized" and "forbidden" are the same situation.
+        result, _ = run_download(FakeResponse(status_code=401))
+        self.assertEqual(result["reason"], "license_restricted")
+
+    def test_404_is_no_download_file(self):
+        result, _ = run_download(FakeResponse(status_code=404))
+        self.assertEqual(result["reason"], "no_download_file")
+        self.assertEqual(result["http_status"], 404)
+
+    def test_other_non_2xx_is_download_http_error(self):
+        result, _ = run_download(FakeResponse(status_code=502))
+        self.assertEqual(result["reason"], "download_http_error")
+        self.assertEqual(result["http_status"], 502)
+
+    def test_2xx_without_filename_stays_not_downloadable(self):
+        # BioPortal answered, just not with a file: the genuinely ambiguous case.
+        result, _ = run_download(FakeResponse(status_code=200, headers={}))
+        self.assertEqual(result["reason"], "not_downloadable")
+        self.assertEqual(result["http_status"], 200)
+
+    def test_successful_download_is_recorded(self):
+        result, _ = run_download(
+            FakeResponse(
+                status_code=200,
+                headers={"Content-Disposition": 'attachment; filename="testonto.owl"'},
+                chunks=[b"<rdf:RDF/>"],
+            )
+        )
+        self.assertEqual(result["status"], "downloaded")
+        self.assertEqual(result["reason"], "")
+        self.assertEqual(result["source_bytes"], len(b"<rdf:RDF/>"))
+
+    def test_error_responses_are_closed(self):
+        response = FakeResponse(status_code=403)
+        run_download(response)
+        self.assertTrue(response.closed, "the streamed response must be released")
+
+
+class TestDownloadReport(TestCase):
+    """The status code has to survive into the report the transform step reads."""
+
+    def test_report_carries_http_status(self):
+        _, row = run_download(FakeResponse(status_code=403))
+        self.assertIn("http_status", row)
+        self.assertEqual(row["http_status"], "403")
+        self.assertEqual(row["reason"], "license_restricted")
+
+    def test_report_leaves_http_status_blank_when_irrelevant(self):
+        # Skiplisted ontologies never hit the network, so there is no code.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dl = Downloader(output_dir=tmpdir, api_key="fake-key")
+            dl.requests_session = FakeSession(FakeResponse())
+            dl.download(["NCBITAXON"])
+            with open(os.path.join(tmpdir, DOWNLOAD_REPORT_NAME), newline="") as f:
+                row = next(csv.DictReader(f, delimiter="\t"))
+        self.assertEqual(row["reason"], "skiplist")
+        self.assertEqual(row["http_status"], "")
+
+
+def entry(status, reason="", nodes=0, edges=0):
+    return {"status": status, "reason": reason, "nodecount": nodes, "edgecount": edges}
+
+
+class TestSummarize(TestCase):
+    """licensedcount is its own line and does not inflate failedcount."""
+
+    def setUp(self):
+        self.onto_log = {
+            "GOOD": entry("OK", nodes=10, edges=20),
+            "ALSOGOOD": entry("OK", nodes=5, edges=7),
+            "BIG": entry("Skipped", "too_large"),
+            "GIANT": entry("Skipped", "skiplist"),
+            "BROKEN": entry("Failed", "transform_error"),
+            "MISSING": entry("Failed", "no_download_file"),
+            "UMLS1": entry("Failed", "license_restricted"),
+            "UMLS2": entry("Failed", "license_restricted"),
+        }
+
+    def test_licensed_are_counted_separately(self):
+        totals = summarize(self.onto_log)
+        self.assertEqual(totals["licensedcount"], 2)
+
+    def test_licensed_are_excluded_from_failed(self):
+        totals = summarize(self.onto_log)
+        # Four entries have status Failed; only two of them are real failures.
+        self.assertEqual(totals["failedcount"], 2)
+
+    def test_every_ontology_is_accounted_for_exactly_once(self):
+        totals = summarize(self.onto_log)
+        counted = (
+            totals["totalcount"]
+            + totals["skippedcount"]
+            + totals["failedcount"]
+            + totals["licensedcount"]
+        )
+        self.assertEqual(counted, len(self.onto_log))
+
+    def test_counts_are_unchanged_without_licensed_entries(self):
+        for acronym in ("UMLS1", "UMLS2"):
+            del self.onto_log[acronym]
+        totals = summarize(self.onto_log)
+        self.assertEqual(totals["failedcount"], 2)
+        self.assertEqual(totals["licensedcount"], 0)
+
+    def test_node_and_edge_totals(self):
+        totals = summarize(self.onto_log)
+        self.assertEqual(totals["totalnodecount"], 15)
+        self.assertEqual(totals["totaledgecount"], 27)


### PR DESCRIPTION
Closes #143.

`Downloader.download` never inspected the download endpoint's status code — it went straight to `Content-Disposition`, so every response without that header became `not_downloadable`. UMLS-licensed terminologies (working as intended) and BioPortal records with no file attached were indistinguishable in the stats, and all 44 counted toward `failedcount`.

## What changed

**Status code decides the reason** ([`downloader.py`](../blob/issue-143-split-not-downloadable/src/kg_bioportal/downloader.py)):

| Response | Reason |
|---|---|
| 401 / 403 | `license_restricted` |
| 404 | `no_download_file` |
| other non-2xx | `download_http_error` |
| 2xx, no `Content-Disposition` | `not_downloadable` (the genuinely ambiguous remainder) |

The code itself is kept in a new `http_status` field so a reason can be audited later without re-running the download. It flows through `download_report.tsv` into `onto_stats.yaml`. The first line of an error body is logged too — BioPortal explains itself there ("You must accept the license terms…"), which is the quickest confirmation that a 403 really is licensing.

**Licensed ontologies are counted apart.** `total_stats.yaml` gains a `licensedcount` line and `failedcount` now excludes them. They keep `status: Failed` in `onto_stats.yaml`, since no KGX artifact exists for them either way — but nothing about them is broken and no rerun will change that, so counting them as failures overstates how much of the pipeline needs fixing. Same rollup in `merge_stats.py`, which is what actually writes the published stats.

**Site.** The summary page's status bar grows a fourth key (only rendered when non-zero, so older stats without the field still render), the browser labels these entries **Licensed** instead of *failed (license_restricted)*, and the resource page explains that the ontology is unavailable by design with nothing to retry. Three new `REASON_MSG` entries cover the new reasons.

**Testability.** The count rollup moved out of `Transformer.transform_all` into a module-level `summarize()`, so it can be tested without standing up ROBOT.

## Verification

- 14 new tests in `tests/test_download_outcomes.py` cover the status→reason mapping, the streamed response being released on every error path, `http_status` reaching the report TSV (and staying blank for skiplisted ontologies that never hit the network), and the accounting — including that every ontology is counted exactly once across the four buckets.
- `merge_stats.py` run against the real `data-2026.07` index with three ontologies reclassified: `failedcount` 141 → 138, `licensedcount` 3, `http_status: 403` preserved on the entries.
- Summary page rendered with and without `licensedcount` present; the legacy path omits the key rather than crashing.

## Notes

- **The 401/403/404 split is the expected mapping, not a measured one.** BioPortal needs an API key, so I couldn't confirm the real distribution across the 44 locally. The code logs the status and body for every one of them, so the next transform run will tell us the actual split — worth a look at the logs before assuming the ~9 I guessed as UMLS-licensed in #133 is the true count.
- `--max_source_mb` was documented as 50 MB in the README while `config.py` says 100; corrected, since this PR touches that section anyway.
- Unrelated to this change, but noticed while adding tests: the seven pre-existing modules in `tests/` all fail to import (they reference `kg_bioportal.download`, `kg_bioportal.utils`, `kg_bioportal.transform_utils` — none of which exist any more), and the `run tests` workflow installs dependencies without ever invoking pytest. The new test module is self-contained and passes, but nothing in CI runs it. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
