### PR TITLE
Record which stage lost an ontology, and what it said

### DIFF
--- a/.claude/skills/kg-bioportal-data/references/data-model.md
+++ b/.claude/skills/kg-bioportal-data/references/data-model.md
@@ -44,8 +44,14 @@ ontologies:
   name: AGRonomy Ontology # human name from BioPortal
   version: '2023-08-14'   # BioPortal submission version string ('NA' if none)
   status: OK              # OK | Failed | Skipped
-  reason: ''              # why non-OK: transform_error | too_large | too_slow |
-                          #   skiplist | not_downloadable | no_submission
+  reason: ''              # why non-OK: transform_error_<stage> | too_large |
+                          #   too_slow | skiplist | not_downloadable | no_submission.
+                          #   <stage> is decompress | convert | relax | kgx — which
+                          #   step lost the ontology. Entries from runs before this
+                          #   was recorded carry a bare `transform_error`.
+  detail: ''              # non-OK entries only, and only when there is something to
+                          #   say: the message from the stage that failed, on one
+                          #   line, truncated to 500 characters
   nodecount: 5102         # 0 unless status OK
   edgecount: 8691
   submission_id: '6'      # BioPortal submission id

--- a/docs/kg_site/build_site.py
+++ b/docs/kg_site/build_site.py
@@ -167,7 +167,8 @@ def onto_to_item(o, transform_date):
         "download_url": o.get("download_url") or "",
         "bioportal_url": f"{BP}/ontologies/{oid}",
         "submission_id": o.get("submission_id", "NA"),
-        "reason": o.get("reason", ""), "transform_date": transform_date or "",
+        "reason": o.get("reason", ""), "detail": o.get("detail", ""),
+        "transform_date": transform_date or "",
     }
 
 # Human-readable explanation for why a non-OK ontology has no KGX artifact.
@@ -178,6 +179,16 @@ REASON_MSG = {
     "skiplist": "This ontology is known to be too large or slow for the automated pipeline and is "
                 "skipped up front.",
     "transform_error": "The transform did not complete — ROBOT or the KGX conversion reported an error.",
+    # Stage-specific forms of the above, written since #134. The plain
+    # transform_error stays: index entries seeded from earlier releases have it.
+    "transform_error_decompress": "The downloaded source could not be unpacked, so the transform "
+                                  "never started.",
+    "transform_error_convert": "ROBOT could not load the source ontology (the `convert` step), so "
+                               "there was nothing to transform.",
+    "transform_error_relax": "ROBOT loaded the ontology but failed to normalise it (the `relax` "
+                             "step).",
+    "transform_error_kgx": "The ontology converted, but the KGX step failed to turn it into nodes "
+                           "and edges.",
     "not_downloadable": "No downloadable source is currently available from BioPortal.",
     "license_restricted": "This ontology is only available under a license we do not hold "
                           "(typically a UMLS licence), so BioPortal does not serve its source "
@@ -957,6 +968,10 @@ def render_ontology_resource(it):
     ]
     if not ok and reason:
         detail_rows.append(drow("Reason", f'<span class="mono">{esc(reason)}</span>'))
+    # The message from the stage that failed, when the index carries one. This
+    # is the difference between "it failed" and knowing what to fix.
+    if not ok and it.get("detail"):
+        detail_rows.append(drow("Detail", f'<span class="mono">{esc(it["detail"])}</span>'))
     detail_rows += [
         drow("Version", esc(ver or "—")),
         drow("Submission", f'<span class="mono">{esc(sub)}</span>'),

--- a/src/kg_bioportal/robot_utils.py
+++ b/src/kg_bioportal/robot_utils.py
@@ -2,14 +2,89 @@
 
 import os
 import logging
+import re
 import requests
 import sh  # type: ignore
 from sh import chmod  # type: ignore
+
+from typing import NamedTuple
 
 from kg_bioportal.config import ROBOT_JAVA_ARGS
 
 # Note that sh module can take environment variables, see
 # https://amoffat.github.io/sh/sections/special_arguments.html#env
+
+# How much of a ROBOT error to carry back. Enough for the exception and its
+# cause chain, which is one line; the stack trace below it says nothing about
+# the ontology.
+_MAX_ERROR_CHARS = 500
+
+
+class RobotResult(NamedTuple):
+    """Whether a ROBOT command succeeded, and what it said if it didn't.
+
+    Truthy exactly when the command succeeded, so ``if not robot_convert(...)``
+    reads the same as it did when these returned a bare bool -- the error text
+    is there for a caller that wants to record *why* (#134).
+    """
+
+    ok: bool
+    error: str = ""
+
+    def __bool__(self) -> bool:
+        return self.ok
+
+
+# Lines the JVM and its logging frameworks write to stderr before ROBOT gets a
+# word in. Whichever of these a runner happens to emit is not the failure.
+_JVM_NOISE = (
+    "Picked up JAVA_TOOL_OPTIONS",
+    "Picked up _JAVA_OPTIONS",
+    "Picked up JAVA_OPTIONS",
+    "SLF4J:",
+    "log4j:",
+    "OpenJDK",
+    "Java HotSpot",
+    "WARNING: ",
+)
+
+# A Java throwable, or anything shouting ERROR -- what ROBOT's failures look
+# like: "java.lang.IllegalArgumentException: ...UnloadableImportException: ..."
+# or "java.io.IOException: errors#INVALID ONTOLOGY FILE ERROR ...".
+_THROWABLE = re.compile(r"\b[\w.$]*(?:Exception|Error|ERROR)\b")
+
+# Enough of stderr to find the error in; a stack trace that deep is not hiding
+# a better line further down.
+_MAX_ERROR_LINES = 200
+
+
+def _error_text(e: Exception) -> str:
+    """The line of a ROBOT failure worth keeping.
+
+    ROBOT writes its verbose (-vvv) log to stdout and the failure to stderr,
+    where one line carries the exception and its whole cause chain --
+    "java.lang.IllegalArgumentException: ...UnloadableImportException: Could not
+    load imported ontology: <url>". Everything under it is a stack trace through
+    OWL API internals, which identifies nothing about the ontology, and anything
+    above it is the JVM clearing its throat.
+
+    So: skip the noise and the stack frames, prefer the first line that names a
+    throwable, and fall back to the first line left. Falls back to the exception
+    itself when there is no stderr to read at all.
+    """
+    stderr = getattr(e, "stderr", b"") or b""
+    if isinstance(stderr, (bytes, bytearray)):
+        stderr = stderr.decode("utf-8", "replace")
+
+    fallback = ""
+    for line in stderr.splitlines()[:_MAX_ERROR_LINES]:
+        line = line.strip()
+        if not line or line.startswith(("at ", "... ")) or line.startswith(_JVM_NOISE):
+            continue
+        if _THROWABLE.search(line):
+            return line[:_MAX_ERROR_CHARS]
+        fallback = fallback or line
+    return (fallback or str(e).strip())[:_MAX_ERROR_CHARS]
 
 
 def initialize_robot(robot_path: str) -> list:
@@ -59,7 +134,7 @@ def robot_relax(
     output_path: str,
     robot_env: dict,
     timeout: int = 10800,
-) -> bool:
+) -> RobotResult:
     """
     Run the ROBOT relax command on a single ontology.
 
@@ -68,11 +143,10 @@ def robot_relax(
     :param output_owl: Ontology file to be created (needs valid ROBOT suffix)
     :param robot_env: dict of environment variables, including ROBOT_JAVA_ARGS
     :param timeout: Wall-clock limit in seconds; the process is killed if exceeded.
-    :return: True if completed without errors, False if errors
+    :return: RobotResult -- truthy if completed without errors, carrying the
+        error text if not.
     """
