### PR TITLE
Resolve graph downloads through the index, not through `latest`

### DIFF
--- a/.claude/skills/kg-bioportal-data/references/data-model.md
+++ b/.claude/skills/kg-bioportal-data/references/data-model.md
@@ -18,9 +18,23 @@ recent artifact, e.g. `.../releases/download/data-2026.08.01-42/GO.tar.gz`. To g
 index, look up its `download_url`, download that. `<ID>` is the BioPortal acronym in **uppercase**;
 each tarball contains `<ID>_nodes.tsv` and `<ID>_edges.tsv`.
 
+The latest release also carries **`graph_urls.tsv`** — the same `<ID>` → artifact-URL mapping as a
+two-column TSV with one header line. Prefer it when you don't need the rest of the index or don't
+want a YAML parser:
+
+```bash
+BASE=https://github.com/ncbo/kg-bioportal/releases/latest/download
+URL=$(curl -sL "$BASE/graph_urls.tsv" | awk -F'\t' '$1=="AGRO"{print $2}')
+curl -LO "$URL"
+```
+
 Release tags are unique per run (`data-YYYY.MM.DD-<run>`). Only `status: OK` ontologies have an
-artifact. (The old `.../releases/latest/download/<ID>.tar.gz` URL only works if that graph happens to
-live in the latest release — always prefer the index `download_url`.)
+artifact.
+
+> `.../releases/latest/download/<ID>.tar.gz` does **not** work and never reliably did. `latest` is
+> just the most recent run's release, holding only that run's artifacts, and no single release can
+> hold them all (GitHub caps a release at 1000 assets; there are more transformed ontologies than
+> that). Always resolve through `graph_urls.tsv` or the index's `download_url`.
 
 ## `onto_stats.yaml`
 

--- a/.claude/skills/kg-bioportal-data/scripts/fetch_graph.py
+++ b/.claude/skills/kg-bioportal-data/scripts/fetch_graph.py
@@ -20,21 +20,33 @@ import urllib.request
 socket.setdefaulttimeout(180)  # don't hang forever on a stalled connection
 
 RELEASE = "https://github.com/ncbo/kg-bioportal/releases/latest/download"
-ASSET = RELEASE + "/{id}.tar.gz"  # fallback only
+
+# Releases are incremental and no single one holds every artifact (GitHub caps a
+# release at 1000 assets), so RELEASE + "/<ID>.tar.gz" 404s for nearly every
+# ontology. Always resolve through the index.
 
 
 def load_index():
-    """Map acronym -> download_url from the latest release's onto_stats index.
+    """Map acronym -> download_url, from the latest release.
 
