### PR TITLE
Keep an invalid xml:lang from taking down the whole ontology

### DIFF
--- a/src/kg_bioportal/transformer.py
+++ b/src/kg_bioportal/transformer.py
@@ -94,6 +94,77 @@ def strip_imports(path: str) -> str:
     return new_path
 
 
+# An xml:lang attribute in either XML serialization, single- or double-quoted.
+_XML_LANG_ATTR = re.compile(r"""\s+xml:lang\s*=\s*(["'])(.*?)\1""", re.S)
+
+# What counts as a language tag. This is rdflib 7's own rule (term.py,
+# _lang_tag_regex) rather than the stricter BCP 47 shape, which caps each subtag
+# at eight characters: rdflib is the only consumer of the file we sanitize, so
+# matching its rule exactly strips every tag that would abort the parse and not
+# one more. A tag like "portuguese" is not BCP 47, but rdflib accepts it and the
+# ontologies carrying it build today.
+_LANG_TAG_SHAPE = re.compile(r"^[a-zA-Z]+(?:-[a-zA-Z0-9]+)*$")
+
+
+def strip_invalid_lang_tags(path: str, ontology_name: str = "") -> str:
+    """Drop xml:lang attributes whose values aren't language tags.
+
+    rdflib validates the language tag on every Literal it builds and raises
+    rather than warning, so a single bogus ``xml:lang`` anywhere in the file
+    aborts the entire KGX parse and loses the ontology (#140). Nothing on the
+    BioPortal side validates these, and the values seen in the wild are not near
+    misses — an email domain, a Medium article slug — so there is nothing to
+    repair. Dropping the attribute keeps the literal, untagged.
+
+    An empty ``xml:lang=""`` is left alone: in XML that resets the language
+    inherited from an ancestor element, and rdflib reads it as no tag at all.
+
+    Args:
+        path: Path to an RDF/XML or OWL/XML ontology file.
+        ontology_name: Acronym, used only to make the log line actionable.
+
+    Returns:
+        Path to use for the transform (cleaned copy, or the original).
+    """
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            text = f.read()
+    except OSError as e:
+        logging.warning(f"Could not read {path} to check language tags: {e}")
+        return path
+
+    if "xml:lang" not in text:
+        return path
+
+    removed: List[str] = []
+
+    def drop_if_invalid(match: "re.Match") -> str:
+        value = match.group(2)
+        if value == "" or _LANG_TAG_SHAPE.match(value):
+            return match.group(0)
+        removed.append(value)
+        return ""
+
+    cleaned = _XML_LANG_ATTR.sub(drop_if_invalid, text)
+    if not removed:
+        return path
+
+    base, ext = os.path.splitext(path)
+    new_path = f"{base}_langfix{ext or '.owl'}"
+    with open(new_path, "w", encoding="utf-8") as f:
+        f.write(cleaned)
+
+    # One line per distinct value, not per occurrence: these repeat in the
+    # hundreds. Named loudly enough to report back to the ontology's maintainers.
+    label = ontology_name or os.path.basename(path)
+    for value in sorted(set(removed)):
+        logging.warning(
+            f"{label}: removed invalid xml:lang={value!r} "
+            f"({removed.count(value)} occurrence(s)); rdflib rejects it as a language tag."
+        )
+    return new_path
+
+
 def summarize(onto_log: dict) -> dict:
     """Roll a per-ontology log up into the fields of total_stats.yaml.
 
@@ -538,7 +609,12 @@ class Transformer:
         # return, and an ontology that succeeded silently absorbed whatever was
         # at those URLs that day. Stripping here makes the KGX step hermetic.
         # ROBOT always writes RDF/XML for a .owl output, so the stripper applies.
-        kgx_input_path = strip_imports(relaxed_outpath)
+        stripped_path = strip_imports(relaxed_outpath)
+
+        # Same pass, same reason: rdflib raises on an invalid xml:lang instead of
+        # warning, so one typo'd attribute in the source takes the whole ontology
+        # down at parse time. By here the file is always RDF/XML from ROBOT.
+        kgx_input_path = strip_invalid_lang_tags(stripped_path, ontology_name)
 
         # Transform to KGX nodes + edges
         txr = KGXTransformer(stream=True)
@@ -588,7 +664,12 @@ class Transformer:
 
             # Remove the owl files
             # They may not exist if the transform failed
-            for path in (owl_output_path, relaxed_outpath, kgx_input_path):
+            for path in (
+                owl_output_path,
+                relaxed_outpath,
+                stripped_path,
+                kgx_input_path,
+            ):
                 try:
                     os.remove(path)
                 except OSError:

--- a/tests/test_strip_lang_tags.py
+++ b/tests/test_strip_lang_tags.py
@@ -1,0 +1,247 @@
+"""Tests for invalid xml:lang removal.
+
+rdflib raises on a language tag it doesn't recognize instead of warning, so one
+bogus xml:lang attribute anywhere in a source file aborts the whole KGX parse
+and loses the ontology (#140). These tests pin down what counts as bogus --
+which is deliberately rdflib's rule and not the stricter BCP 47 shape, so that
+ontologies building today are not perturbed.
+"""
+
+import os
+import tempfile
+from unittest import TestCase
+
+from rdflib.term import Literal
+
+from kg_bioportal.transformer import strip_invalid_lang_tags
+from tests.test_transform_imports import RELAXED_WITH_IMPORTS, TransformImportsTestCase
+
+RDFXML = """<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+  <owl:Class rdf:about="http://example.org/onto#A">
+    <rdfs:label xml:lang="en">alpha</rdfs:label>
+    <rdfs:comment xml:lang="{tag}">contact the author</rdfs:comment>
+  </owl:Class>
+</rdf:RDF>
+"""
+
+# The two values that actually took an ontology down, from #140.
+DRMO_TAG = "gmail.com"
+PEO_TAG = "mansoorsyed05/encoders-and-decoders-in-generative-ai-3a717d50fced"
+
+
+class LangTagTestCase(TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+
+    def write(self, name, text):
+        path = os.path.join(self._tmp.name, name)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(text)
+        return path
+
+    def clean(self, tag, name="ONTO"):
+        """Sanitize a fixture carrying `tag`, returning (path, text)."""
+        path = self.write("onto.owl", RDFXML.format(tag=tag))
+        out = strip_invalid_lang_tags(path, name)
+        with open(out, encoding="utf-8") as f:
+            return out, f.read()
+
+
+class TestInvalidTagsAreRemoved(LangTagTestCase):
+    def test_email_domain_tag_is_removed(self):
+        _, text = self.clean(DRMO_TAG)
+        self.assertNotIn(DRMO_TAG, text)
+
+    def test_article_slug_tag_is_removed(self):
+        _, text = self.clean(PEO_TAG)
+        self.assertNotIn(PEO_TAG, text)
+
+    def test_the_literal_survives_without_its_tag(self):
+        # The point of dropping the attribute rather than the element: the text
+        # still reaches the output TSVs, minus the language it was never in.
+        _, text = self.clean(DRMO_TAG)
+        self.assertIn("<rdfs:comment>contact the author</rdfs:comment>", text)
+
+    def test_valid_tags_on_other_literals_are_kept(self):
+        _, text = self.clean(DRMO_TAG)
+        self.assertIn('xml:lang="en"', text)
+
+    def test_a_cleaned_sibling_is_written(self):
+        path = self.write("onto.owl", RDFXML.format(tag=DRMO_TAG))
+        out = strip_invalid_lang_tags(path, "ONTO")
+        self.assertNotEqual(out, path, "should return a cleaned sibling file")
+        self.assertTrue(out.endswith("_langfix.owl"), out)
+
+    def test_the_original_file_is_not_modified(self):
+        path = self.write("onto.owl", RDFXML.format(tag=DRMO_TAG))
+        strip_invalid_lang_tags(path, "ONTO")
+        with open(path, encoding="utf-8") as f:
+            self.assertIn(DRMO_TAG, f.read())
+
+    def test_every_occurrence_is_removed_not_just_the_first(self):
+        body = "\n".join(
+            f'    <rdfs:comment xml:lang="{DRMO_TAG}">note {i}</rdfs:comment>'
+            for i in range(5)
+        )
+        path = self.write("onto.owl", RDFXML.format(tag=DRMO_TAG).replace(
+            f'    <rdfs:comment xml:lang="{DRMO_TAG}">contact the author</rdfs:comment>',
+            body,
+        ))
+        with open(strip_invalid_lang_tags(path, "ONTO"), encoding="utf-8") as f:
+            self.assertNotIn("xml:lang=\"" + DRMO_TAG, f.read())
+
+    def test_single_quoted_attributes_are_handled(self):
+        path = self.write("onto.owl", RDFXML.format(tag=DRMO_TAG).replace(
+            f'xml:lang="{DRMO_TAG}"', f"xml:lang='{DRMO_TAG}'"))
+        with open(strip_invalid_lang_tags(path, "ONTO"), encoding="utf-8") as f:
+            self.assertNotIn(DRMO_TAG, f.read())
+
+    def test_owlxml_literals_are_handled_too(self):
+        # ROBOT writes RDF/XML for the .owl it hands us, but the attribute is
+        # spelled identically in OWL/XML and the pass is serialization-agnostic.
+        path = self.write("onto.owx", (
+            '<?xml version="1.0"?>\n<Ontology xmlns="http://www.w3.org/2002/07/owl#">\n'
+            f'  <Literal xml:lang="{DRMO_TAG}">contact the author</Literal>\n</Ontology>\n'
+        ))
+        with open(strip_invalid_lang_tags(path, "ONTO"), encoding="utf-8") as f:
+            self.assertNotIn(DRMO_TAG, f.read())
+
+    def test_each_distinct_tag_is_logged_with_the_acronym(self):
+        # The log is how we tell an ontology's maintainers what is wrong with
+        # their file rather than silently papering over it.
+        path = self.write("onto.owl", RDFXML.format(tag=DRMO_TAG))
+        with self.assertLogs(level="WARNING") as captured:
+            strip_invalid_lang_tags(path, "DRMO")
+        joined = "\n".join(captured.output)
+        self.assertIn("DRMO", joined)
+        self.assertIn(DRMO_TAG, joined)
+
+    def test_repeated_tags_are_logged_once_with_a_count(self):
+        body = "\n".join(
+            f'    <rdfs:comment xml:lang="{DRMO_TAG}">note {i}</rdfs:comment>'
+            for i in range(3)
+        )
+        path = self.write("onto.owl", RDFXML.format(tag=DRMO_TAG).replace(
+            f'    <rdfs:comment xml:lang="{DRMO_TAG}">contact the author</rdfs:comment>',
+            body,
+        ))
+        with self.assertLogs(level="WARNING") as captured:
+            strip_invalid_lang_tags(path, "DRMO")
+        self.assertEqual(len(captured.output), 1, captured.output)
+        self.assertIn("3 occurrence", captured.output[0])
+
+
+class TestValidFilesAreUntouched(LangTagTestCase):
+    """The common case: nothing to fix, so nothing is rewritten."""
+
+    def _assert_untouched(self, tag):
+        path = self.write("onto.owl", RDFXML.format(tag=tag))
+        self.assertEqual(
+            strip_invalid_lang_tags(path, "ONTO"), path,
+            f"xml:lang={tag!r} is accepted by rdflib and must be left alone",
+        )
+
+    def test_simple_tag(self):
+        self._assert_untouched("fr")
+
+    def test_region_subtag(self):
+        self._assert_untouched("en-GB")
+
+    def test_script_and_region_subtags(self):
+        self._assert_untouched("zh-Hans-CN")
+
+    def test_overlong_subtag_rdflib_still_accepts(self):
+        # Not BCP 47 -- subtags cap at eight characters -- but rdflib takes it,
+        # so stripping it would perturb an ontology that builds today.
+        self._assert_untouched("portuguese")
+
+    def test_empty_tag_resets_inherited_language(self):
+        # xml:lang="" is XML's way of clearing an ancestor's language, and
+        # rdflib reads it as no tag. Removing it would change what descendant
+        # literals are tagged with.
+        self._assert_untouched("")
+
+    def test_file_with_no_language_tags_at_all(self):
+        path = self.write("onto.owl", RDFXML.format(tag="en").replace(
+            ' xml:lang="en"', ""))
+        self.assertEqual(strip_invalid_lang_tags(path, "ONTO"), path)
+
+    def test_unreadable_path_returns_the_input(self):
+        missing = os.path.join(self._tmp.name, "nope.owl")
+        self.assertEqual(strip_invalid_lang_tags(missing, "ONTO"), missing)
+
+
+class TestAgreesWithRdflib(LangTagTestCase):
+    """The criterion is exactly 'would rdflib raise on this?'.
+
+    Anything the pass keeps must construct a Literal without raising, and
+    anything it drops must be a value that raises -- otherwise we either fail to
+    fix an ontology or damage one that was fine.
+    """
+
+    CASES = [
+        "en", "en-GB", "zh-Hans-CN", "portuguese", "x-custom", "i-klingon",
+        DRMO_TAG, PEO_TAG, "en_US", "en GB", "3", "en-", "-en", "en--GB",
+    ]
+
+    def test_kept_iff_rdflib_accepts(self):
+        for tag in self.CASES:
+            with self.subTest(tag=tag):
+                try:
+                    Literal("x", lang=tag)
+                except ValueError:
+                    rdflib_accepts = False
+                else:
+                    rdflib_accepts = True
+
+                path = self.write("onto.owl", RDFXML.format(tag=tag))
+                kept = strip_invalid_lang_tags(path, "ONTO") == path
+                self.assertEqual(
+                    kept, rdflib_accepts,
+                    f"xml:lang={tag!r}: rdflib accepts={rdflib_accepts}, kept={kept}",
+                )
+
+
+class TestKGXInputHasParseableLangTags(TransformImportsTestCase):
+    """The sanitized file is what transform() actually hands KGX.
+
+    Reuses the #136 harness: ROBOT and KGX are faked, and what matters is the
+    content of the file KGX is pointed at.
+    """
+
+    BAD = f'    <rdfs:comment xml:lang="{DRMO_TAG}">contact the author</rdfs:comment>\n'
+    RELAXED_WITH_BAD_TAG = RELAXED_WITH_IMPORTS.replace(
+        "  </owl:Ontology>", f"  </owl:Ontology>\n{BAD}")
+
+    def test_invalid_tag_is_gone_before_kgx_parses(self):
+        self.run_transform(self.RELAXED_WITH_BAD_TAG)
+        _, content = self.kgx_saw()
+        self.assertNotIn(DRMO_TAG, content)
+
+    def test_imports_are_still_stripped_alongside(self):
+        # Both passes run, in order, on the same file.
+        self.run_transform(self.RELAXED_WITH_BAD_TAG)
+        _, content = self.kgx_saw()
+        self.assertNotIn("owl:imports", content)
+        self.assertIn("contact the author", content)
+
+    def test_transform_still_succeeds(self):
+        success, _, _ = self.run_transform(self.RELAXED_WITH_BAD_TAG)
+        self.assertTrue(success)
+
+    def test_a_clean_file_is_passed_through_untouched(self):
+        # No bogus tags means no rewrite, so the ontologies that build today are
+        # handed exactly the file the import strip left them.
+        self.run_transform(RELAXED_WITH_IMPORTS)
+        path, _ = self.kgx_saw()
+        self.assertTrue(path.endswith("_noimports.owl"), path)
+
+    def test_both_intermediates_are_cleaned_up(self):
+        self.run_transform(self.RELAXED_WITH_BAD_TAG)
+        workdir = os.path.join(self.output_dir, "ONTO", "1")
+        leftovers = [f for f in os.listdir(workdir) if f.endswith(".owl")]
+        self.assertEqual(leftovers, [], f"OWL intermediates left behind: {leftovers}")


### PR DESCRIPTION
rdflib validates the language tag on every `Literal` it builds and raises rather than warning, so one typo'd `xml:lang` anywhere in a file aborts the KGX parse and loses the ontology. DRMO carried an email domain as a language tag; PEO_ONTOLOGY carried Medium article slugs. Nothing on the BioPortal side validates these, so this recurs with any future typo.

Sanitize the file KGX is handed, in the same pass that strips imports: drop the attribute, keep the literal. Each distinct bad value is logged with the acronym and an occurrence count, so an ontology's maintainers can be told what is wrong with their file rather than papering over it.

```
WARNING:root:DRMO: removed invalid xml:lang='gmail.com' (1 occurrence(s)); rdflib rejects it as a language tag.
```

## Verification

Against live BioPortal — downloaded both sources, ran ROBOT and KGX for real.

| | before | after |
|---|---|---|
| DRMO | `ValueError: 'gmail.com' is not a valid language tag!` | `status: OK`, 534 nodes / 424 edges |
| PEO_ONTOLOGY | same error on the Medium slug | `status: OK`, 538 nodes / 359 edges |

Also ran a control with the bad tags rewritten to `xml:lang="en"` rather than removed. Nodes and edges come out identical to the stripped version, once rdflib's per-parse blank node ids and KGX's generated edge UUIDs are normalized. Dropping the attribute costs nothing but the tag.

Two things the issue did not have:

- DRMO's `DrMO Updated.rdf` is actually **Turtle**, and its bad tag is `"…"@gmail.com` in the source. ROBOT accepts it and writes it out as `xml:lang="gmail.com"`, which is why sanitizing ROBOT's output catches it and sanitizing the download would not have.
- PEO_ONTOLOGY has a **third** bad tag, a second Medium slug (`pickleprat/encoder-only-architecture-bert-…`). The log names all of them.

## On what counts as invalid

The issue proposed the BCP 47 shape, which caps subtags at eight characters. This uses rdflib 7's looser rule instead (`term.py`, `_lang_tag_regex`). rdflib is the only consumer of the file we sanitize, so matching its rule exactly strips every tag that would abort the parse and not one more — the BCP 47 regex would also strip `xml:lang="portuguese"` from ontologies that build today. A test asserts the two agree case by case against real `Literal()` construction, so it fails loudly if rdflib ever tightens.

`xml:lang=""` is deliberately left alone: in XML that resets the language inherited from an ancestor, and rdflib reads it as no tag at all.

## On not perturbing what already works

The pass returns the input path untouched unless it finds a tag rdflib would reject, and an ontology that reaches OK today by definition has none — KGX would have aborted on it. So no currently-building graph can see a change.

## Related

While verifying, I confirmed `provided_by` still carries the intermediate's filename rather than the acronym, and that it now varies by which sanitizing passes fired. Written up in #72; deliberately not addressed here.

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)