-    success = False
-
-    print(f"Relaxing {input_path} to {output_path}...")
+    logging.info(f"Relaxing {input_path} to {output_path}...")
 
     robot_command = sh.Command(robot_path)
 
@@ -87,19 +161,24 @@ def robot_relax(
             _env=robot_env,
             _timeout=timeout,
         )
-        print("Complete.")
-        success = True
-    except sh.ErrorReturnCode_1 as e:  # If ROBOT runs but returns an error
-        print(f"ROBOT encountered an error: {e}")
-        success = False
-    except sh.SignalException_SIGKILL as e:  # If ROBOT encounters severe error
-        print(f"ROBOT crashed! {e}")
-        success = False
-    except sh.TimeoutException as e:  # If ROBOT exceeded the wall-clock limit
-        print(f"ROBOT relax timed out after {timeout}s: {e}")
-        success = False
+        logging.info("Complete.")
+        return RobotResult(True)
+    # SignalException subclasses ErrorReturnCode, so it has to be caught first
+    # or a kill reads as an ordinary nonzero exit and reports a stderr that a
+    # killed process never got to write.
+    except sh.SignalException_SIGKILL:  # If ROBOT encounters severe error
+        error = "ROBOT was killed (SIGKILL); the runner most likely ran out of memory"
+        logging.error(error)
+    # The base class, not ErrorReturnCode_1: a nonzero exit of any other code is
+    # recorded as a failure rather than taking the whole shard down with it.
+    except sh.ErrorReturnCode as e:  # If ROBOT runs but returns an error
+        error = _error_text(e)
+        logging.error(f"ROBOT encountered an error: {error}")
+    except sh.TimeoutException:  # If ROBOT exceeded the wall-clock limit
+        error = f"ROBOT relax timed out after {timeout}s"
+        logging.error(error)
 
-    return success
+    return RobotResult(False, error)
 
 
 def robot_convert(
@@ -108,7 +187,7 @@ def robot_convert(
     output_path: str,
     robot_env: dict,
     timeout: int = 10800,
-) -> bool:
+) -> RobotResult:
     """
     Run a ROBOT convert command on a single ontology.
 
@@ -117,11 +196,10 @@ def robot_convert(
     :param output_path: Ontology file to be created (needs valid ROBOT suffix)
     :param robot_env: dict of environment variables, including ROBOT_JAVA_ARGS
     :param timeout: Wall-clock limit in seconds; the process is killed if exceeded.
-    :return: True if completed without errors, False if errors
+    :return: RobotResult -- truthy if completed without errors, carrying the
+        error text if not.
     """
-    success = False
-
-    print(f"Converting {input_path} to {output_path}...")
+    logging.info(f"Converting {input_path} to {output_path}...")
 
     robot_command = sh.Command(robot_path)
 
@@ -136,19 +214,24 @@ def robot_convert(
             _env=robot_env,
             _timeout=timeout,
         )
-        print("Complete.")
-        success = True
-    except sh.ErrorReturnCode_1 as e:  # If ROBOT runs but returns an error
-        print(f"ROBOT encountered an error: {e}")
-        success = False
-    except sh.SignalException_SIGKILL as e:  # If ROBOT encounters severe error
-        print(f"ROBOT crashed! {e}")
-        success = False
-    except sh.TimeoutException as e:  # If ROBOT exceeded the wall-clock limit
-        print(f"ROBOT convert timed out after {timeout}s: {e}")
-        success = False
+        logging.info("Complete.")
+        return RobotResult(True)
+    # SignalException subclasses ErrorReturnCode, so it has to be caught first
+    # or a kill reads as an ordinary nonzero exit and reports a stderr that a
+    # killed process never got to write.
+    except sh.SignalException_SIGKILL:  # If ROBOT encounters severe error
+        error = "ROBOT was killed (SIGKILL); the runner most likely ran out of memory"
+        logging.error(error)
+    # The base class, not ErrorReturnCode_1: a nonzero exit of any other code is
+    # recorded as a failure rather than taking the whole shard down with it.
+    except sh.ErrorReturnCode as e:  # If ROBOT runs but returns an error
+        error = _error_text(e)
+        logging.error(f"ROBOT encountered an error: {error}")
+    except sh.TimeoutException:  # If ROBOT exceeded the wall-clock limit
+        error = f"ROBOT convert timed out after {timeout}s"
+        logging.error(error)
 
