### PR TITLE
Stop ROBOT handing the next step a file XML cannot represent

### DIFF
--- a/src/kg_bioportal/robot_utils.py
+++ b/src/kg_bioportal/robot_utils.py
@@ -58,6 +58,24 @@ _THROWABLE = re.compile(r"\b[\w.$]*(?:Exception|Error|ERROR)\b")
 _MAX_ERROR_LINES = 200
 
 
+def _output_written(output_path: str) -> str:
+    """Why a ROBOT command's output is unusable, or "" if it is fine.
+
+    A command that exits 0 having written nothing is not a success, and saying
+    so here keeps the blame with the step that produced the file rather than the
+    next one to read it (#141). It is not hypothetical that the next step would
+    swallow it: ROBOT reads a zero-byte file as a valid *empty* ontology, so an
+    empty intermediate transforms all the way to a graph with nothing in it.
+    """
+    if not os.path.exists(output_path):
+        return (f"ROBOT exited cleanly but wrote no output file "
+                f"({os.path.basename(output_path)})")
+    if os.path.getsize(output_path) == 0:
+        return (f"ROBOT exited cleanly but wrote an empty output file "
+                f"({os.path.basename(output_path)})")
+    return ""
+
+
 def _error_text(e: Exception) -> str:
     """The line of a ROBOT failure worth keeping.
 
@@ -162,6 +180,10 @@ def robot_relax(
             _timeout=timeout,
         )
         logging.info("Complete.")
+        unusable = _output_written(output_path)
+        if unusable:
+            logging.error(unusable)
+            return RobotResult(False, unusable)
         return RobotResult(True)
     # SignalException subclasses ErrorReturnCode, so it has to be caught first
     # or a kill reads as an ordinary nonzero exit and reports a stderr that a
@@ -215,6 +237,10 @@ def robot_convert(
             _timeout=timeout,
         )
         logging.info("Complete.")
+        unusable = _output_written(output_path)
+        if unusable:
+            logging.error(unusable)
+            return RobotResult(False, unusable)
         return RobotResult(True)
     # SignalException subclasses ErrorReturnCode, so it has to be caught first
     # or a kill reads as an ordinary nonzero exit and reports a stderr that a

--- a/src/kg_bioportal/transformer.py
+++ b/src/kg_bioportal/transformer.py
@@ -430,6 +430,69 @@ def strip_imports(path: str) -> str:
     return new_path
 
 
+# XML 1.0 forbids the C0 control characters outright -- only tab, newline and
+# carriage return are allowed -- and U+FFFE / U+FFFF are never legal either.
+# Nothing escapes them: not a character reference, not CDATA. A document holding
+# one cannot be parsed, whatever wrote it.
+_XML_ILLEGAL_CHARS = re.compile("[\x00-\x08\x0b\x0c\x0e-\x1f\ufffe\uffff]")
+
+# The two that are whitespace by origin. A vertical tab or form feed sits
+# between words -- they arrive in definitions pasted out of PDFs -- so a space
+# keeps the text as it read; dropping it would run the words together.
+_ILLEGAL_AS_SPACE = "\x0b\x0c"
+
+
+def strip_xml_illegal_chars(path: str, ontology_name: str = "") -> str:
+    """Remove characters XML cannot represent from an ontology file.
+
+    This is what makes ``robot relax`` fail to load the file ``robot convert``
+    just wrote (#141). A control character is perfectly legal in the source: in
+    Turtle it is written as an escape (``\\u0001``), and ROBOT parses it happily.
+    On the way out, though, ROBOT unescapes it and writes the raw character into
+    RDF/XML -- ``<rdfs:label>bad\x01char</rdfs:label>`` -- which no XML parser
+    will read back. ``convert`` exits 0, and ``relax`` takes the blame for an
+    unusable intermediate it did not produce.
+
+    So this runs over ROBOT's output rather than the source: by then whatever the
+    source encoded is raw text, and it is the only point where both spellings of
+    the problem look the same.
+
+    Args:
+        path: Path to the RDF/XML ROBOT wrote.
+        ontology_name: Acronym, used only to make the log line actionable.
+
+    Returns:
+        Path to use for the next step (cleaned copy, or the original).
+    """
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            text = f.read()
+    except OSError as e:
+        logging.warning(f"Could not read {path} to check for illegal characters: {e}")
+        return path
+
+    found = _XML_ILLEGAL_CHARS.findall(text)
+    if not found:
+        return path
+
+    cleaned = _XML_ILLEGAL_CHARS.sub(
+        lambda m: " " if m.group() in _ILLEGAL_AS_SPACE else "", text
+    )
+
+    base, ext = os.path.splitext(path)
+    new_path = f"{base}_xmlsafe{ext or '.owl'}"
+    with open(new_path, "w", encoding="utf-8") as f:
+        f.write(cleaned)
+
+    label = ontology_name or os.path.basename(path)
+    seen = sorted({f"U+{ord(c):04X}" for c in found})
+    logging.warning(
+        f"{label}: removed {len(found)} character(s) XML cannot represent "
+        f"({', '.join(seen)}); they would have made ROBOT's own output unreadable."
+    )
+    return new_path
+
+
 # An xml:lang attribute in either XML serialization, single- or double-quoted.
 _XML_LANG_ATTR = re.compile(r"""\s+xml:lang\s*=\s*(["'])(.*?)\1""", re.S)
 
@@ -992,11 +1055,15 @@ class Transformer:
         if not converted:
             return TransformOutcome.failed("convert", converted.error)
 
+        # ROBOT can write a character into its own output that no XML parser will
+        # read back, so `relax` fails on a file `convert` exited 0 over (#141).
+        relax_input_path = strip_xml_illegal_chars(owl_output_path, ontology_name)
+
         # Relax
         relaxed_outpath = os.path.join(workdir, f"{ontology_name}_relaxed.owl")
         relaxed = robot_relax(
             robot_path=self.robot_path,
-            input_path=owl_output_path,
+            input_path=relax_input_path,
             output_path=relaxed_outpath,
             robot_env=self.robot_env,
             timeout=self.timeout_sec,
@@ -1069,6 +1136,7 @@ class Transformer:
             # They may not exist if the transform failed
             for path in (
                 owl_output_path,
+                relax_input_path,
                 relaxed_outpath,
                 stripped_path,
                 kgx_input_path,

--- a/tests/test_strip_xml_illegal_chars.py
+++ b/tests/test_strip_xml_illegal_chars.py
@@ -1,0 +1,290 @@
+"""ROBOT must not hand the next step a file no XML parser can read.
+
+`robot convert` exits 0, prints "Complete.", and `robot relax` then cannot load
+the file it just wrote (#141). The cause is a character XML forbids: legal in
+the source, where Turtle spells it as an escape (\\u0001), and raw in the RDF/XML
+ROBOT writes back out. Verified against ROBOT 1.9.6 -- convert exit 0, a 964-byte
+output holding `<rdfs:label>bad\\x01char</rdfs:label>`, relax exit 1 with
+"INVALID ONTOLOGY FILE ERROR Could not load a valid ontology from file".
+
+These tests cover the sanitizer that runs over ROBOT's output, and the
+post-condition that stops a command claiming success over an unusable file.
+"""
+
+import os
+import shutil
+import tempfile
+from unittest import TestCase, mock
+from xml.etree import ElementTree
+
+from kg_bioportal.robot_utils import RobotResult, _output_written, robot_convert
+from kg_bioportal.transformer import Transformer, strip_xml_illegal_chars
+
+RDFXML = """<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+  <owl:Ontology rdf:about="http://example.org/onto"/>
+  <owl:Class rdf:about="http://example.org/ns#A">
+    <rdfs:label>{label}</rdfs:label>
+  </owl:Class>
+</rdf:RDF>
+"""
+
+
+class StripIllegalCharsTestCase(TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+
+    def write(self, name, text):
+        path = os.path.join(self._tmp.name, name)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(text)
+        return path
+
+    def clean(self, label, name="ONTO.owl"):
+        """Sanitize a document carrying `label`, and return (path, text)."""
+        path = self.write(name, RDFXML.format(label=label))
+        out = strip_xml_illegal_chars(path, "ONTO")
+        with open(out, encoding="utf-8") as f:
+            return out, f.read()
+
+    def assert_parses(self, text):
+        """The whole point: an XML parser must be able to read it back."""
+        try:
+            ElementTree.fromstring(text)
+        except ElementTree.ParseError as e:
+            self.fail(f"cleaned document still does not parse: {e}")
+
+
+class TestIllegalCharactersAreRemoved(StripIllegalCharsTestCase):
+    def test_the_document_does_not_parse_before_the_fix(self):
+        # Establishes that the fixture reproduces the problem, so the tests
+        # below are not asserting against an already-valid document.
+        with self.assertRaises(ElementTree.ParseError):
+            ElementTree.fromstring(RDFXML.format(label="bad\x01char"))
+
+    def test_a_control_character_is_removed(self):
+        out, text = self.clean("bad\x01char")
+        self.assertNotEqual(out, os.path.join(self._tmp.name, "ONTO.owl"))
+        self.assertNotIn("\x01", text)
+        self.assert_parses(text)
+
+    def test_the_rest_of_the_label_survives(self):
+        _, text = self.clean("bad\x01char")
+        self.assertIn("badchar", text)
+
+    def test_a_form_feed_becomes_a_space(self):
+        # A form feed sits between words -- dropping it would join them.
+        _, text = self.clean("page\x0cbreak")
+        self.assertIn("page break", text)
+        self.assert_parses(text)
+
+    def test_a_vertical_tab_becomes_a_space(self):
+        _, text = self.clean("line\x0bbreak")
+        self.assertIn("line break", text)
+
+    def test_every_occurrence_goes_not_just_the_first(self):
+        _, text = self.clean("a\x01b\x02c\x1fd")
+        self.assertIn("abcd", text)
+        self.assert_parses(text)
+
+    def test_the_whole_forbidden_range_is_covered(self):
+        forbidden = (
+            [chr(c) for c in range(0x00, 0x09)]
+            + ["\x0b", "\x0c"]
+            + [chr(c) for c in range(0x0e, 0x20)]
+            + ["￾", "￿"]
+        )
+        for char in forbidden:
+            with self.subTest(char=f"U+{ord(char):04X}"):
+                _, text = self.clean(f"a{char}b", name=f"O{ord(char)}.owl")
+                self.assertNotIn(char, text)
+                self.assert_parses(text)
+
+    def test_the_ontology_is_otherwise_untouched(self):
+        _, text = self.clean("bad\x01char")
+        self.assertIn("http://example.org/onto", text)
+        self.assertIn("http://example.org/ns#A", text)
+
+    def test_the_original_file_is_left_alone(self):
+        path = self.write("ONTO.owl", RDFXML.format(label="bad\x01char"))
+        strip_xml_illegal_chars(path, "ONTO")
+        with open(path, encoding="utf-8") as f:
+            self.assertIn("\x01", f.read())
+
+
+class TestWhatIsLeftAlone(StripIllegalCharsTestCase):
+    """Characters XML does allow must survive: this runs over every ontology."""
+
+    def test_a_clean_document_is_passed_through_untouched(self):
+        path = self.write("ONTO.owl", RDFXML.format(label="a normal label"))
+        self.assertEqual(strip_xml_illegal_chars(path, "ONTO"), path)
+
+    def test_tab_newline_and_carriage_return_are_kept(self):
+        path = self.write("ONTO.owl", RDFXML.format(label="a\tb\nc\rd"))
+        self.assertEqual(strip_xml_illegal_chars(path, "ONTO"), path)
+
+    def test_non_ascii_text_is_kept(self):
+        # Ontology labels are full of accents, Greek and CJK.
+        path = self.write("ONTO.owl", RDFXML.format(label="Ω café 表現 — naïve"))
+        self.assertEqual(strip_xml_illegal_chars(path, "ONTO"), path)
+
+    def test_c1_controls_are_kept(self):
+        # XML 1.0 permits these in content; removing them would be a change
+        # this fix has no reason to make.
+        path = self.write("ONTO.owl", RDFXML.format(label="a\x85b\x9fc"))
+        self.assertEqual(strip_xml_illegal_chars(path, "ONTO"), path)
+
+    def test_an_unreadable_path_returns_the_input(self):
+        missing = os.path.join(self._tmp.name, "nope.owl")
+        self.assertEqual(strip_xml_illegal_chars(missing, "ONTO"), missing)
+
+
+class TestOutputPostcondition(TestCase):
+    """A ROBOT command that exits 0 having written nothing has not succeeded.
+
+    ROBOT reads a zero-byte file as a valid empty ontology (checked against
+    1.9.6), so without this the next step accepts the empty intermediate and the
+    ontology transforms to a graph with nothing in it, recorded OK.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+
+    def path(self, name):
+        return os.path.join(self._tmp.name, name)
+
+    def test_a_missing_output_is_a_failure(self):
+        problem = _output_written(self.path("ONTO.owl"))
+        self.assertIn("no output file", problem)
+        self.assertIn("ONTO.owl", problem)
+
+    def test_an_empty_output_is_a_failure(self):
+        path = self.path("ONTO.owl")
+        open(path, "w").close()
+        self.assertIn("empty output file", _output_written(path))
+
+    def test_a_written_output_is_fine(self):
+        path = self.path("ONTO.owl")
+        with open(path, "w") as f:
+            f.write(RDFXML.format(label="A"))
+        self.assertEqual(_output_written(path), "")
+
+    def test_the_problem_reads_as_a_robot_failure(self):
+        # It travels as the RobotResult error, so it lands in onto_stats as
+        # transform_error_convert rather than being blamed on the next step.
+        result = RobotResult(False, _output_written(self.path("ONTO.owl")))
+        self.assertFalse(result)
+        self.assertIn("ROBOT exited cleanly", result.error)
+
+
+class TestRelaxIsHandedACleanFile(TestCase):
+    """The pipeline has to sanitize between the two ROBOT steps, not after.
+
+    `relax` is the step that fails, so cleaning up afterwards would be too late.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.input_dir = os.path.join(self._tmp.name, "raw")
+        self.output_dir = os.path.join(self._tmp.name, "transformed")
+
+        self.txr = Transformer.__new__(Transformer)
+        self.txr.input_dir = self.input_dir
+        self.txr.output_dir = self.output_dir
+        self.txr.timeout_sec = 60
+        self.txr.timeout_min = 1
+        self.txr.max_source_bytes = 0
+        self.txr.robot_path = "/nonexistent/robot"
+        self.txr.robot_env = {}
+
+        self.source = os.path.join(self.input_dir, "ONTO", "1", "onto.owl")
+        os.makedirs(os.path.dirname(self.source), exist_ok=True)
+        with open(self.source, "w") as f:
+            f.write(RDFXML.format(label="A"))
+
+        self.relax_saw = {}
+
+    def run_transform(self, convert_writes):
+        """Drive transform() with ROBOT faked; convert writes `convert_writes`."""
+        def fake_convert(**kwargs):
+            os.makedirs(os.path.dirname(kwargs["output_path"]), exist_ok=True)
+            with open(kwargs["output_path"], "w", encoding="utf-8") as f:
+                f.write(convert_writes)
+            return RobotResult(True)
+
+        def fake_relax(**kwargs):
+            with open(kwargs["input_path"], encoding="utf-8") as f:
+                self.relax_saw["path"] = kwargs["input_path"]
+                self.relax_saw["text"] = f.read()
+            with open(kwargs["output_path"], "w", encoding="utf-8") as f:
+                f.write(RDFXML.format(label="A"))
+            return RobotResult(True)
+
+        class FakeKGX:
+            def __init__(self, *a, **k):
+                pass
+
+            def transform(self, input_args, output_args):
+                for suffix in ("_nodes.tsv", "_edges.tsv"):
+                    with open(output_args["filename"] + suffix, "w") as fh:
+                        fh.write("id\n")
+
+        with mock.patch("kg_bioportal.transformer.robot_convert", fake_convert), \
+             mock.patch("kg_bioportal.transformer.robot_relax", fake_relax), \
+             mock.patch("kg_bioportal.transformer.KGXTransformer", FakeKGX):
+            return self.txr.transform(self.source, compress=False)
+
+    def test_relax_never_sees_the_illegal_character(self):
+        self.run_transform(RDFXML.format(label="bad\x01char"))
+        self.assertNotIn("\x01", self.relax_saw["text"])
+        ElementTree.fromstring(self.relax_saw["text"])  # must parse
+
+    def test_relax_is_given_the_cleaned_file(self):
+        self.run_transform(RDFXML.format(label="bad\x01char"))
+        self.assertTrue(self.relax_saw["path"].endswith("_xmlsafe.owl"),
+                        self.relax_saw["path"])
+
+    def test_a_clean_convert_output_is_passed_through_untouched(self):
+        # The common case: no rewrite, so this cannot perturb what builds today.
+        self.run_transform(RDFXML.format(label="A"))
+        self.assertTrue(self.relax_saw["path"].endswith("ONTO.owl"),
+                        self.relax_saw["path"])
+
+    def test_the_transform_succeeds(self):
+        self.assertTrue(self.run_transform(RDFXML.format(label="bad\x01char")).success)
+
+    def test_the_cleaned_intermediate_is_cleaned_up(self):
+        self.run_transform(RDFXML.format(label="bad\x01char"))
+        workdir = os.path.join(self.output_dir, "ONTO", "1")
+        leftovers = [f for f in os.listdir(workdir) if f.endswith(".owl")]
+        self.assertEqual(leftovers, [], f"OWL intermediates left behind: {leftovers}")
+
+
+class TestRobotCommandsCheckTheirOutput(TestCase):
+    """Wiring check: the post-condition is actually applied by the commands.
+
+    /bin/true stands in for a ROBOT that exits 0 and writes nothing -- which is
+    the whole failure mode, and needs no ROBOT to reproduce.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.true = shutil.which("true")
+        if not self.true:
+            self.skipTest("no `true` binary to stand in for ROBOT")
+
+    def test_convert_that_writes_nothing_reports_failure(self):
+        result = robot_convert(
+            robot_path=self.true,
+            input_path=os.path.join(self._tmp.name, "in.owl"),
+            output_path=os.path.join(self._tmp.name, "out.owl"),
+            robot_env={},
+        )
+        self.assertFalse(result, "a command that wrote no file claimed success")
+        self.assertIn("no output file", result.error)


### PR DESCRIPTION
Fixes #141. The repro the issue asked for, the cause, and the fix.

## What's actually happening

`robot convert` exits 0, prints `Complete.`, and `robot relax` cannot read the file it just wrote. The cause is **a character XML forbids**.

It is legal in the source — Turtle spells it as an escape (``), and ROBOT parses it happily. On the way out ROBOT unescapes it and writes the raw character into RDF/XML:

```xml
<rdfs:label>bad^Achar</rdfs:label>
```

No XML parser will read that back; neither would rdflib at the KGX step. `convert` can't see the problem because it never re-reads its own output, so `relax` takes the blame for an intermediate it did not produce — which is why all five land on `relax` across mixed input serializations. Control characters in labels and definitions are exactly what you get from text pasted out of PDFs and Word, which fits the affected set better than anything serialization-specific.

**Reproduced against ROBOT 1.9.6** — a label carrying `U+0001` or `U+000C`:

| step | result |
|---|---|
| `robot convert` | exit **0**, 964-byte output holding the raw character |
| `robot relax` | exit **1**, `INVALID ONTOLOGY FILE ERROR Could not load a valid ontology from file: …` |

That's the issue's symptom byte for byte. It reproduces identically whether the source escapes the character or carries it raw — both are raw by the time ROBOT writes.

**The issue's leading hypothesis does not hold.** A degenerate/empty `convert` output for the tiny sources: ROBOT writes valid RDF/XML for an empty input, for triples with no ontology header, and for an anonymous ontology IRI, and `relax` reads all three. Recorded so nobody re-runs that experiment.

## The fix

`strip_xml_illegal_chars` runs over **ROBOT's output, between the two steps** — the point where both spellings of the problem look the same, and the last point before the step that fails. Characters XML cannot represent are dropped, except vertical tab and form feed: those are whitespace by origin, so they become a space and the words either side stay apart (`page\x0cbreak` → `page break`). Only a file that actually carries one is rewritten; everything else is passed through untouched, byte for byte.

Scope is exactly what XML 1.0 forbids — `U+0000`–`U+0008`, `U+000B`, `U+000C`, `U+000E`–`U+001F`, `U+FFFE`, `U+FFFF`. Tab, newline and carriage return stay, and so do the C1 controls, which XML 1.0 permits in content.

## The post-condition, which the issue wanted regardless

A ROBOT command that exits 0 having written no file — or an empty one — now reports failure instead of passing an unusable artifact to the next step. Not hypothetical: **ROBOT reads a zero-byte file as a valid empty ontology**, so an empty intermediate would transform all the way to a graph with nothing in it, recorded `OK`. With #157's stage tracking in place, a failure of this shape now lands as `transform_error_convert` instead of being misfiled against `relax`.

## Verification

End to end with real ROBOT through `transform_all`, same input both ways:

| | `reason` | |
|---|---|---|
| before | `transform_error_relax` | `detail: java.lang.IllegalArgumentException: java.io.IOException: errors#INVALID ONTOLOGY FILE ERROR Could not load a valid ontology from file: CTRLTTL.owl` |
| after | — | `status: OK`, labels intact (`badchar`, `page break`) |

24 new tests: every character in the forbidden range (each one re-parsed with an XML parser to prove the document loads), what must be left alone (tab/newline/CR, non-ASCII, C1), the pipeline handing `relax` the cleaned file and cleaning the intermediate up afterwards, and the post-condition — including a wiring check that runs `robot_convert` against `/bin/true` as a stand-in for a ROBOT that exits 0 and writes nothing. Full suite: 219 passed.

**One caveat, stated plainly:** fetching the five real sources (ELD, INFRARISK, MOMCARE, OPD-NAMBOBI, G-PROV) needs a BioPortal API key, which this environment doesn't have. So this demonstrates the mechanism cured, not those five confirmed. If any of them is failing for a different reason, the next run now says which stage and why rather than the generic error — which is the issue's own fallback acceptance criterion.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JM47TqJy5r9R2T2FgcWJhM)_