-    Graphs are hosted incrementally across releases; each OK entry records which
-    release holds its artifact. Returns {} if PyYAML/index is unavailable (callers
-    then fall back to the latest-release URL).
+    graph_urls.tsv is the resolver and needs no third-party parser; onto_stats.yaml
+    is the same mapping with everything else attached, used only as a fallback for
+    releases published before the TSV existed.
     """
     try:
-        import yaml
-    except ImportError:
-        return {}
+        with urllib.request.urlopen(RELEASE + "/graph_urls.tsv", timeout=60) as r:
+            rows = r.read().decode("utf-8").splitlines()
+        index = {}
+        for line in rows[1:]:  # skip header
+            parts = line.split("\t")
+            if len(parts) == 2 and parts[1]:
+                index[parts[0]] = parts[1]
+        if index:
+            return index
+    except Exception:
+        pass
     try:
+        import yaml
         with urllib.request.urlopen(RELEASE + "/onto_stats.yaml", timeout=60) as r:
             onts = (yaml.safe_load(r.read()) or {}).get("ontologies", [])
     except Exception:
@@ -52,7 +64,11 @@ def _safe_extract(tar, dest):
 
 
 def fetch(acr, outdir, flat, index):
-    url = index.get(acr) or ASSET.format(id=acr)
+    url = index.get(acr)
+    if not url:
+        print(f"{acr}: not in the index — no KGX artifact is published for it "
+              f"(it may have failed, been skipped, or not exist).", file=sys.stderr)
+        return False
     dest = outdir if flat else os.path.join(outdir, acr)
     os.makedirs(dest, exist_ok=True)
     tmp = os.path.join(tempfile.gettempdir(), f"{acr}.tar.gz")

--- a/.claude/skills/kg-bioportal-data/scripts/list_graphs.py
+++ b/.claude/skills/kg-bioportal-data/scripts/list_graphs.py
@@ -23,7 +23,9 @@ except ImportError:
     sys.exit("PyYAML required: pip install pyyaml")
 
 RELEASE = "https://github.com/ncbo/kg-bioportal/releases/latest/download"
-ASSET = RELEASE + "/{id}.tar.gz"
+
+# There is no RELEASE + "/<ID>.tar.gz": releases are incremental and no single one
+# holds every artifact, so each entry's own download_url is the only reliable answer.
 
 
 def load_stats():
@@ -57,11 +59,9 @@ def main():
     onts.sort(key=keys[a.sort])
 
     if a.json:
-        # Each OK entry already carries its download_url (which release it lives
-        # in); fall back to the latest-release URL for older indexes.
-        for o in onts:
-            if o.get("status") == "OK":
-                o.setdefault("download_url", ASSET.format(id=o["id"]))
+        # Each OK entry carries its own download_url (which release it lives in).
+        # Entries without one come from an index predating the field; report that
+        # honestly rather than inventing a URL that would 404.
         print(json.dumps(onts, indent=2))
         return
 
@@ -69,8 +69,13 @@ def main():
     for o in onts:
         print(f"{o['id']:24} {o.get('status', ''):8} "
               f"{fmt(o.get('nodecount')):>11} {fmt(o.get('edgecount')):>11}  {o.get('name') or ''}")
+    unresolved = sum(1 for o in onts
+                     if o.get("status") == "OK" and not o.get("download_url"))
     print(f"\n{len(onts)} graphs. Each OK entry's download_url (in onto_stats / --json) points at "
-          f"whichever release holds its most recent artifact.")
+          f"whichever release holds its most recent artifact; "
+          f"graph_urls.tsv on the latest release is the same mapping for shell use.")
+    if unresolved:
+        print(f"{unresolved} OK entries have no recorded download_url.")
 
 
 if __name__ == "__main__":

--- a/.claude/skills/kg-bioportal-merge/scripts/merge_kgs.py
+++ b/.claude/skills/kg-bioportal-merge/scripts/merge_kgs.py
@@ -25,7 +25,10 @@ import urllib.request
 socket.setdefaulttimeout(180)  # don't hang forever on a stalled connection
 
 RELEASE = "https://github.com/ncbo/kg-bioportal/releases/latest/download"
-ASSET = RELEASE + "/{id}.tar.gz"  # fallback only
+
+# There is no RELEASE + "/<ID>.tar.gz": releases are incremental and no single one
+# holds every artifact (GitHub caps a release at 1000 assets), so that URL 404s for
+# nearly every ontology. Always resolve through the index.
 
 
 def load_index():
@@ -37,12 +40,15 @@ def load_index():
     import yaml
     with urllib.request.urlopen(RELEASE + "/onto_stats.yaml", timeout=60) as r:
         onts = (yaml.safe_load(r.read()) or {}).get("ontologies", [])
-    return {o["id"]: (o.get("download_url") or ASSET.format(id=o["id"]))
-            for o in onts if o.get("status") == "OK"}
+    return {o["id"]: o["download_url"] for o in onts
+            if o.get("status") == "OK" and o.get("download_url")}
 
 
 def fetch_tsvs(acr, indir, index):
-    url = index.get(acr) or ASSET.format(id=acr)
+    url = index.get(acr)
+    if not url:
+        print(f"  skip {acr}: not in the index — no KGX artifact is published for it")
+        return False
     tmp = os.path.join(tempfile.gettempdir(), f"{acr}.tar.gz")
     try:
         urllib.request.urlretrieve(url, tmp)

--- a/.github/scripts/merge_stats.py
+++ b/.github/scripts/merge_stats.py
@@ -8,10 +8,14 @@ optionally seeds from an existing index (<base_onto_stats>, the previous latest
 release's onto_stats — carries every ontology's download_url), overlays this
 run's results, sets each of this run's OK entries' download_url to <release_tag>,
 adds the statically skiplisted giants as Skipped/skiplist rows, and writes the
-merged onto_stats.yaml + total_stats.yaml into <output_dir>.
+merged onto_stats.yaml + total_stats.yaml + graph_urls.tsv into <output_dir>.
 
 The merged index is authoritative across releases: each OK entry's download_url
-points at whichever release holds that ontology's most recent artifact.
+points at whichever release holds that ontology's most recent artifact. There is
+no release that holds them all — GitHub caps a release at 1000 assets and there
+are more transformed ontologies than that — so resolving through the index is
+the only way to find an artifact. graph_urls.tsv is that same mapping in a form
+a shell can read without a YAML parser.
 
 Depends only on PyYAML. The skiplist is loaded directly from the package's
 config.py by path, so this script needs no heavy dependencies installed.
@@ -107,6 +111,22 @@ def main():
     with open(os.path.join(output_dir, "onto_stats.yaml"), "w") as f:
         yaml.dump({"ontologies": ontologies}, f, sort_keys=False)
 
+    # Shell-readable resolver: acronym -> the release that actually holds its
+    # artifact. Published on every release so `latest/download/graph_urls.tsv`
+    # is a stable entry point even though `latest/download/<ACRONYM>.tar.gz`
+    # cannot be (no single release can hold every artifact).
+    resolvable = [o for o in ontologies if o.get("status") == "OK" and o.get("download_url")]
+    with open(os.path.join(output_dir, "graph_urls.tsv"), "w") as f:
+        f.write("id\tdownload_url\n")
+        for o in resolvable:
+            f.write(f"{o['id']}\t{o['download_url']}\n")
+    missing = [
+        o["id"] for o in ontologies
+        if o.get("status") == "OK" and not o.get("download_url")
+    ]
+    if missing:
+        print(f"WARNING: {len(missing)} OK ontologies have no download_url: {missing[:10]}")
+
     ok = sum(1 for o in ontologies if o.get("status") == "OK")
     skipped = sum(1 for o in ontologies if o.get("status") == "Skipped")
     # License-restricted entries stay status Failed (no artifact exists) but are
@@ -125,7 +145,10 @@ def main():
         if transform_date:
             f.write(f"transform_date: {transform_date}\n")
 
-    print(f"OK={ok} Skipped={skipped} Failed={failed} Licensed={licensed} -> {output_dir}/")
+    print(
+        f"OK={ok} Skipped={skipped} Failed={failed} Licensed={licensed} "
+        f"resolvable={len(resolvable)} -> {output_dir}/"
+    )
 
 
 if __name__ == "__main__":

--- a/.github/workflows/transform.yml
+++ b/.github/workflows/transform.yml
@@ -181,7 +181,10 @@ jobs:
         # The index (onto_stats/total_stats) is authoritative and lives on every
         # release; each OK entry's download_url points at whichever release holds
         # its most recent artifact. The docs site fetches these from latest.
-        run: gh release upload "${{ needs.prepare.outputs.tag }}" docs/onto_stats.yaml docs/total_stats.yaml --clobber
+        # graph_urls.tsv is the same acronym -> artifact mapping in a form a
+        # shell can resolve, since no single release can hold every artifact
+        # (GitHub caps a release at 1000 assets; there are more than that).
+        run: gh release upload "${{ needs.prepare.outputs.tag }}" docs/onto_stats.yaml docs/total_stats.yaml docs/graph_urls.tsv --clobber
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Mark this run's release as latest

--- a/README.md
+++ b/README.md
@@ -10,18 +10,40 @@ assets on this repository's [Releases](../../releases).
 ## Getting the graphs
 
 Each transformed ontology is a `<ACRONYM>.tar.gz` release asset containing
-`<ACRONYM>_nodes.tsv` and `<ACRONYM>_edges.tsv`. The latest build is always
-reachable at a stable URL:
+`<ACRONYM>_nodes.tsv` and `<ACRONYM>_edges.tsv`.
 
+Releases are **incremental**: a run publishes only the ontologies it transformed,
+so an artifact lives in whichever release most recently rebuilt it, and there is
+no release that holds them all — GitHub caps a release at 1000 assets, and there
+are more transformed ontologies than that. So look the artifact up rather than
+guessing its URL. Three files are published on **every** release for this, which
+makes `releases/latest/download/<that file>` a stable entry point:
+
+| File | What it is |
+|---|---|
+| `graph_urls.tsv` | `<ACRONYM>` → artifact URL. Two columns, one header line. |
+| `onto_stats.yaml` | Full per-ontology index: status, reason, node/edge counts, `download_url`. |
+| `total_stats.yaml` | Site-wide totals. |
+
+To fetch one ontology:
+
+```bash
+BASE=https://github.com/ncbo/kg-bioportal/releases/latest/download
+URL=$(curl -sL "$BASE/graph_urls.tsv" | awk -F'\t' '$1=="AGRO"{print $2}')
+curl -LO "$URL"
 ```
-https://github.com/ncbo/kg-bioportal/releases/latest/download/<ACRONYM>.tar.gz
+
+To fetch all of them:
+
+```bash
+curl -sL "$BASE/graph_urls.tsv" | tail -n +2 | cut -f2 | xargs -n1 -P4 curl -sLO
 ```
 
-For example, AGRO: `.../releases/latest/download/AGRO.tar.gz`.
+From Python, read `download_url` off the entry you want in `onto_stats.yaml`.
 
-Per-ontology status and node/edge counts live in `onto_stats.yaml`
-(and totals in `total_stats.yaml`), attached to the release and committed under
-`docs/`.
+> **Note:** `releases/latest/download/<ACRONYM>.tar.gz` does *not* work, despite
+> looking like it should. `latest` is just the most recent run's release, which
+> holds only that run's handful of artifacts.
 
 ## What gets skipped, and why
 

--- a/docs/kg_site/build_site.py
+++ b/docs/kg_site/build_site.py
@@ -103,7 +103,13 @@ def fmt_class(f):
 #  unified item model (KG-Registry KGs + transformed BioPortal ontologies)
 # --------------------------------------------------------------------------- #
 # Where a transformed ontology's KGX artifact lives (a release asset).
-RELEASE_ASSET = "https://github.com/ncbo/kg-bioportal/releases/latest/download/{id}.tar.gz"
+# Where to send someone when the index doesn't say where an artifact lives.
+# There is deliberately no `releases/latest/download/<ID>.tar.gz` fallback:
+# releases are incremental and no single release holds every artifact, so that
+# URL 404s for nearly every ontology. The index's per-entry download_url is the
+# only reliable answer; without one we link to the releases page rather than
+# hand out a link we know is broken.
+RELEASES_PAGE = "https://github.com/ncbo/kg-bioportal/releases"
 
 def kg_to_item(r):
     """Normalize a KG-Registry knowledge graph into a browse item."""
@@ -154,10 +160,11 @@ def onto_to_item(o, transform_date):
         # Every transformed-ontology entry now gets a page — OK ones with the KGX
         # download, non-OK ones collecting the metadata we do have + why there's no artifact.
         "href": f"resource/{oid}/", "has_page": True, "version": ver,
-        # Prefer the index's per-entry download_url (points at whichever release
-        # holds this ontology's most recent artifact); fall back to the latest
-        # release for older indexes without the field.
-        "download_url": o.get("download_url") or RELEASE_ASSET.format(id=oid),
+        # The index's per-entry download_url points at whichever release holds
+        # this ontology's most recent artifact. Empty for entries from an index
+        # predating the field; the page then omits the download rather than
+        # guessing a URL (see RELEASES_PAGE).
+        "download_url": o.get("download_url") or "",
         "bioportal_url": f"{BP}/ontologies/{oid}",
         "submission_id": o.get("submission_id", "NA"),
         "reason": o.get("reason", ""), "transform_date": transform_date or "",
@@ -886,7 +893,7 @@ def render_ontology_resource(it):
               '1 1h14a1 1 0 0 0 1-1v-2"/></svg>')
     bp_svg = ('<svg width=16 height=16 viewBox="0 0 24 24" fill=none stroke=currentColor '
               'stroke-width=2.2><path d="M7 17L17 7M9 7h8v8"/></svg>')
-    if ok:
+    if ok and it["download_url"]:
         cta = (f'<a class="btn btn-primary" href="{esc(it["download_url"])}">{dl_svg} Download KGX</a>'
                f'<a class="btn btn-ghost" href="{esc(it["bioportal_url"])}" target="_blank" '
                f'rel="noopener">{bp_svg} View on BioPortal</a>')
@@ -894,8 +901,8 @@ def render_ontology_resource(it):
         cta = (f'<a class="btn btn-primary" href="{esc(it["bioportal_url"])}" target="_blank" '
                f'rel="noopener">{bp_svg} View on BioPortal</a>')
 
-    # main body — lead + (download section | not-available notice)
-    if ok:
+    # main body — lead + (download section | location-unknown | not-available notice)
+    if ok and it["download_url"]:
         lead = (f'A KGX transformation of the BioPortal ontology <b>{esc(name)}</b> ({esc(acr)}), '
                 f'produced by KG&#8209;Bioportal. Nodes are ontology classes; edges are the '
                 f'relations between them.')
@@ -910,7 +917,24 @@ def render_ontology_resource(it):
             <a class="dl" href="{esc(it['download_url'])}" aria-label="Download KGX"><svg width=18 height=18 viewBox="0 0 24 24" fill=none stroke=currentColor stroke-width=2.1><path d="M12 3v12m0 0l-4-4m4 4l4-4"/><path d="M5 19h14"/></svg></a>
           </div>
         </div>
-        <p class="muted mt">From the latest transform release. Contains <span class="mono">{esc(acr)}_nodes.tsv</span> and <span class="mono">{esc(acr)}_edges.tsv</span>.</p>
+        <p class="muted mt">Contains <span class="mono">{esc(acr)}_nodes.tsv</span> and <span class="mono">{esc(acr)}_edges.tsv</span>. Releases are incremental, so this points at whichever release most recently rebuilt this ontology.</p>
+      </section>"""
+    elif ok:
+        # Transformed, but the index doesn't record where the artifact lives.
+        # Send them to the releases page rather than a URL we know 404s.
+        lead = (f'A KGX transformation of the BioPortal ontology <b>{esc(name)}</b> ({esc(acr)}), '
+                f'produced by KG&#8209;Bioportal. Nodes are ontology classes; edges are the '
+                f'relations between them.')
+        body_section = f"""
+      <section class="block">
+        <p class="eyebrow">Products &amp; downloads</p>
+        <div class="notice">
+          <div class="notice-t">Artifact location not recorded</div>
+          <p>This ontology transformed successfully, but the index does not say which
+             release holds its artifact. Look for <span class="mono">{esc(acr)}.tar.gz</span>
+             on the <a href="{esc(RELEASES_PAGE)}" target="_blank" rel="noopener">releases page</a>,
+             or check <span class="mono">graph_urls.tsv</span> on the latest release.</p>
+        </div>
       </section>"""
     else:
         lead = (f'<b>{esc(name)}</b> ({esc(acr)}) is a BioPortal ontology that KG&#8209;Bioportal '

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -91,15 +91,29 @@ class TestDownloadLinks(TestCase):
             "an entry with a download_url must not fall back to the latest release",
         )
 
