### PR TITLE
Stop losing 24 ontologies to a mixed-type sort in KGX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ __pycache__/
 # BioPortal / NCBO API key — the transform reads it from the NCBO_API_KEY
 # secret in CI; a local copy must never be committed.
 ncbo_key
+# ROBOT is downloaded into the repo root on first transform (robot.jar is ~90 MB).
+robot
+robot.jar

--- a/src/kg_bioportal/kgx_patches.py
+++ b/src/kg_bioportal/kgx_patches.py
@@ -1,0 +1,83 @@
+"""Runtime patches for KGX bugs that cost us whole ontologies.
+
+Each patch here works around a defect in an installed dependency. They are
+narrow on purpose: a patch must not change behaviour in any case that already
+worked, so that applying it cannot perturb the ontologies that transform today.
+
+Remove a patch once the upstream fix is in a release we depend on.
+"""
+
+import logging
+from typing import Any, Callable, Iterable, List, Optional
+
+# Number of times the mixed-type sort fallback has been used this process.
+# Not used for control flow -- it is here so a transform can say whether an
+# ontology carried mixed-type property values.
+_mixed_type_sorts = 0
+
+_patched = False
+
+
+def mixed_type_sort_count() -> int:
+    """How many times the mixed-type sort fallback has fired this process."""
+    return _mixed_type_sorts
+
+
+def _safe_sorted(
+    iterable: Iterable,
+    key: Optional[Callable] = None,
+    reverse: bool = False,
+) -> List[Any]:
+    """``sorted`` that falls back to string ordering when values aren't comparable.
+
+    A multi-valued node or edge property can hold a mix of ``str`` and typed
+    literals -- rdflib hands back ``int``, ``datetime``, ``date``, ``Decimal``,
+    ``Document`` -- and Python has no ordering across those. The same applies
+    within a single type: two ``Document`` objects aren't orderable at all, and
+    a naive and an aware ``datetime`` can't be compared to each other.
+
+    The fallback only runs when the normal sort raises, so any list that sorts
+    today sorts identically after this patch.
+    """
+    global _mixed_type_sorts
+    try:
+        return sorted(iterable, key=key, reverse=reverse)
+    except TypeError:
+        _mixed_type_sorts += 1
+        if _mixed_type_sorts == 1:
+            logging.warning(
+                "Sorted a property holding values of mixed or unorderable types by "
+                "their string form. Without this the ontology would fail to transform."
+            )
+        str_key = (lambda v: str(key(v))) if key else str
+        return sorted(iterable, key=str_key, reverse=reverse)
+
+
+def patch_mixed_type_sorting() -> bool:
+    """Make KGX tolerate multi-valued properties with mixed value types.
+
+    ``kgx.utils.kgx_utils._sanitize_import_property`` deduplicates a list-valued
+    property and then calls bare ``sorted`` on the result. When the values are
+    not mutually orderable that raises ``TypeError``, KGX aborts, and the whole
+    ontology is lost -- 24 of them in the ``data-2026.07`` index, including
+    FOODON, FYPO, MAXO, HANCESTRO and GSSO. See issue #135; upstream fix is a
+    one-liner (``sorted(value_set, key=str)``).
+
+    ``sorted`` is looked up in the module's globals before builtins, so binding
+    the name on the module redirects it without copying any of KGX's code --
+    which keeps this working across KGX versions and makes it a no-op once
+    upstream fixes it.
+
+    Returns:
+        True if the patch was applied, False if it was already in place.
+    """
+    global _patched
+    if _patched:
+        return False
+
+    from kgx.utils import kgx_utils
+
+    kgx_utils.sorted = _safe_sorted
+    _patched = True
+    logging.debug("Patched kgx.utils.kgx_utils.sorted for mixed-type property values.")
+    return True

--- a/src/kg_bioportal/transformer.py
+++ b/src/kg_bioportal/transformer.py
@@ -16,7 +16,12 @@ from kgx.transformer import Transformer as KGXTransformer
 
 from kg_bioportal.config import LICENSE_RESTRICTED_REASON, PER_ONTOLOGY_TIMEOUT_MIN
 from kg_bioportal.downloader import DOWNLOAD_REPORT_NAME, ONTOLOGY_LIST_NAME
+from kg_bioportal.kgx_patches import patch_mixed_type_sorting
 from kg_bioportal.robot_utils import initialize_robot, robot_convert, robot_relax
+
+# Applied at import so it is in place for any use of the KGX transform, not just
+# the ones that go through Transformer. See kgx_patches for what and why.
+patch_mixed_type_sorting()
 
 # TODO: Don't repeat steps if the products already exist
 # TODO: Fix KGX hijacking logging

