### PR TITLE
Unpack the archives BioPortal actually serves

### DIFF
--- a/.github/workflows/transform.yml
+++ b/.github/workflows/transform.yml
@@ -129,7 +129,7 @@ jobs:
         env:
           NCBO_API_KEY: ${{ secrets.NCBO_API_KEY }}
       - name: Transform shard
-        run: kgbioportal -v transform -i data/raw -o data/transformed --timeout_min "$TIMEOUT_MIN"
+        run: kgbioportal -v transform -i data/raw -o data/transformed --timeout_min "$TIMEOUT_MIN" --max_source_mb "$MAX_SOURCE_MB"
         env:
           ROBOT_JAVA_ARGS: "-Xmx13g -XX:+UseG1GC"
       - name: Upload KGX artifacts to release

--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ the stats with a reason, rather than failing the build:
 - **`skiplist`** — a known giant, skipped up front with no download attempt
   (e.g. NCBITAXON, SNOMEDCT, RXNORM, GAZ, PR, NCIT, …). See `KNOWN_GIANTS` in
   [`src/kg_bioportal/config.py`](src/kg_bioportal/config.py).
-- **`too_large`** — the downloaded source exceeded the size gate
-  (`--max_source_mb`, default 100 MB).
+- **`too_large`** — the source exceeded the size gate (`--max_source_mb`,
+  default 100 MB). Checked twice: on the file as downloaded, and again after
+  decompression, since a gzipped source understates its real size by an order
+  of magnitude (ROR is 14 MB gzipped and 135 MB unpacked).
 - **`too_slow`** — the transform exceeded the per-ontology wall-clock cap
   (`--timeout_min`, default 30 min).
 

--- a/src/kg_bioportal/cli.py
+++ b/src/kg_bioportal/cli.py
@@ -268,7 +268,15 @@ def download(
     type=float,
     help="Per-ontology wall-clock cap in minutes; slower transforms are skipped.",
 )
-def transform(input_dir, output_dir, compress, timeout_min) -> None:
+@click.option(
+    "--max_source_mb",
+    default=MAX_SOURCE_MB,
+    show_default=True,
+    type=float,
+    help="Skip an ontology whose decompressed source exceeds this many MB. "
+    "The download-time gate can only weigh the compressed file.",
+)
+def transform(input_dir, output_dir, compress, timeout_min, max_source_mb) -> None:
     """Transforms all ontologies in the input directory to KGX nodes and edges.
 
     Yields two log files: total_stats.yaml and onto_stats.yaml.
@@ -285,7 +293,10 @@ def transform(input_dir, output_dir, compress, timeout_min) -> None:
     """
 
     tx = Transformer(
-        input_dir=input_dir, output_dir=output_dir, timeout_min=timeout_min
+        input_dir=input_dir,
+        output_dir=output_dir,
+        timeout_min=timeout_min,
+        max_source_mb=max_source_mb,
     )
 
     tx.transform_all(compress=compress)

--- a/src/kg_bioportal/transformer.py
+++ b/src/kg_bioportal/transformer.py
@@ -1,20 +1,26 @@
 """Transformer for KG-Bioportal."""
 
 import csv
+import gzip
 import logging
 import os
 import re
+import shutil
 import signal
 import sys
 import tarfile
 import zipfile
 from contextlib import contextmanager
-from typing import Tuple
+from typing import List, Optional, Tuple
 
 import yaml
 from kgx.transformer import Transformer as KGXTransformer
 
-from kg_bioportal.config import LICENSE_RESTRICTED_REASON, PER_ONTOLOGY_TIMEOUT_MIN
+from kg_bioportal.config import (
+    LICENSE_RESTRICTED_REASON,
+    MAX_SOURCE_MB,
+    PER_ONTOLOGY_TIMEOUT_MIN,
+)
 from kg_bioportal.downloader import DOWNLOAD_REPORT_NAME, ONTOLOGY_LIST_NAME
 from kg_bioportal.kgx_patches import patch_mixed_type_sorting
 from kg_bioportal.robot_utils import initialize_robot, robot_convert, robot_relax
@@ -119,8 +125,117 @@ def summarize(onto_log: dict) -> dict:
     }
 
 