-    return success
+    return RobotResult(False, error)
 
 
 def merge_and_convert_ontology(
@@ -166,7 +249,7 @@ def merge_and_convert_ontology(
     """
     success = False
 
-    print(f"Merging and converting {input_path} to {output_path}...")
+    logging.info(f"Merging and converting {input_path} to {output_path}...")
 
     robot_command = sh.Command(robot_path)
 
@@ -182,13 +265,13 @@ def merge_and_convert_ontology(
             _env=robot_env,
             _timeout=10800,
         )
-        print("Complete.")
+        logging.info("Complete.")
         success = True
     except sh.ErrorReturnCode_1 as e:  # If ROBOT runs but returns an error
-        print(f"ROBOT encountered an error: {e}")
+        logging.error(f"ROBOT encountered an error: {e}")
         success = False
     except sh.SignalException_SIGKILL as e:  # If ROBOT encounters severe error
-        print(f"ROBOT crashed! {e}")
+        logging.error(f"ROBOT crashed! {e}")
         success = False
 
     return success
@@ -209,7 +292,7 @@ def measure_ontology(
     """
     success = False
 
-    print(f"Obtaining metrics for {input_path}...")
+    logging.info(f"Obtaining metrics for {input_path}...")
 
     robot_command = sh.Command(robot_path)
 
@@ -226,10 +309,10 @@ def measure_ontology(
             output_log,
             _env=robot_env,
         )
-        print(f"Complete. See log in {output_log}")
+        logging.info(f"Complete. See log in {output_log}")
         success = True
     except sh.ErrorReturnCode_1 as e:  # If ROBOT runs but returns an error
-        print(f"ROBOT encountered an error: {e}")
+        logging.error(f"ROBOT encountered an error: {e}")
         success = False
 
     return success
@@ -254,7 +337,7 @@ def robot_remove(
     """
     success = False
 
-    print(f"Removing selected elements from {input_path}: {term}...")
+    logging.info(f"Removing selected elements from {input_path}: {term}...")
 
     robot_command = sh.Command(robot_path)
 
@@ -270,10 +353,10 @@ def robot_remove(
             output_path,
             _env=robot_env,
         )
-        print(f"Complete. See {output_path}")
+        logging.info(f"Complete. See {output_path}")
         success = True
     except sh.ErrorReturnCode_1 as e:  # If ROBOT runs but returns an error
-        print(f"ROBOT encountered an error: {e}")
+        logging.error(f"ROBOT encountered an error: {e}")
         success = False
 
     return success
@@ -293,7 +376,7 @@ def robot_report(
     """
     success = False
 
-    print(f"Generating ROBOT report for {input_path}...")
+    logging.info(f"Generating ROBOT report for {input_path}...")
 
     robot_command = sh.Command(robot_path)
 
@@ -308,12 +391,12 @@ def robot_report(
             "tsv",
             _env=robot_env,
         )
-        print(f"No errors here! See {output_path}")
+        logging.info(f"No errors here! See {output_path}")
         success = True
     except sh.ErrorReturnCode_1 as e:  # If ROBOT runs but returns an error
         # For report, this is expected, as the error may be
         # in the target ontology.
-        print(f"ROBOT report results: {e}\nSee {output_path}")
+        logging.error(f"ROBOT report results: {e}\nSee {output_path}")
         success = False
 
     return success
@@ -333,7 +416,7 @@ def robot_measure(
     """
     success = False
 
-    print(f"Generating ROBOT measure log for {input_path}...")
+    logging.info(f"Generating ROBOT measure log for {input_path}...")
 
     robot_command = sh.Command(robot_path)
 
@@ -351,10 +434,10 @@ def robot_measure(
             "all",
             _env=robot_env,
         )
-        print(f"Complete. See {output_path}")
+        logging.info(f"Complete. See {output_path}")
         success = True
     except sh.ErrorReturnCode_1 as e:  # If ROBOT runs but returns an error
-        print(f"ROBOT encountered an error: {e}")
+        logging.error(f"ROBOT encountered an error: {e}")
         success = False
 
     return success

--- a/src/kg_bioportal/transformer.py
+++ b/src/kg_bioportal/transformer.py
@@ -11,7 +11,7 @@ import sys
 import tarfile
 import zipfile
 from contextlib import contextmanager
-from typing import List, Optional, Tuple
+from typing import List, NamedTuple, Optional, Tuple
 
 import yaml
 from kgx.transformer import Transformer as KGXTransformer
@@ -631,6 +631,56 @@ def pick_ontology_member(
     return sorted(ontology_files or candidates, key=rank)[0][0]
 
 
+# How much of a failure message to keep in the stats. Long enough for a ROBOT
+# exception with its cause chain, short enough that onto_stats.yaml stays
+# readable with a few hundred failures in it.
+MAX_DETAIL_CHARS = 500
+
+# Stages a transform can fail at, in the order it runs them. The reason written
+# to onto_stats is "transform_error_<stage>", so every transform failure still
+# greps as transform_error while saying which step lost the ontology (#134).
+TRANSFORM_STAGES = ("decompress", "convert", "relax", "kgx")
+
+
+def reason_for_stage(stage: str) -> str:
+    """The onto_stats ``reason`` for a transform that died at ``stage``."""
+    if stage in TRANSFORM_STAGES:
+        return f"transform_error_{stage}"
+    return "transform_error"  # a failure with no stage recorded; keep the old name
+
+
+class TransformOutcome(NamedTuple):
+    """What became of one ontology, and -- when it failed -- where and why.
+
+    Every failure used to arrive at the caller as a bare False, so the stats
+    could only record the constant "transform_error" for all of them. Auditing
+    66 failures then meant reconstructing the stage from half a million lines of
+    Actions logs, which expire (#134).
+    """
+
+    success: bool
+    nodecount: int = 0
+    edgecount: int = 0
+    stage: str = ""
+    detail: str = ""
+
+    @classmethod
+    def failed(cls, stage: str, detail: str = "") -> "TransformOutcome":
+        return cls(False, 0, 0, stage, summarize_detail(detail))
+
+
+def summarize_detail(text: str, limit: int = MAX_DETAIL_CHARS) -> str:
+    """Squash a failure message onto one line and cap its length.
+
+    These end up in a YAML field that people read; a multi-line exception or a
+    dumped stack trace makes onto_stats.yaml unusable as a summary.
+    """
+    collapsed = " ".join(str(text).split())
+    if len(collapsed) <= limit:
+        return collapsed
+    return collapsed[: limit - 3].rstrip() + "..."
+
+
 class TransformTimeout(Exception):
     """Raised when a single ontology transform exceeds its wall-clock budget."""
 
@@ -737,7 +787,8 @@ class Transformer:
         Yields two log files: total_stats.yaml and onto_stats.yaml.
         The first contains the total counts of Bioportal ontologies and transforms.
         The second contains the counts of nodes and edges for each ontology, plus
-        its status (OK / Failed / Skipped) and the reason for any skip.
+        its status (OK / Failed / Skipped), the reason for any skip or failure,
+        and -- for a failure -- a detail field carrying the message that caused it.
 
         Args:
             compress: If True, compresses the output nodes and edges to tar.gz.
@@ -794,21 +845,25 @@ class Transformer:
             ontology_name = (os.path.relpath(filepath, self.input_dir)).split(os.sep)[0]
             report_row = download_report.get(ontology_name, {})
             reason = ""
+            detail = ""
             try:
                 with deadline(self.timeout_sec):
-                    success, nodecount, edgecount = self.transform(filepath, compress)
+                    outcome = self.transform(filepath, compress)
             except TransformTimeout:
                 logging.error(
                     f"Transform of {ontology_name} exceeded {self.timeout_min} min; skipping."
                 )
-                success, nodecount, edgecount = False, 0, 0
+                outcome = TransformOutcome(False)
                 reason = "too_slow"
+                detail = f"exceeded the per-ontology limit of {self.timeout_min} min"
             except SourceTooLarge as e:
                 logging.warning(f"Skipping {ontology_name}: {e}.")
-                success, nodecount, edgecount = False, 0, 0
+                outcome = TransformOutcome(False)
                 reason = "too_large"
+                detail = summarize_detail(e)
 
-            if not success:
+            nodecount, edgecount = outcome.nodecount, outcome.edgecount
+            if not outcome.success:
                 strstatus = "Skipped" if reason in ("too_slow", "too_large") else "Failed"
                 # A deliberate skip is not an error; saying so in the log made
                 # the two indistinguishable when reading a run afterwards.
@@ -819,12 +874,15 @@ class Transformer:
                 nodecount = 0
                 edgecount = 0
                 if not reason:
-                    reason = "transform_error"
+                    # Name the stage that lost it, so the next audit is a grep of
+                    # onto_stats.yaml rather than an archaeology of expiring logs.
+                    reason = reason_for_stage(outcome.stage)
+                    detail = outcome.detail
             else:
                 logging.info(f"Transformed {filepath}.")
                 strstatus = "OK"
 
-            onto_log[ontology_name] = {
+            entry = {
                 "status": strstatus,
                 "reason": reason,
                 "name": report_row.get("name", ""),
@@ -834,6 +892,11 @@ class Transformer:
                 "submission_id": report_row.get("submission_id", "NA"),
                 "source_bytes": int(report_row.get("source_bytes") or 0),
             }
+            # Only failures have anything to explain; an empty field on every OK
+            # entry would be a thousand lines of noise in the index.
+            if detail:
+                entry["detail"] = detail
+            onto_log[ontology_name] = entry
 
         # Write total stats to a yaml
         logging.info("Writing total stats to total_stats.yaml.")
@@ -854,7 +917,7 @@ class Transformer:
 
         return None
 
-    def transform(self, ontology_path: str, compress: bool) -> Tuple[bool, int, int]:
+    def transform(self, ontology_path: str, compress: bool) -> TransformOutcome:
         """Transforms a single ontology to KGX nodes and edges.
 
         The compressed product is written flat as ``<output_dir>/<ACRONYM>.tar.gz``
@@ -865,12 +928,10 @@ class Transformer:
             compress: If True, compresses the output nodes and edges to tar.gz.
 
         Returns:
-            Tuple of:
-                True if transform was successful, otherwise False.
-                Number of nodes in the ontology.
-                Number of edges in the ontology.
+            A TransformOutcome: whether it succeeded, the node and edge counts,
+            and for a failure the stage it died at and the message that stage
+            gave, so the stats can say more than "transform_error".
         """
-        status = False
         nodecount = 0
         edgecount = 0
 
@@ -899,7 +960,10 @@ class Transformer:
                 ontology_path = new_path
             else:
                 logging.error(f"Failed to decompress {ontology_path}")
-                return False, nodecount, edgecount
+                return TransformOutcome.failed(
+                    "decompress",
+                    f"could not decompress {os.path.basename(ontology_path)}",
+                )
 
             # Re-apply the size gate now that we can see the real size. The
             # downloader weighed the compressed file, which understates a
@@ -918,25 +982,27 @@ class Transformer:
         ontology_path = strip_imports(ontology_path)
 
         # Convert
-        if not robot_convert(
+        converted = robot_convert(
             robot_path=self.robot_path,
             input_path=ontology_path,
             output_path=owl_output_path,
             robot_env=self.robot_env,
             timeout=self.timeout_sec,
-        ):
-            return False, nodecount, edgecount
+        )
+        if not converted:
+            return TransformOutcome.failed("convert", converted.error)
 
         # Relax
         relaxed_outpath = os.path.join(workdir, f"{ontology_name}_relaxed.owl")
-        if not robot_relax(
+        relaxed = robot_relax(
             robot_path=self.robot_path,
             input_path=owl_output_path,
             output_path=relaxed_outpath,
             robot_env=self.robot_env,
             timeout=self.timeout_sec,
-        ):
-            return False, nodecount, edgecount
+        )
+        if not relaxed:
+            return TransformOutcome.failed("relax", relaxed.error)
 
         # Strip imports again, this time from ROBOT's output. ROBOT keeps the
         # owl:imports triples in what it writes, and KGX's OwlSource dereferences
@@ -953,7 +1019,6 @@ class Transformer:
         kgx_input_path = strip_invalid_lang_tags(stripped_path, ontology_name)
 
         # Transform to KGX nodes + edges
-        txr = KGXTransformer(stream=True)
         outfilename = os.path.join(workdir, f"{ontology_name}")
         nodefilename = outfilename + "_nodes.tsv"
         edgefilename = outfilename + "_edges.tsv"
@@ -968,7 +1033,11 @@ class Transformer:
             "aggregator_knowledge_source": "infores:bioportal",
         }
         logging.info("Doing KGX transform.")
+        # Constructing the transformer is inside the try as well: it is part of
+        # the KGX stage, and an exception raised out here would take down the
+        # whole shard instead of costing one ontology.
         try:
+            txr = KGXTransformer(stream=True)
             txr.transform(
                 input_args=input_args,
                 output_args=output_args,
@@ -976,8 +1045,6 @@ class Transformer:
             logging.info(
                 f"Nodes and edges written to {nodefilename} and {edgefilename}."
             )
-            status = True
-
             # Get length of nodefile
             with open(nodefilename, "r") as f:
                 nodecount = len(f.readlines()) - 1
@@ -1015,9 +1082,11 @@ class Transformer:
             logging.error(
                 f"Error transforming {ontology_name} to KGX nodes and edges: {e}"
             )
-            return False, nodecount, edgecount
+            # The exception type carries as much as its message does when the
+            # message is empty, which some of KGX's are.
+            return TransformOutcome.failed("kgx", f"{type(e).__name__}: {e}")
 
-        return status, nodecount, edgecount
+        return TransformOutcome(True, nodecount, edgecount)
 
     def decompress(self, ontology_path: str, ontology_name: str) -> str:
         """Decompresses a downloaded ontology archive.

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -29,6 +29,8 @@ class TestReasonMessages(TestCase):
     # renders as a generic "has not been transformed", which tells nobody why.
     REASONS = [
         "too_large", "too_slow", "skiplist", "transform_error",
+        "transform_error_decompress", "transform_error_convert",
+        "transform_error_relax", "transform_error_kgx",
         "not_downloadable", "license_restricted", "no_download_file",
         "download_http_error", "no_submission", "metadata_http_error",
         "download_error",
@@ -63,6 +65,13 @@ class TestOntologyItems(TestCase):
         self.assertFalse(it["ok"])
         self.assertIn("transform_error", it["blurb"])
 
+    def test_stage_specific_messages_differ_from_each_other(self):
+        # Four stages that fail for four different reasons; one shared message
+        # would put us back where #134 started.
+        messages = {bs.reason_message(f"transform_error_{stage}")
+                    for stage in ("decompress", "convert", "relax", "kgx")}
+        self.assertEqual(len(messages), 4)
+
     def test_licensed_ontology_is_not_called_failed(self):
         it = item("NDDF", "Failed", "license_restricted")
         self.assertEqual(it["status_label"], "Licensed")
@@ -73,6 +82,37 @@ class TestOntologyItems(TestCase):
         self.assertIsNone(it["nodes"])
         self.assertIsNone(it["edges"])
         self.assertEqual(it["fmts"], [])
+
+
+class TestFailureDetail(TestCase):
+    """A failed ontology's page should say what actually went wrong."""
+
+    def test_detail_is_carried_onto_the_item(self):
+        it = item("FYPO", "Failed", "transform_error_kgx",
+                  detail="TypeError: '<' not supported")
+        self.assertIn("not supported", it["detail"])
+
+    def test_missing_detail_is_empty_not_absent(self):
+        # Entries seeded from an index written before #134 have no detail field.
+        self.assertEqual(item("FYPO", "Failed", "transform_error")["detail"], "")
+
+    def test_detail_is_rendered_on_the_resource_page(self):
+        html = bs.render_ontology_resource(item(
+            "FYPO", "Failed", "transform_error_kgx", detail="TypeError: bad sort"))
+        self.assertIn("Detail", html)
+        self.assertIn("TypeError: bad sort", html)
+
+    def test_detail_is_escaped_not_injected(self):
+        # ROBOT errors carry angle brackets and quotes straight from Java.
+        html = bs.render_ontology_resource(item(
+            "FYPO", "Failed", "transform_error_convert",
+            detail='could not load <http://x/y> "z"'))
+        self.assertNotIn("<http://x/y>", html)
+        self.assertIn("&lt;http://x/y&gt;", html)
+
+    def test_an_ok_ontology_shows_no_detail_row(self):
+        html = bs.render_ontology_resource(item("AGRO", "OK", nodecount=5, edgecount=6))
+        self.assertNotIn(">Detail<", html)
 
 
 class TestDownloadLinks(TestCase):

--- a/tests/test_merge_stats.py
+++ b/tests/test_merge_stats.py
@@ -226,6 +226,49 @@ class TestSeedAndOverlay(MergeStatsTestCase):
         self.assertEqual(list(index), sorted(index))
 
 
+class TestFailureDetail(MergeStatsTestCase):
+    """The stage and message a shard recorded have to survive the merge.
+
+    Shards write the per-ontology reason/detail (#134); if the merge dropped
+    them, the published index would be back to a bare "transform_error".
+    """
+
+    def test_stage_specific_reason_survives_the_merge(self):
+        self.write_fragment([entry(
+            "FYPO", status="Failed", reason="transform_error_kgx",
+            detail="TypeError: '<' not supported between instances of 'str' and 'int'")])
+        index, _ = self.run_merge()
+        self.assertEqual(index["FYPO"]["reason"], "transform_error_kgx")
+
+    def test_detail_survives_the_merge(self):
+        self.write_fragment([entry(
+            "FYPO", status="Failed", reason="transform_error_kgx",
+            detail="TypeError: '<' not supported")])
+        index, _ = self.run_merge()
+        self.assertIn("not supported", index["FYPO"]["detail"])
+
+    def test_a_fresh_failure_replaces_a_seeded_one(self):
+        # A re-run that fails differently has to say so, not keep the old cause.
+        base = self.write_base([entry(
+            "FYPO", status="Failed", reason="transform_error", detail="")])
+        self.write_fragment([entry(
+            "FYPO", status="Failed", reason="transform_error_convert",
+            detail="UnloadableImportException: Could not load imported ontology")])
+        index, _ = self.run_merge(base)
+        self.assertEqual(index["FYPO"]["reason"], "transform_error_convert")
+        self.assertIn("UnloadableImportException", index["FYPO"]["detail"])
+
+    def test_stage_specific_failures_are_still_counted_as_failures(self):
+        self.write_fragment([
+            entry("A", status="Failed", reason="transform_error_convert"),
+            entry("B", status="Failed", reason="transform_error_kgx"),
+            entry("C"),
+        ])
+        _, totals = self.run_merge()
+        self.assertEqual(totals["failedcount"], 2)
+        self.assertEqual(totals["totalcount"], 1)
+
+
 class TestTotals(MergeStatsTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/test_strip_lang_tags.py
+++ b/tests/test_strip_lang_tags.py
@@ -230,8 +230,7 @@ class TestKGXInputHasParseableLangTags(TransformImportsTestCase):
         self.assertIn("contact the author", content)
 
     def test_transform_still_succeeds(self):
-        success, _, _ = self.run_transform(self.RELAXED_WITH_BAD_TAG)
-        self.assertTrue(success)
+        self.assertTrue(self.run_transform(self.RELAXED_WITH_BAD_TAG).success)
 
     def test_a_clean_file_is_passed_through_untouched(self):
         # No bogus tags means no rewrite, so the ontologies that build today are

--- a/tests/test_transform_failure_reasons.py
+++ b/tests/test_transform_failure_reasons.py
@@ -1,0 +1,336 @@
+"""A failed transform has to say what failed, and why.
+
+Every failing ontology used to land in onto_stats.yaml with the same string:
+
+    - id: FYPO
+      status: Failed
+      reason: transform_error
+
+so auditing 66 failures meant reconstructing the stage from half a million lines
+of Actions logs, which GitHub expires (#134). These tests drive a transform to
+its knees at each stage in turn and assert that the stats say which one, and
+carry the message that stage gave.
+"""
+
+import os
+import tempfile
+from unittest import TestCase, mock
+
+import yaml
+
+from kg_bioportal.robot_utils import RobotResult, _error_text
+from kg_bioportal.transformer import (
+    MAX_DETAIL_CHARS,
+    TRANSFORM_STAGES,
+    SourceTooLarge,
+    TransformOutcome,
+    Transformer,
+    TransformTimeout,
+    reason_for_stage,
+    summarize_detail,
+)
+
+RDFXML = """<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#">
+  <owl:Ontology rdf:about="http://example.org/onto"/>
+</rdf:RDF>
+"""
+
+CONVERT_ERROR = (
+    "java.lang.IllegalArgumentException: org.semanticweb.owlapi.model."
+    "UnloadableImportException: Could not load imported ontology: "
+    "<http://purl.example.org/dead.owl>"
+)
+RELAX_ERROR = "org.semanticweb.owlapi.model.OWLOntologyStorageException: ONTOLOGY STORAGE ERROR"
+
+
+class FakeKGXTransformer:
+    """Writes the TSVs KGX would, or raises what KGX would."""
+
+    raises = None
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def transform(self, input_args, output_args):
+        if type(self).raises is not None:
+            raise type(self).raises
+        for suffix in ("_nodes.tsv", "_edges.tsv"):
+            with open(output_args["filename"] + suffix, "w") as f:
+                f.write("id\n")
+
+
+class TransformFailureTestCase(TestCase):
+    """Drives Transformer with ROBOT and KGX faked, one stage failing at a time."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.input_dir = os.path.join(self._tmp.name, "raw")
+        self.output_dir = os.path.join(self._tmp.name, "transformed")
+        os.makedirs(self.output_dir, exist_ok=True)
+
+        self.txr = Transformer.__new__(Transformer)
+        self.txr.input_dir = self.input_dir
+        self.txr.output_dir = self.output_dir
+        self.txr.timeout_sec = 60
+        self.txr.timeout_min = 1
+        self.txr.max_source_bytes = 0
+        self.txr.robot_path = "/nonexistent/robot"
+        self.txr.robot_env = {}
+
+        self.source = os.path.join(self.input_dir, "ONTO", "1", "onto.owl")
+        os.makedirs(os.path.dirname(self.source), exist_ok=True)
+        with open(self.source, "w") as f:
+            f.write(RDFXML)
+
+        FakeKGXTransformer.raises = None
+
+    def run_transform(self, convert=None, relax=None, kgx_raises=None, all_at_once=False):
+        """Run one ontology through, with the named stage rigged to fail.
+
+        `convert` and `relax` take a RobotResult; None means "succeed and write
+        the file the step would have".
+        """
+        def writer(result):
+            def run(**kwargs):
+                if result is not None and not result.ok:
+                    return result
+                os.makedirs(os.path.dirname(kwargs["output_path"]), exist_ok=True)
+                with open(kwargs["output_path"], "w") as f:
+                    f.write(RDFXML)
+                return RobotResult(True)
+            return run
+
+        FakeKGXTransformer.raises = kgx_raises
+        with mock.patch("kg_bioportal.transformer.robot_convert", writer(convert)), \
+             mock.patch("kg_bioportal.transformer.robot_relax", writer(relax)), \
+             mock.patch("kg_bioportal.transformer.KGXTransformer", FakeKGXTransformer):
+            if all_at_once:
+                self.txr.transform_all(compress=False)
+                return None
+            return self.txr.transform(self.source, compress=False)
+
+    def stats(self):
+        """The ONTO entry of the onto_stats.yaml just written."""
+        with open(os.path.join(self.output_dir, "onto_stats.yaml")) as f:
+            data = yaml.safe_load(f)
+        by_id = {o["id"]: o for o in data["ontologies"]}
+        self.assertIn("ONTO", by_id, "the ontology is missing from the stats")
+        return by_id["ONTO"]
+
+
+class TestStageIsRecorded(TransformFailureTestCase):
+    def test_convert_failure_names_the_convert_stage(self):
+        outcome = self.run_transform(convert=RobotResult(False, CONVERT_ERROR))
+        self.assertFalse(outcome.success)
+        self.assertEqual(outcome.stage, "convert")
+
+    def test_relax_failure_names_the_relax_stage(self):
+        outcome = self.run_transform(relax=RobotResult(False, RELAX_ERROR))
+        self.assertFalse(outcome.success)
+        self.assertEqual(outcome.stage, "relax")
+
+    def test_kgx_failure_names_the_kgx_stage(self):
+        outcome = self.run_transform(kgx_raises=TypeError(
+            "'<' not supported between instances of 'str' and 'int'"))
+        self.assertFalse(outcome.success)
+        self.assertEqual(outcome.stage, "kgx")
+
+    def test_decompress_failure_names_the_decompress_stage(self):
+        archive = os.path.join(self.input_dir, "ONTO", "1", "onto.owl.gz")
+        with open(archive, "wb") as f:
+            f.write(b"not actually gzipped")
+        outcome = self.txr.transform(archive, compress=False)
+        self.assertFalse(outcome.success)
+        self.assertEqual(outcome.stage, "decompress")
+
+    def test_a_kgx_constructor_failure_is_recorded_not_raised(self):
+        # Building the transformer is part of the KGX stage; an exception
+        # escaping here would end the shard, not just this ontology.
+        class ExplodingKGX:
+            def __init__(self, *args, **kwargs):
+                raise RuntimeError("kgx would not start")
+
+        def writer(**kwargs):
+            os.makedirs(os.path.dirname(kwargs["output_path"]), exist_ok=True)
+            with open(kwargs["output_path"], "w") as f:
+                f.write(RDFXML)
+            return RobotResult(True)
+
+        with mock.patch("kg_bioportal.transformer.robot_convert", writer), \
+             mock.patch("kg_bioportal.transformer.robot_relax", writer), \
+             mock.patch("kg_bioportal.transformer.KGXTransformer", ExplodingKGX):
+            outcome = self.txr.transform(self.source, compress=False)
+        self.assertEqual(outcome.stage, "kgx")
+        self.assertIn("kgx would not start", outcome.detail)
+
+    def test_a_successful_transform_has_no_stage_or_detail(self):
+        outcome = self.run_transform()
+        self.assertTrue(outcome.success)
+        self.assertEqual(outcome.stage, "")
+        self.assertEqual(outcome.detail, "")
+
+
+class TestDetailIsCarried(TransformFailureTestCase):
+    def test_robot_error_text_reaches_the_outcome(self):
+        outcome = self.run_transform(convert=RobotResult(False, CONVERT_ERROR))
+        self.assertIn("UnloadableImportException", outcome.detail)
+        self.assertIn("purl.example.org/dead.owl", outcome.detail)
+
+    def test_kgx_exception_reaches_the_outcome(self):
+        outcome = self.run_transform(kgx_raises=TypeError(
+            "'<' not supported between instances of 'str' and 'int'"))
+        self.assertIn("not supported between instances", outcome.detail)
+
+    def test_an_exception_with_no_message_still_says_its_type(self):
+        outcome = self.run_transform(kgx_raises=RecursionError())
+        self.assertIn("RecursionError", outcome.detail)
+
+
+class TestStatsFileRecordsIt(TransformFailureTestCase):
+    """The point of the exercise: reading a run is a grep of onto_stats.yaml."""
+
+    def test_convert_failure_is_written_to_onto_stats(self):
+        self.run_transform(convert=RobotResult(False, CONVERT_ERROR), all_at_once=True)
+        entry = self.stats()
+        self.assertEqual(entry["status"], "Failed")
+        self.assertEqual(entry["reason"], "transform_error_convert")
+        self.assertIn("UnloadableImportException", entry["detail"])
+
+    def test_kgx_failure_is_written_to_onto_stats(self):
+        self.run_transform(kgx_raises=ValueError("bad literal"), all_at_once=True)
+        entry = self.stats()
+        self.assertEqual(entry["reason"], "transform_error_kgx")
+        self.assertIn("bad literal", entry["detail"])
+
+    def test_every_reason_still_greps_as_a_transform_error(self):
+        # Whatever the stage, the coarse grouping the old string gave is intact.
+        for stage in TRANSFORM_STAGES:
+            self.assertTrue(reason_for_stage(stage).startswith("transform_error"))
+
+    def test_a_stageless_failure_keeps_the_old_reason(self):
+        self.assertEqual(reason_for_stage(""), "transform_error")
+
+    def test_successful_transforms_carry_no_detail_field(self):
+        self.run_transform(all_at_once=True)
+        entry = self.stats()
+        self.assertEqual(entry["status"], "OK")
+        self.assertNotIn("detail", entry)
+
+    def test_the_stats_file_is_still_valid_yaml_with_a_robot_error_in_it(self):
+        # ROBOT errors carry colons, angle brackets and quotes; a detail field
+        # that broke the YAML would take the whole index down with it.
+        self.run_transform(convert=RobotResult(
+            False, 'ERROR: could not load <http://x/y#z>: "bad" value @ line 1'),
+            all_at_once=True)
+        self.assertIn("could not load", self.stats()["detail"])
+
+
+class TestSkipsAlsoExplainThemselves(TransformFailureTestCase):
+    """A deliberate skip keeps its own reason, and says what the limit was.
+
+    These are not transform_error and must not be relabelled as one -- nothing
+    about them is broken -- but "too_slow" alone doesn't say slower than what.
+    """
+
+    def run_with(self, exception):
+        with mock.patch.object(Transformer, "transform", side_effect=exception):
+            self.txr.transform_all(compress=False)
+        return self.stats()
+
+    def test_a_timeout_stays_too_slow_and_names_the_limit(self):
+        entry = self.run_with(TransformTimeout())
+        self.assertEqual(entry["status"], "Skipped")
+        self.assertEqual(entry["reason"], "too_slow")
+        self.assertIn("1 min", entry["detail"])
+
+    def test_an_oversized_source_stays_too_large_and_names_the_size(self):
+        entry = self.run_with(SourceTooLarge("ONTO unpacks to 141.0 MB (> 100 MB limit)"))
+        self.assertEqual(entry["status"], "Skipped")
+        self.assertEqual(entry["reason"], "too_large")
+        self.assertIn("141.0 MB", entry["detail"])
+
+
+class TestDetailSummary(TestCase):
+    def test_a_multiline_message_becomes_one_line(self):
+        self.assertEqual(summarize_detail("first line\n  second line\n"), "first line second line")
+
+    def test_a_long_message_is_truncated(self):
+        detail = summarize_detail("x" * (MAX_DETAIL_CHARS * 2))
+        self.assertLessEqual(len(detail), MAX_DETAIL_CHARS)
+        self.assertTrue(detail.endswith("..."))
+
+    def test_a_short_message_is_left_alone(self):
+        self.assertEqual(summarize_detail("ONTOLOGY STORAGE ERROR"), "ONTOLOGY STORAGE ERROR")
+
+    def test_an_exception_can_be_passed_directly(self):
+        self.assertEqual(summarize_detail(ValueError("nope")), "nope")
+
+
+class FakeShError(Exception):
+    """Stands in for sh.ErrorReturnCode, which carries stdout/stderr as bytes."""
+
+    def __init__(self, stderr, message="RAN: robot convert ... (the whole blob)"):
+        super().__init__(message)
+        self.stderr = stderr.encode() if isinstance(stderr, str) else stderr
+
+
+# Verbatim from ROBOT 1.9.6 (an unresolvable import), stack frames included.
+ROBOT_STDERR = """java.lang.IllegalArgumentException: org.semanticweb.owlapi.model.\
+UnloadableImportException: Could not load imported ontology: <http://x.invalid/dead.owl>
+	at org.obolibrary.robot.CommandLineHelper.updateInputOntology(CommandLineHelper.java:585)
+	at org.obolibrary.robot.ConvertCommand.execute(ConvertCommand.java:130)
+Caused by: org.semanticweb.owlapi.model.UnloadableImportException: Could not load
+	... 6 more
+"""
+
+
+class TestRobotErrorText(TestCase):
+    """What gets pulled out of a ROBOT failure decides whether the stats help."""
+
+    def test_the_exception_line_is_picked(self):
+        detail = _error_text(FakeShError(ROBOT_STDERR))
+        self.assertIn("UnloadableImportException", detail)
+        self.assertIn("x.invalid/dead.owl", detail)
+
+    def test_stack_frames_are_not_picked(self):
+        self.assertNotIn("at org.obolibrary", _error_text(FakeShError(ROBOT_STDERR)))
+
+    def test_jvm_preamble_is_skipped(self):
+        # A runner with JAVA_TOOL_OPTIONS set prints a line to stderr before
+        # ROBOT runs at all; taking it would bury the actual error.
+        noisy = ("Picked up JAVA_TOOL_OPTIONS: -Dhttps.proxyHost=127.0.0.1\n"
+                 "SLF4J: Defaulting to no-operation (NOP) logger implementation\n"
+                 + ROBOT_STDERR)
+        detail = _error_text(FakeShError(noisy))
+        self.assertNotIn("Picked up", detail)
+        self.assertNotIn("SLF4J", detail)
+        self.assertIn("UnloadableImportException", detail)
+
+    def test_a_message_with_no_throwable_still_comes_through(self):
+        self.assertEqual(_error_text(FakeShError("something went sideways\n")),
+                         "something went sideways")
+
+    def test_empty_stderr_falls_back_to_the_exception(self):
+        self.assertIn("RAN: robot convert", _error_text(FakeShError("")))
+
+    def test_an_exception_without_stderr_at_all_is_handled(self):
+        self.assertEqual(_error_text(ValueError("plain old exception")),
+                         "plain old exception")
+
+    def test_the_text_is_capped(self):
+        self.assertLessEqual(len(_error_text(FakeShError("Error: " + "x" * 5000))), 500)
+
+
+class TestOutcomeContract(TestCase):
+    def test_a_failure_carries_no_counts(self):
+        outcome = TransformOutcome.failed("kgx", "boom")
+        self.assertFalse(outcome.success)
+        self.assertEqual((outcome.nodecount, outcome.edgecount), (0, 0))
+
+    def test_robot_result_is_truthy_only_when_ok(self):
+        # transform() tests these with `if not ...`, as it did when they were bools.
+        self.assertTrue(RobotResult(True))
+        self.assertFalse(RobotResult(False, "boom"))

--- a/tests/test_transform_imports.py
+++ b/tests/test_transform_imports.py
@@ -132,8 +132,7 @@ class TestKGXInputIsImportFree(TransformImportsTestCase):
         self.assertTrue(path.endswith("ONTO_relaxed.owl"), path)
 
     def test_transform_still_succeeds(self):
-        success, _, _ = self.run_transform(RELAXED_WITH_IMPORTS)
-        self.assertTrue(success)
+        self.assertTrue(self.run_transform(RELAXED_WITH_IMPORTS).success)
 
 
 class TestIntermediateCleanup(TransformImportsTestCase):


### PR DESCRIPTION
Fixes #134. Recovers nothing directly; makes every other fix in #133 verifiable from `onto_stats.yaml` instead of from logs that expire.

## The problem

Every failing ontology carried the same string:

```yaml
- id: FYPO
  status: Failed
  reason: transform_error
```

So the #133 audit meant pulling ~540k lines of Actions logs across 20 shard jobs and reconstructing, per ontology, which of `decompress` / `convert` / `relax` / KGX had died and why — work that doesn't survive log retention, and that `gh run view --log` already couldn't do reliably (one shard's output was missing entirely).

## The change

`Transformer.transform` returns a `TransformOutcome` carrying the stage and message alongside the counts; `robot_convert` / `robot_relax` return a `RobotResult` carrying ROBOT's error text instead of dropping it on the floor. The stats gain:

```yaml
- id: GARBAGE
  status: Failed
  reason: transform_error_convert
  detail: 'java.lang.IllegalArgumentException: java.io.IOException: errors#INVALID
    ONTOLOGY FILE ERROR Could not load a valid ontology from file: onto.owl'
```

`reason` is `transform_error_<stage>` for `decompress`, `convert`, `relax`, `kgx` — it still greps as `transform_error`, and a failure with no stage recorded still reads exactly `transform_error`, so nothing reading the index breaks. (The issue sketched `decompress_error` for that one stage; I kept the uniform prefix so one grep still finds every transform failure.) `detail` is on one line, capped at 500 characters, and written only for entries that have something to explain.

**Getting the useful line out of ROBOT takes some care.** ROBOT writes its `-vvv` log to stdout and the failure to stderr, where one line carries the exception and its whole cause chain; above it the JVM and SLF4J clear their throat, below it is a stack trace through OWL API internals that names nothing about the ontology. The extractor skips both and prefers the line naming a throwable. This was worth checking against the real thing: on a runner with `JAVA_TOOL_OPTIONS` set, the JVM's own line comes first, and taking it buried the error the field exists to carry.

## Two things found while wiring this up

Both are "record it instead of dying", which is what the issue asks for:

- `robot_convert` / `robot_relax` caught `ErrorReturnCode_1` only, so **any other nonzero exit propagated and took the whole shard down**. They catch the base class now. `SignalException` subclasses it, so the SIGKILL branch has to come first — otherwise an OOM kill reads as an ordinary exit and reports a stderr the killed process never got to write.
- The KGX transformer was **constructed outside the `try`** that guards the KGX stage, so an exception there ended the shard rather than costing one ontology.

Also switches this module's `print()` calls to `logging`, per the issue: block-buffered stdout landed out of order against the log lines, which is exactly why matching a ROBOT stderr to its ontology needed job-local ordering reconstructed by hand.

## Everything downstream

- **Site**: each new reason gets its own message (the plain `transform_error` stays, for entries seeded from earlier releases), and a failed ontology's page shows the detail, escaped.
- **Merge**: `merge_stats.py` carries both fields through the shard merge and a fresh failure replaces a seeded one — now under test.
- **Skips**: `too_slow` and `too_large` keep their own reasons (nothing about them is broken) and now say which limit they hit.
- **Docs**: the `onto_stats.yaml` schema reference is updated.

## Verification

Real ROBOT 1.9.6 over a mixed set, driven through `transform_all`:

| Source | reason | detail |
|---|---|---|
| Not an ontology | `transform_error_convert` | the `IllegalArgumentException` naming the file |
| `.gz` that isn't gzipped | `transform_error_decompress` | `could not decompress onto.owl.gz` |
| Dead `owl:imports` | `OK` | — (stripped, per #138) |
| Clean ontology | `OK` | — |

40 new unit tests cover each stage, the detail extraction (including JVM preamble, stack frames, an exception with no message, and the length cap), the YAML surviving a ROBOT error full of colons and angle brackets, the merge pass-through, and the site rendering. Full suite: 195 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JM47TqJy5r9R2T2FgcWJhM)_