--- a/tests/test_kgx_patches.py
+++ b/tests/test_kgx_patches.py
@@ -1,0 +1,134 @@
+"""Tests for the KGX runtime patches.
+
+The mixed-type sort patch is the difference between 24 ontologies transforming
+and 24 ontologies being lost (#135). Two things have to hold: it fixes the
+values that crash, and it changes nothing about the values that don't -- the
+latter matters because 1108 ontologies transform today and their output must not
+move.
+"""
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from kgx.utils import kgx_utils
+
+from kg_bioportal import kgx_patches
+
+# Importing the transformer applies the patch; do it explicitly so this module
+# does not depend on import order.
+kgx_patches.patch_mixed_type_sorting()
+
+DELIM = "|"
+
+
+def sanitize(values):
+    """Run a multi-valued property through the KGX code path that used to crash."""
+    return kgx_utils._sanitize_import_property("synonym", values, DELIM)
+
+
+class TestPatchIsApplied(TestCase):
+    def test_kgx_uses_the_safe_sort(self):
+        self.assertIs(kgx_utils.sorted, kgx_patches._safe_sorted)
+
+    def test_patching_twice_is_a_no_op(self):
+        self.assertFalse(
+            kgx_patches.patch_mixed_type_sorting(),
+            "already-applied patch should report that it did nothing",
+        )
+
+
+class TestMixedTypesNoLongerCrash(TestCase):
+    """Every type pairing observed in the failing ontologies."""
+
+    def test_int_and_str(self):
+        # CDO, DOVES, EMIF-AD, FRMO, HANCESTRO, ICEO, OAE, VALUESETS
+        self.assertEqual(len(sanitize(["b", 3])), 2)
+
+    def test_datetime_and_str(self):
+        # FOVT, FYPO, MAXO, NMDCO, RBO
+        self.assertEqual(len(sanitize(["b", datetime(2020, 1, 1)])), 2)
+
+    def test_date_and_str(self):
+        # KISAO
+        self.assertEqual(len(sanitize(["b", date(2020, 1, 1)])), 2)
+
+    def test_decimal_and_str(self):
+        # EO, WWECA
+        self.assertEqual(len(sanitize(["b", Decimal("1.5")])), 2)
+
+    def test_naive_and_aware_datetimes(self):
+        # FOODON: same type, still not comparable to each other.
+        values = [datetime(2020, 1, 1), datetime(2021, 1, 1, tzinfo=timezone.utc)]
+        self.assertEqual(len(sanitize(values)), 2)
+
+    def test_values_with_no_ordering_at_all(self):
+        # ONTOPSYCARE: 'Document' vs 'Document'.
+        class Unorderable:
+            def __init__(self, n):
+                self.n = n
+
+            def __hash__(self):
+                return hash(self.n)
+
+            def __eq__(self, other):
+                return isinstance(other, Unorderable) and self.n == other.n
+
+            def __str__(self):
+                return f"doc{self.n}"
+
+        self.assertEqual(len(sanitize([Unorderable(1), Unorderable(2)])), 2)
+
+    def test_values_are_preserved_not_coerced(self):
+        # The string form is only the sort key; the values themselves are
+        # untouched, so downstream serialization behaves as it always did.
+        out = sanitize(["b", 3])
+        self.assertIn(3, out)
+        self.assertIn("b", out)
+
+    def test_result_is_deterministic(self):
+        values = ["b", 3, datetime(2020, 1, 1), Decimal("1.5")]
+        self.assertEqual(sanitize(list(values)), sanitize(list(values)))
+
+
+class TestBehaviourIsOtherwiseUnchanged(TestCase):
+    """Anything that sorted before must sort identically now."""
+
+    def test_strings_sort_as_before(self):
+        self.assertEqual(sanitize(["c", "a", "b"]), ["a", "b", "c"])
+
+    def test_numbers_sort_numerically_not_as_strings(self):
+        # The fallback would give [1, 10, 2]; the normal path must still win.
+        self.assertEqual(sanitize([10, 2, 1]), [1, 2, 10])
+
+    def test_duplicates_are_still_removed(self):
+        self.assertEqual(sanitize(["a", "b", "a"]), ["a", "b"])
+
+    def test_delimited_string_is_still_split(self):
+        self.assertEqual(sanitize("b|a"), ["a", "b"])
+
+
+class TestSafeSorted(TestCase):
+    """The wrapper itself, independent of KGX."""
+
+    def test_passes_through_key_and_reverse(self):
+        self.assertEqual(
+            kgx_patches._safe_sorted(["bb", "a", "ccc"], key=len, reverse=True),
+            ["ccc", "bb", "a"],
+        )
+
+    def test_key_is_honoured_in_the_fallback_too(self):
+        # key() returns unorderable values; the fallback must apply str to the
+        # key's output, not to the raw item.
+        out = kgx_patches._safe_sorted([("b", 1), ("a", None)], key=lambda t: t[1])
+        self.assertEqual(len(out), 2)
+
+    def test_counter_records_fallbacks(self):
+        before = kgx_patches.mixed_type_sort_count()
+        kgx_patches._safe_sorted(["a", 1])
+        self.assertEqual(kgx_patches.mixed_type_sort_count(), before + 1)
+
+    def test_counter_ignores_normal_sorts(self):
+        before = kgx_patches.mixed_type_sort_count()
+        kgx_patches._safe_sorted(["b", "a"])
+        self.assertEqual(kgx_patches.mixed_type_sort_count(), before)