+# Extensions BioPortal sources actually arrive in. Used to find the ontology
+# among an archive's members; order carries no preference.
+_ONTOLOGY_EXTS = frozenset(
+    {".owl", ".rdf", ".ttl", ".obo", ".owx", ".n3", ".nt", ".xml", ".omn", ".ofn"}
+)
+
+# Archive members that are never the ontology: macOS bundles zip metadata, and
+# some submissions carry a licence or readme alongside the source.
+_JUNK_PREFIXES = ("__MACOSX/", "._")
+
+
+def _extract_all(archive, dest: str) -> None:
+    """Extract every member, preferring the 'data' filter where available.
+
+    The filter became available in Python 3.12 and is the default from 3.14; ask
+    for it explicitly so behaviour doesn't change under us, and fall back for
+    the older interpreters this package still supports.
+    """
+    try:
+        archive.extractall(dest, filter="data")
+    except TypeError:
+        archive.extractall(dest)
+
+
+def _archive_stem(archive_path: str) -> str:
+    """``…/PatientSafetyIncident.zip`` -> ``patientsafetyincident``."""
+    base = os.path.basename(archive_path)
+    for suffix in (".gz", ".zip"):
+        if base.lower().endswith(suffix):
+            base = base[: -len(suffix)]
+            break
+    if base.lower().endswith(".tar"):
+        base = base[: -len(".tar")]
+    return os.path.splitext(base)[0].lower()
+
+
+def pick_ontology_member(
+    members: List[Tuple[str, int]], ontology_name: str, archive_path: str = ""
+) -> Optional[str]:
+    """Choose the ontology file from an archive's members.
+
+    Several BioPortal submissions ship the ontology alongside its imports, a
+    licence, or a project file — OCRE has six members, ICPS twenty-five.
+    Refusing those outright (as this used to) loses the ontology entirely.
+
+    Size alone is not a good enough signal: ICPS ships a 340 kB ``Countries.owl``
+    next to the 126 kB ``PatientSafetyIncident.owl`` that is actually the
+    ontology. What names the subject is the archive itself. So prefer, in order:
+
+    1. a member named after the archive — ``PatientSafetyIncident.zip`` holds
+       ``PatientSafetyIncident.owl``;
+    2. a member named after the acronym — ``OCRe.zip`` holds ``OCRe.owl``;
+    3. the largest file carrying an ontology extension;
+    4. the largest file of any kind, since the extension may simply be missing
+       (BioPortal serves extensionless sources).
+
+    Ties break on name, so the choice is deterministic across runs.
+
+    Args:
+        members: ``(path, size)`` for each file in the archive, paths relative
+            to the extraction directory.
+        ontology_name: The ontology's acronym.
+        archive_path: Path to the archive, for rule 1. Optional so the rule
+            simply doesn't apply when the caller has no name to offer.
+
+    Returns:
+        The chosen member path, or None if the archive holds nothing usable.
+    """
+    def is_junk(name):
+        base = os.path.basename(name)
+        return not base or name.startswith(_JUNK_PREFIXES) or base.startswith(_JUNK_PREFIXES)
+
+    candidates = [(n, s) for n, s in members if not is_junk(n)]
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0][0]
+
+    # Largest first, then by name for a stable tie-break.
+    def rank(item):
+        name, size = item
+        return (-size, name)
+
+    def stem(name):
+        return os.path.splitext(os.path.basename(name))[0].lower()
+
+    for wanted in (_archive_stem(archive_path) if archive_path else "", ontology_name.lower()):
+        if not wanted:
+            continue
+        matches = [(n, s) for n, s in candidates if stem(n) == wanted]
+        if matches:
+            return sorted(matches, key=rank)[0][0]
+
+    ontology_files = [
+        (n, s) for n, s in candidates if os.path.splitext(n)[1].lower() in _ONTOLOGY_EXTS
+    ]
+    return sorted(ontology_files or candidates, key=rank)[0][0]
+
+
 class TransformTimeout(Exception):
     """Raised when a single ontology transform exceeds its wall-clock budget."""
+
+
+class SourceTooLarge(Exception):
+    """Raised when a decompressed source exceeds the size gate.
+
+    The downloader's gate weighs the file as served, which for a compressed
+    source says nothing useful: ROR is 14 MB gzipped and 141 MB unpacked, HGNC-NR
+    7.8 MB and 170 MB. Both are past the limit that exists to keep the runner
+    alive, and neither could be caught until decompression made them visible.
+    """
 
 
 @contextmanager