-    def test_missing_download_url_falls_back_to_latest(self):
-        # Known gap (#147): `latest` only holds the assets of the most recent
-        # run, so this fallback 404s for nearly every ontology. Reachable for
-        # entries carried forward from an index predating download_url.
+    def test_missing_download_url_is_not_guessed(self):
+        # Fixed in #147: `latest` holds only the most recent run's assets, so a
+        # `releases/latest/download/<ID>.tar.gz` fallback 404s for nearly every
+        # ontology. An entry with no recorded URL must offer none.
         it = item("ABD", "OK")
-        self.assertIn(
-            "releases/latest/download", it["download_url"],
-            "known gap (#147): the fallback still points at an unreliable URL",
-        )
+        self.assertEqual(it["download_url"], "")
+
+    def test_no_rendered_page_links_at_the_latest_download_pattern(self):
+        for it in (item("ABD", "OK", download_url=self.INDEX_URL),
+                   item("ABD", "OK"),
+                   item("NDDF", "Failed", "license_restricted")):
+            page = bs.render_ontology_resource(it)
+            self.assertNotIn("releases/latest/download", page)
+
+    def test_page_without_a_url_points_at_the_releases_page(self):
+        page = bs.render_ontology_resource(item("ABD", "OK"))
+        self.assertIn("Artifact location not recorded", page)
+        self.assertIn(bs.RELEASES_PAGE, page)
+
+    def test_page_with_a_url_offers_the_download(self):
+        page = bs.render_ontology_resource(item("ABD", "OK", download_url=self.INDEX_URL))
+        self.assertIn(self.INDEX_URL, page)
+        self.assertNotIn("Artifact location not recorded", page)
 
 
 class TestSummaryCounts(TestCase):