### PR DESCRIPTION
Closes #135. **Recovers 24 ontologies.**

`kgx.utils.kgx_utils._sanitize_import_property` deduplicates a list-valued node or edge property and then calls bare `sorted()` on the result. rdflib hands back typed literals, so a property holding (say) a `str` and an `int` has no ordering — `sorted()` raises `TypeError`, KGX aborts, and the whole ontology is lost. 24 of them in the `data-2026.07` index, including FOODON, FYPO, MAXO, HANCESTRO and GSSO.

Worth noting the pathological cases aren't only cross-type, because it rules out the obvious fix: two `Document` objects have no ordering at all (ONTOPSYCARE), and a naive and an aware `datetime` can't be compared *to each other* (FOODON). Coercing to a common type isn't enough — the sort key has to be a string.

## The seam

`sorted()` resolves through the module's globals before builtins, so binding the name on `kgx_utils` redirects it **without copying any of KGX's code**:

```python
kgx_utils.sorted = _safe_sorted
```

That survives KGX version changes (no vendored function body to drift) and becomes a no-op the moment upstream fixes this. The alternative — reimplementing `_sanitize_import_property` locally — would have pinned us to the current KGX internals.

The wrapper only reaches for string ordering when the normal sort **raises**:

```python
try:
    return sorted(iterable, key=key, reverse=reverse)
except TypeError:
    return sorted(iterable, key=(lambda v: str(key(v))) if key else str, reverse=reverse)
```

so anything that sorts today sorts identically afterwards. That property is what makes this safe to merge against 1108 working ontologies.

## Verified on real ontologies, not just fixtures

Same relaxed OWL, same code path, patch off then on:

```
ADHER_INTCARE_EN  unpatched:  TypeError: '<' not supported between instances of 'str' and 'int'
                  patched:    304 nodes, 388 edges
```

That's the exact error string that ontology produced in the transform logs. ADHER_INTCARE_EN, EO and KISAO all now transform end to end (`totalcount: 3, failedcount: 0`).

**Regression control:** ACESO, an ontology that already works, produces identical nodes and edges with the patch applied — once KGX's per-run random identifiers are masked. I can't claim byte-identical output, because KGX's output isn't byte-stable between any two runs: BNode names and `urn:uuid` edge IDs are regenerated each time (#71). With those masked, both files match exactly. The fallback also cannot have engaged for ACESO by construction: the unpatched run didn't raise, and `_safe_sorted` only deviates when `sorted` raises.

## Tests

18 new, covering every type pairing observed across the 24 failing ontologies (`int`/`str`, `datetime`/`str`, `date`/`str`, `Decimal`/`str`, naive-vs-aware datetimes, values with no ordering at all), that values are preserved rather than coerced, and — the important half — that ordinary sorting is untouched, including that `[10, 2, 1]` still sorts numerically to `[1, 2, 10]` rather than as strings. 89 tests total.

## Not done here

**The upstream one-liner.** `sorted(value_set, key=str)` in `kgx_utils.py` is the real fix and belongs in [biolink/kgx](https://github.com/biolink/kgx). I haven't opened that PR — it's a contribution to someone else's repo and felt like your call. Say the word and I'll fork and file it, with this reproduction attached. Once it lands in a release we depend on, `kgx_patches.py` can be deleted; the module docstring says so.

**Also in this branch:** `robot` and `robot.jar` are now gitignored. The transform downloads them into the repo root and `robot.jar` is 90 MB — it was one `git add -A` from being committed. Same class of thing as the `ncbo_key` fix in #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