@@ -155,6 +270,7 @@ class Transformer:
         input_dir: str = "data/raw",
         output_dir: str = "data/transformed",
         timeout_min: float = PER_ONTOLOGY_TIMEOUT_MIN,
+        max_source_mb: float = MAX_SOURCE_MB,
     ) -> None:
         """Initializes the Transformer class.
 
@@ -165,6 +281,9 @@ class Transformer:
             output_dir: A string pointing to the location to write products to.
             timeout_min: Per-ontology wall-clock cap in minutes. An ontology that
                 runs longer is killed and recorded as skipped (too_slow).
+            max_source_mb: Size gate re-applied to a *decompressed* source, which
+                the downloader's gate could not weigh. Over this, the ontology is
+                recorded as skipped (too_large) instead of being handed to ROBOT.
 
         Returns:
             None.
@@ -173,6 +292,8 @@ class Transformer:
         self.output_dir = output_dir
         self.timeout_min = timeout_min
         self.timeout_sec = int(timeout_min * 60)
+        self.max_source_mb = max_source_mb
+        self.max_source_bytes = int(max_source_mb * 1024 * 1024)
 
         # If the output directory does not exist, create it
         if not os.path.exists(self.output_dir):
@@ -275,10 +396,19 @@ class Transformer:
                 )
                 success, nodecount, edgecount = False, 0, 0
                 reason = "too_slow"
+            except SourceTooLarge as e:
+                logging.warning(f"Skipping {ontology_name}: {e}.")
+                success, nodecount, edgecount = False, 0, 0
+                reason = "too_large"
 
             if not success:
-                logging.error(f"Error transforming {filepath}.")
-                strstatus = "Skipped" if reason == "too_slow" else "Failed"
+                strstatus = "Skipped" if reason in ("too_slow", "too_large") else "Failed"
+                # A deliberate skip is not an error; saying so in the log made
+                # the two indistinguishable when reading a run afterwards.
+                if strstatus == "Failed":
+                    logging.error(f"Error transforming {filepath}.")
+                else:
+                    logging.info(f"Skipped {filepath} ({reason}).")
                 nodecount = 0
                 edgecount = 0
                 if not reason:
@@ -363,6 +493,16 @@ class Transformer:
             else:
                 logging.error(f"Failed to decompress {ontology_path}")
                 return False, nodecount, edgecount
+
+            # Re-apply the size gate now that we can see the real size. The
+            # downloader weighed the compressed file, which understates a
+            # gzipped ontology by an order of magnitude.
+            unpacked = os.path.getsize(ontology_path)
+            if self.max_source_bytes and unpacked > self.max_source_bytes:
+                raise SourceTooLarge(
+                    f"{ontology_name} unpacks to {unpacked / 1024 / 1024:.1f} MB "
+                    f"(> {self.max_source_mb} MB limit)"
+                )
 
         # Remove owl:imports so ROBOT doesn't try (and fail) to fetch external
         # ontologies over the network — the dominant cause of transform errors.
@@ -454,44 +594,64 @@ class Transformer:
         return status, nodecount, edgecount
 
     def decompress(self, ontology_path: str, ontology_name: str) -> str:
-        """Decompresses a compressed ontology file.
+        """Decompresses a downloaded ontology archive.
+
+        Handles the three shapes BioPortal actually serves: a zip, a gzipped
+        tarball, and a bare gzipped file. Archives holding several members are
+        unpacked in full and the ontology is picked out of them (see
+        ``pick_ontology_member``) rather than being refused.
 
         Args:
-            ontology_path: A string of the path to the ontology file to decompress.
+            ontology_path: Path to the compressed file.
+            ontology_name: The ontology's acronym, used to name the extraction
+                directory and to recognise the ontology among several members.
 
         Returns:
-            The path to the decompressed file.
+            Path to the file to transform, or ``ontology_path`` unchanged if the
+            archive could not be decompressed — which the caller reads as failure.
         """
-        new_path = self.input_dir
-
         logging.info(f"Decompressing {ontology_path}")
+        extract_dir = os.path.join(self.input_dir, ontology_name)
+
         try:
             if ontology_path.endswith(".zip"):
                 with zipfile.ZipFile(ontology_path, "r") as zip_ref:
-                    extract_dir = os.path.join(self.input_dir, ontology_name)
-                    zip_ref.extractall(extract_dir)
-                    extracted_files = zip_ref.namelist()
-                    if len(extracted_files) == 1:
-                        new_path = os.path.join(extract_dir, extracted_files[0])
-                    else:
-                        logging.error(
-                            f"Expected one file in the zip archive, but found {len(extracted_files)}."
-                        )
-                        return ontology_path
+                    _extract_all(zip_ref, extract_dir)
+                    members = [
+                        (i.filename, i.file_size)
+                        for i in zip_ref.infolist()
+                        if not i.is_dir()
+                    ]
+            elif tarfile.is_tarfile(ontology_path):
+                # A .tar.gz (or any tarball); is_tarfile sniffs the content, so
+                # this no longer depends on the file being named .tar.gz.
+                with tarfile.open(ontology_path) as tar:
+                    _extract_all(tar, extract_dir)
+                    members = [(m.name, m.size) for m in tar.getmembers() if m.isfile()]
             elif ontology_path.endswith(".gz"):
-                with tarfile.open(ontology_path, "r:gz") as tar:
-                    extract_dir = os.path.join(self.input_dir, ontology_name)
-                    tar.extractall(extract_dir)
-                    extracted_files = tar.getnames()
-                    if len(extracted_files) == 1:
-                        new_path = os.path.join(extract_dir, extracted_files[0])
-                    else:
-                        logging.error(
-                            f"Expected one file in the tar archive, but found {len(extracted_files)}."
-                        )
-                        return ontology_path
-        except tarfile.ReadError as e:
+                # A bare gzipped ontology, not a tarball. Opening this with
+                # tarfile — as this used to — fails with "invalid header".
+                os.makedirs(extract_dir, exist_ok=True)
+                member = os.path.basename(ontology_path)[: -len(".gz")] or ontology_name
+                out_path = os.path.join(extract_dir, member)
+                with gzip.open(ontology_path, "rb") as src, open(out_path, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+                members = [(member, os.path.getsize(out_path))]
+            else:
+                logging.error(f"Not a recognised archive: {ontology_path}")
+                return ontology_path
+        except (tarfile.TarError, zipfile.BadZipFile, EOFError, OSError) as e:
+            # gzip.BadGzipFile is an OSError. Whatever the archive's problem,
+            # it is this ontology's failure and not the run's.
             logging.error(f"Error when decompressing {ontology_path}: {e}")
             return ontology_path
 
-        return new_path
+        chosen = pick_ontology_member(members, ontology_name, ontology_path)
+        if chosen is None:
+            logging.error(f"No ontology file found inside {ontology_path} ({len(members)} members).")
+            return ontology_path
+        if len(members) > 1:
+            logging.info(
+                f"{ontology_name}: chose {chosen} from {len(members)} archive members."
+            )
+        return os.path.join(extract_dir, chosen)

--- a/tests/test_decompress.py
+++ b/tests/test_decompress.py
@@ -1,8 +1,7 @@
 """Tests for archive handling on downloaded sources.
 
-Six ontologies are lost to this in the published stats (#137): plain gzip files
-opened as tarballs, and zips with more than one member. These tests pin the
-current behaviour so the fix is visible as an inversion.
+Six ontologies were lost to this in the published stats (#137): plain gzip files
+opened as tarballs, and zips with more than one member refused outright.
 """
 
 import gzip
@@ -12,7 +11,7 @@ import tempfile
 import zipfile
 from unittest import TestCase
 
-from kg_bioportal.transformer import Transformer
+from kg_bioportal.transformer import SourceTooLarge, Transformer, pick_ontology_member
 
 ONTOLOGY = b'<?xml version="1.0"?>\n<rdf:RDF/>\n'
 
@@ -38,67 +37,253 @@ class DecompressTestCase(TestCase):
     def path(self, name):
         return os.path.join(self.input_dir, name)
 
-
-class TestDecompressTarGz(DecompressTestCase):
-    """Single-member .tar.gz -- the case the code was written for."""
-
-    def test_single_member_tarball_is_extracted(self):
-        inner = self.path("onto.owl")
-        with open(inner, "wb") as f:
-            f.write(ONTOLOGY)
-        archive = self.path("ONTO.tar.gz")
-        with tarfile.open(archive, "w:gz") as tar:
-            tar.add(inner, arcname="onto.owl")
-        os.remove(inner)
-
-        out = self.txr.decompress(archive, "ONTO")
-        self.assertNotEqual(out, archive)
-        self.assertTrue(os.path.exists(out))
-        self.assertEqual(open(out, "rb").read(), ONTOLOGY)
-
-
-class TestDecompressZip(DecompressTestCase):
-    def _zip(self, members):
-        archive = self.path("ONTO.zip")
+    def make_zip(self, members, name="ONTO.zip"):
+        """members: {archive path: bytes}."""
+        archive = self.path(name)
         with zipfile.ZipFile(archive, "w") as z:
-            for name in members:
-                z.writestr(name, ONTOLOGY)
+            for member, data in members.items():
+                z.writestr(member, data)
         return archive
 
+    def make_targz(self, members, name="ONTO.tar.gz"):
+        archive = self.path(name)
+        staging = os.path.join(self.input_dir, "_staging")
+        os.makedirs(staging, exist_ok=True)
+        with tarfile.open(archive, "w:gz") as tar:
+            for member, data in members.items():
+                staged = os.path.join(staging, os.path.basename(member))
+                with open(staged, "wb") as f:
+                    f.write(data)
+                tar.add(staged, arcname=member)
+        return archive
+
+    def make_gzip(self, name="onto.owl.gz", data=ONTOLOGY):
+        archive = self.path(name)
+        with gzip.open(archive, "wb") as f:
+            f.write(data)
+        return archive
+
+    def assert_extracted(self, out, archive, expected=ONTOLOGY):
+        self.assertNotEqual(out, archive, "should return the extracted file, not the archive")
+        self.assertTrue(os.path.exists(out), f"{out} does not exist")
+        self.assertEqual(open(out, "rb").read(), expected)
+
+
+class TestTarGz(DecompressTestCase):
+    def test_single_member_tarball_is_extracted(self):
+        archive = self.make_targz({"onto.owl": ONTOLOGY})
+        self.assert_extracted(self.txr.decompress(archive, "ONTO"), archive)
+
+    def test_tarball_is_detected_by_content_not_extension(self):
+        # BioPortal names sources inconsistently; a tarball called .gz is common.
+        archive = self.make_targz({"onto.owl": ONTOLOGY}, name="ONTO.gz")
+        self.assert_extracted(self.txr.decompress(archive, "ONTO"), archive)
+
+    def test_multi_member_tarball_picks_the_ontology(self):
+        archive = self.make_targz({"README.txt": b"hi", "onto.owl": ONTOLOGY})
+        self.assert_extracted(self.txr.decompress(archive, "ONTO"), archive)
+
+
+class TestZip(DecompressTestCase):
     def test_single_member_zip_is_extracted(self):
-        archive = self._zip(["onto.owl"])
+        archive = self.make_zip({"onto.owl": ONTOLOGY})
+        self.assert_extracted(self.txr.decompress(archive, "ONTO"), archive)
+
+    def test_multi_member_zip_is_no_longer_refused(self):
+        # Fixed in #137: CTX (3 members), ICPS (25), OCDARWN (2), OCRE (6) were
+        # all lost because the code insisted on exactly one member.
+        archive = self.make_zip({"onto.owl": ONTOLOGY, "imports/other.owl": b"<rdf:RDF/>"})
         out = self.txr.decompress(archive, "ONTO")
         self.assertNotEqual(out, archive)
-        self.assertEqual(open(out, "rb").read(), ONTOLOGY)
+        self.assertTrue(out.endswith("onto.owl"))
 
-    def test_multi_member_zip_is_declined(self):
-        # Known gap (#137): CTX (3 members), ICPS (25), OCDARWN (2), OCRE (6).
-        # Returning the input unchanged is what transform() reads as failure.
-        archive = self._zip(["onto.owl", "imports/other.owl"])
-        self.assertEqual(
-            self.txr.decompress(archive, "ONTO"), archive,
-            "known gap (#137): multi-member archives are refused outright",
-        )
+    def test_member_named_after_the_acronym_wins(self):
+        archive = self.make_zip({
+            "imports/big-import.owl": b"x" * 5000,   # larger, but not the subject
+            "OCRe.owl": ONTOLOGY,
+        })
+        out = self.txr.decompress(archive, "OCRE")
+        self.assertTrue(out.endswith("OCRe.owl"), out)
+
+    def test_member_named_after_the_archive_wins(self):
+        # ICPS: PatientSafetyIncident.zip ships a 340 kB Countries.owl next to
+        # the 126 kB PatientSafetyIncident.owl that is actually the ontology.
+        archive = self.make_zip({
+            "Countries.owl": b"x" * 5000,
+            "PatientSafetyIncident.owl": ONTOLOGY,
+        }, name="PatientSafetyIncident.zip")
+        out = self.txr.decompress(archive, "ICPS")
+        self.assertTrue(out.endswith("PatientSafetyIncident.owl"), out)
+
+    def test_macos_metadata_is_ignored(self):
+        archive = self.make_zip({
+            "__MACOSX/._onto.owl": b"junk" * 500,
+            "onto.owl": ONTOLOGY,
+        })
+        out = self.txr.decompress(archive, "ONTO")
+        self.assert_extracted(out, archive)
+
+    def test_empty_archive_is_a_failure(self):
+        archive = self.make_zip({})
+        self.assertEqual(self.txr.decompress(archive, "ONTO"), archive)
 
 
-class TestDecompressPlainGzip(DecompressTestCase):
-    """A .gz that is not a tarball -- ROR and HGNC-NR in the published stats."""
+class TestPlainGzip(DecompressTestCase):
+    """A .gz that is not a tarball — ROR and HGNC-NR in the published stats."""
 
-    def test_plain_gzip_is_declined(self):
-        archive = self.path("onto.owl.gz")
-        with gzip.open(archive, "wb") as f:
-            f.write(ONTOLOGY)
-        # Known gap (#137): every .gz goes through tarfile.open(..., "r:gz"),
-        # which needs a tar inside and raises ReadError: invalid header.
-        self.assertEqual(
-            self.txr.decompress(archive, "ONTO"), archive,
-            "known gap (#137): plain gzip is opened as a tarball",
-        )
+    def test_plain_gzip_is_decompressed(self):
+        # Fixed in #137: every .gz used to go through tarfile.open(..., "r:gz"),
+        # which needs a tar inside and raised ReadError: invalid header.
+        archive = self.make_gzip()
+        out = self.txr.decompress(archive, "ONTO")
+        self.assert_extracted(out, archive)
 
-    def test_corrupt_archive_does_not_raise(self):
-        # Whatever the fix, a bad archive must be reported as a failed
-        # decompression rather than escaping as an exception.
+    def test_gz_suffix_is_stripped_from_the_output_name(self):
+        out = self.txr.decompress(self.make_gzip(name="ror.owl.gz"), "ROR")
+        self.assertTrue(out.endswith("ror.owl"), out)
+
+    def test_extensionless_gzip_still_produces_a_file(self):
+        out = self.txr.decompress(self.make_gzip(name="ONTO.gz"), "ONTO")
+        self.assert_extracted(out, self.path("ONTO.gz"))
+
+
+class TestBadArchives(DecompressTestCase):
+    """A broken archive is one ontology's failure, never the run's."""
+
+    def test_corrupt_gzip_does_not_raise(self):
         archive = self.path("onto.owl.gz")
         with open(archive, "wb") as f:
             f.write(b"this is not gzip data at all")
         self.assertEqual(self.txr.decompress(archive, "ONTO"), archive)
+
+    def test_corrupt_zip_does_not_raise(self):
+        archive = self.path("onto.zip")
+        with open(archive, "wb") as f:
+            f.write(b"PK\x03\x04 and then nonsense")
+        self.assertEqual(self.txr.decompress(archive, "ONTO"), archive)
+
+    def test_truncated_gzip_does_not_raise(self):
+        archive = self.make_gzip(data=ONTOLOGY * 100)
+        with open(archive, "r+b") as f:
+            f.truncate(20)
+        self.assertEqual(self.txr.decompress(archive, "ONTO"), archive)
+
+    def test_unrecognised_extension_is_a_failure(self):
+        archive = self.path("onto.owl")
+        with open(archive, "wb") as f:
+            f.write(ONTOLOGY)
+        self.assertEqual(self.txr.decompress(archive, "ONTO"), archive)
+
+
+class TestPickOntologyMember(TestCase):
+    """Selection rules, independent of any real archive."""
+
+    def test_single_member_is_chosen(self):
+        self.assertEqual(pick_ontology_member([("a.owl", 10)], "ONTO"), "a.owl")
+
+    def test_acronym_match_beats_size(self):
+        members = [("huge.owl", 10_000), ("OCRe.owl", 10)]
+        self.assertEqual(pick_ontology_member(members, "OCRE"), "OCRe.owl")
+
+    def test_acronym_match_is_case_insensitive(self):
+        self.assertEqual(
+            pick_ontology_member([("x.owl", 99), ("ctx.ttl", 1)], "CTX"), "ctx.ttl"
+        )
+
+    def test_largest_ontology_file_otherwise(self):
+        members = [("small.owl", 10), ("big.ttl", 900), ("readme.txt", 100_000)]
+        self.assertEqual(pick_ontology_member(members, "ONTO"), "big.ttl")
+
+    def test_falls_back_to_largest_file_when_no_extension_matches(self):
+        members = [("notes", 10), ("source", 900)]
+        self.assertEqual(pick_ontology_member(members, "ONTO"), "source")
+
+    def test_junk_is_skipped(self):
+        members = [("__MACOSX/._onto.owl", 9999), ("onto.owl", 10)]
+        self.assertEqual(pick_ontology_member(members, "ONTO"), "onto.owl")
+
+    def test_no_members_returns_none(self):
+        self.assertIsNone(pick_ontology_member([], "ONTO"))
+
+    def test_only_junk_returns_none(self):
+        self.assertIsNone(pick_ontology_member([("__MACOSX/._x", 5)], "ONTO"))
+
+    def test_choice_is_deterministic_on_ties(self):
+        members = [("b.owl", 100), ("a.owl", 100)]
+        self.assertEqual(pick_ontology_member(members, "ONTO"), "a.owl")
+
+    def test_archive_name_beats_acronym_and_size(self):
+        members = [("Countries.owl", 340_000), ("PatientSafetyIncident.owl", 126_000)]
+        self.assertEqual(
+            pick_ontology_member(members, "ICPS", "data/raw/ICPS/7/PatientSafetyIncident.zip"),
+            "PatientSafetyIncident.owl",
+        )
+
+    def test_archive_name_rule_handles_tar_gz(self):
+        members = [("other.owl", 900), ("onto.owl", 10)]
+        self.assertEqual(
+            pick_ontology_member(members, "X", "/tmp/onto.tar.gz"), "onto.owl"
+        )
+
+    def test_acronym_still_wins_when_archive_name_matches_nothing(self):
+        members = [("big.owl", 900), ("OCRe.owl", 10)]
+        self.assertEqual(
+            pick_ontology_member(members, "OCRE", "/tmp/submission-23.zip"), "OCRe.owl"
+        )
+
+
+class TestDecompressedSizeGate(DecompressTestCase):
+    """The downloader's gate weighs the compressed file, which understates it.
+
+    ROR is 14 MB gzipped and 141 MB unpacked; HGNC-NR 7.8 MB and 170 MB. Both
+    are past the limit that keeps the runner alive, and neither was visible
+    until #137 made them decompress at all.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.txr.max_source_mb = 1
+        self.txr.max_source_bytes = 1024 * 1024
+        # transform() reaches the gate before it needs ROBOT, but it does name
+        # an output directory on the way there.
+        self.txr.output_dir = os.path.join(self.input_dir, "_out")
+
+    def transform_archive(self, archive):
+        """Drive transform() far enough to hit the gate, without ROBOT."""
+        return self.txr.transform(archive, compress=False)
+
+    def test_oversized_unpacked_source_raises(self):
+        archive = self.make_gzip(name="big.owl.gz", data=b"<rdf:RDF/>" + b"x" * (2 * 1024 * 1024))
+        os.makedirs(os.path.join(self.input_dir, "BIG", "1"), exist_ok=True)
+        moved = os.path.join(self.input_dir, "BIG", "1", "big.owl.gz")
+        os.replace(archive, moved)
+        with self.assertRaises(SourceTooLarge):
+            self.transform_archive(moved)
+
+    def test_gate_is_not_applied_below_the_limit(self):
+        # Under the limit it must get past the gate; it then fails in ROBOT,
+        # which is not what this test is about -- only that SourceTooLarge
+        # is not what stopped it.
+        archive = self.make_gzip(name="small.owl.gz")
+        os.makedirs(os.path.join(self.input_dir, "SMALL", "1"), exist_ok=True)
+        moved = os.path.join(self.input_dir, "SMALL", "1", "small.owl.gz")
+        os.replace(archive, moved)
+        try:
+            self.transform_archive(moved)
+        except SourceTooLarge:
+            self.fail("a source under the limit must not trip the size gate")
+        except Exception:
+            pass  # ROBOT isn't set up here; anything else is fine
+
+    def test_gate_can_be_disabled(self):
+        self.txr.max_source_bytes = 0
+        archive = self.make_gzip(name="big.owl.gz", data=b"x" * (2 * 1024 * 1024))
+        os.makedirs(os.path.join(self.input_dir, "BIG", "1"), exist_ok=True)
+        moved = os.path.join(self.input_dir, "BIG", "1", "big.owl.gz")
+        os.replace(archive, moved)
+        try:
+            self.transform_archive(moved)
+        except SourceTooLarge:
+            self.fail("max_source_bytes=0 must disable the gate")
+        except Exception:
+            pass


### PR DESCRIPTION
Closes #137.

`decompress()` handled exactly one shape — a gzipped tarball with a single member. Everything else was refused, costing six ontologies.

## The two bugs

**Bare gzip opened as a tarball.** Every `.gz` went through `tarfile.open(..., "r:gz")`, which needs a tar inside, so a plain gzipped OWL raised `invalid header` (ROR, HGNC-NR). Tarballs are now recognised by content via `tarfile.is_tarfile`, and a bare gzip is decompressed to its name minus `.gz`.

**Multi-member archives rejected on principle.** The extra members are usually imports, a licence, or a Protégé project file sitting next to the ontology — CTX 3, OCDARWN 2, OCRE 6, ICPS 25. Now everything is unpacked and the ontology is picked out.

## Picking the right member

Size alone isn't good enough, and ICPS proves it:

```
339835  Countries.owl              <- largest
125669  PatientSafetyIncident.owl  <- actually the ontology
 46571  ActionsToReduceRisk.owl
        … 22 more
```

What names the subject is **the archive itself** (`PatientSafetyIncident.zip`). So the order is: a member named after the archive, then one named after the acronym, then the largest file with an ontology extension, then the largest file at all. Ties break on name, so the choice is stable across runs. That resolves all four real archives correctly:

```
ICPS  (25 members) -> PatientSafetyIncident.owl
CTX   (3 members)  -> XCTontologyvtemp2/XCTontologyvtemp2.owl
OCRE  (6 members)  -> OCRe.owl
```

## A hole this exposed

Fixing decompression made two enormous ontologies newly eligible for transform. The downloader's size gate weighs the file **as served**, which says nothing useful about a compressed one:

| | downloaded | unpacked |
|---|---:|---:|
| ROR | 14.2 MB | 135 MB |
| HGNC-NR | 7.8 MB | 162 MB |

Both are far past the 100 MB limit that exists to keep the runner alive, and until now neither could be seen — the gate had nothing to weigh them with. Shipping the decompression fix alone would have handed ROBOT a 162 MB ontology with a 13 GB heap and a 30-minute cap.

So the gate is re-applied to the *decompressed* source, and the ontology is recorded `Skipped` / `too_large` instead. Exposed as `--max_source_mb` on `transform` and passed by the workflow. This is scope beyond the issue, but the fix isn't safe to merge without it.

## Also

- Catch `BadZipFile`, `BadGzipFile` and `EOFError`, not just `tarfile.ReadError`, so a broken archive stays one ontology's failure rather than escaping.
- Pass `filter="data"` to `extractall`, pinning behaviour before Python 3.14 changes the default.
- Stop logging a deliberate skip as `ERROR`, which made skips and failures indistinguishable when reading a run afterwards.

## Verification

Ran all six against BioPortal for real:

```
CTX       OK       nodes=1291  edges=781
ICPS      OK       nodes=255   edges=274
OCRE      OK       nodes=444   edges=638
ROR       Skipped  too_large   (135 MB unpacked)
HGNC-NR   Skipped  too_large   (162 MB unpacked)
```

**OCDARWN has been withdrawn from BioPortal since the audit** — its metadata endpoint now returns 404, so it is a `metadata_http_error` and never reaches this code. That's 3 recovered and 2 correctly reclassified, not the 6 recovered that #137 estimated.

28 tests on decompression and member selection, including that each known-broken case now succeeds, that junk (`__MACOSX/`) is ignored, that corrupt and truncated archives fail without raising, and 3 on the size gate. 115 total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