--- a/tests/test_merge_stats.py
+++ b/tests/test_merge_stats.py
@@ -69,6 +69,13 @@ class MergeStatsTestCase(TestCase):
             totals = yaml.safe_load(f)
         return index, totals
 
+    def read_manifest(self):
+        """graph_urls.tsv as {id: url}, asserting the header is intact."""
+        with open(os.path.join(self.out, "graph_urls.tsv")) as f:
+            lines = f.read().splitlines()
+        self.assertEqual(lines[0], "id\tdownload_url")
+        return dict(line.split("\t") for line in lines[1:])
+
 
 class TestDownloadUrlInvariants(MergeStatsTestCase):
     """Where each artifact lives must survive a run that didn't rebuild it.
@@ -120,6 +127,65 @@ class TestDownloadUrlInvariants(MergeStatsTestCase):
             "download_url", index["WAS_OK"],
             "a now-failing ontology must not keep pointing at an old artifact",
         )
+
+
+class TestGraphUrlsManifest(MergeStatsTestCase):
+    """The shell-readable resolver published alongside the index (#147).
+
+    `releases/latest/download/<ACRONYM>.tar.gz` cannot work -- no single release
+    holds every artifact -- so `latest/download/graph_urls.tsv` is the stable
+    entry point that replaces it.
+    """
+
+    def test_manifest_covers_every_resolvable_graph(self):
+        base = self.write_base([entry("OLD", download_url=asset(PREV_TAG, "OLD"))])
+        self.write_fragment([entry("FRESH")])
+        index, _ = self.run_merge(base)
+        manifest = self.read_manifest()
+        expected = {oid for oid, o in index.items()
+                    if o["status"] == "OK" and o.get("download_url")}
+        self.assertEqual(set(manifest), expected)
+
+    def test_manifest_urls_match_the_index(self):
+        base = self.write_base([entry("OLD", download_url=asset(PREV_TAG, "OLD"))])
+        self.write_fragment([entry("FRESH")])
+        index, _ = self.run_merge(base)
+        for oid, url in self.read_manifest().items():
+            self.assertEqual(url, index[oid]["download_url"])
+
+    def test_manifest_spans_releases(self):
+        # The whole point: one file resolving artifacts that live in different
+        # releases, which is what makes a single stable URL impossible.
+        base = self.write_base([entry("OLD", download_url=asset(PREV_TAG, "OLD"))])
+        self.write_fragment([entry("FRESH")])
+        self.run_merge(base)
+        manifest = self.read_manifest()
+        self.assertEqual(manifest["OLD"], asset(PREV_TAG, "OLD"))
+        self.assertEqual(manifest["FRESH"], asset(THIS_TAG, "FRESH"))
+
+    def test_manifest_excludes_non_ok_entries(self):
+        self.write_fragment([
+            entry("GOOD"),
+            entry("BAD", status="Failed", reason="transform_error"),
+            entry("LIC", status="Failed", reason="license_restricted"),
+            entry("BIG", status="Skipped", reason="too_large"),
+        ])
+        self.run_merge()
+        self.assertEqual(set(self.read_manifest()), {"GOOD"})
+
+    def test_manifest_never_uses_the_latest_download_pattern(self):
+        self.write_fragment([entry("FRESH")])
+        self.run_merge()
+        with open(os.path.join(self.out, "graph_urls.tsv")) as f:
+            self.assertNotIn("releases/latest/download", f.read())
+
+    def test_manifest_is_written_even_when_nothing_transformed(self):
+        # A run over undownloadable ontologies produces no artifacts, but the
+        # manifest must still be published or `latest` loses the resolver.
+        base = self.write_base([entry("OLD", download_url=asset(PREV_TAG, "OLD"))])
+        self.write_fragment([entry("NDDF", status="Failed", reason="license_restricted")])
+        self.run_merge(base)
+        self.assertEqual(self.read_manifest(), {"OLD": asset(PREV_TAG, "OLD")})
 
 
 class TestSeedAndOverlay(MergeStatsTestCase):


### PR DESCRIPTION
Closes #147.

`releases/latest/download/<ACRONYM>.tar.gz` was advertised in the README as the stable way to fetch a graph. It 404s for nearly every ontology, and always has — releases are incremental, so `latest` holds only the most recent run's artifacts. Right now that's **2 of 1108**; the other 1106 live across three older releases.

## Why option 2 from the issue is out

A `data-latest` release re-hosting everything is not merely expensive, it's impossible: GitHub caps a release at **1000 assets** and there are **1108** transformed ontologies. So resolving through the index isn't a workaround, it's the only thing that can work. This PR makes that easy rather than pretending the shortcut works.

## The manifest

`merge_stats.py` now writes **`graph_urls.tsv`** next to `onto_stats.yaml` — acronym → artifact URL, two columns and a header — and the workflow publishes it on every release.

That makes `latest/download/graph_urls.tsv` a genuinely stable entry point, for the reason the tarball URL isn't: every release carries the *full* mapping, even a release carrying no artifacts. It also warns when an `OK` ontology has no recorded `download_url`, which would otherwise be an invisible hole in the index.

```bash
BASE=https://github.com/ncbo/kg-bioportal/releases/latest/download
URL=$(curl -sL "$BASE/graph_urls.tsv" | awk -F'\t' '$1=="AGRO"{print $2}')
curl -LO "$URL"
```

The README documents this, including a parallel-fetch one-liner for all of them, and says plainly that the old URL does not work.

## No more guessed URLs

`RELEASE_ASSET` is deleted from `build_site.py`. A transformed ontology whose location isn't recorded now says *"Artifact location not recorded"* and links to the releases page, instead of offering a download button we know is broken. The three skill scripts lose the same fallback and prefer `graph_urls.tsv` — which also means they no longer need PyYAML on the common path.

## Tests

The two assertions that pinned #147 as a known gap now invert:

- a missing `download_url` is no longer guessed;
- no rendered page contains `releases/latest/download` at all.

Plus six new ones covering the manifest: that it matches the index, spans releases, excludes non-OK entries, keeps its header, never contains the latest-download pattern, and is still written by a run that transforms nothing. 71 tests total.

## Verification

Ran `merge_stats.py` over the live published index: **1108 resolvable**, manifest and index agree entry-for-entry. Spot-checked resolved URLs from different releases:

```
ABD     -> data-2026.07/ABD.tar.gz          200
AGRO    -> data-2026.08.02-7/AGRO.tar.gz    200
GO-PLUS -> not in manifest (too_large, no artifact)  ✓
```

## One thing done outside the branch

I uploaded `graph_urls.tsv` (generated from the current index) to the existing `data-2026.08.10-8` release, so `latest/download/graph_urls.tsv` resolves **now** rather than only after the next transform run. Otherwise merging this would publish a README documenting a file that doesn't exist yet. It's additive, and every future run overwrites it with `--clobber`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
