### PR TITLE
Fall back to Turtle when RDF/XML cannot express an ontology

### DIFF
--- a/src/kg_bioportal/kgx_patches.py
+++ b/src/kg_bioportal/kgx_patches.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, Iterable, List, Optional
 _mixed_type_sorts = 0
 
 _patched = False
+_owl_format_patched = False
 
 
 def mixed_type_sort_count() -> int:
@@ -80,4 +81,69 @@ def patch_mixed_type_sorting() -> bool:
     kgx_utils.sorted = _safe_sorted
     _patched = True
     logging.debug("Patched kgx.utils.kgx_utils.sorted for mixed-type property values.")
+    return True
+
+
+def owl_source_format(filename: str, requested: Optional[str]) -> str:
+    """The rdflib format KGX should read ``filename`` with.
+
+    ``OwlSource.parse`` maps its default format ("owl") straight to "xml", so
+    KGX reads every file as RDF/XML whatever it actually is. That is fine until
+    RDF/XML cannot hold the ontology: three ontologies cannot be serialized to
+    it at all (#139), so their intermediate is Turtle, and KGX then tries to
+    read Turtle with an XML parser.
+
+    Resolving the format from the file name instead is a no-op for everything
+    that works today -- rdflib's own ``guess_format`` maps .owl to "xml", which
+    is exactly what the hardcoded value says -- and correct for the rest.
+
+    Args:
+        filename: The file KGX is about to parse.
+        requested: The format KGX was asked for; "owl" or None mean "work it out".
+
+    Returns:
+        An rdflib format name.
+    """
+    if requested not in (None, "owl"):
+        return requested  # an explicit format the caller meant; leave it alone
+
+    import rdflib.util
+
+    return rdflib.util.guess_format(filename) or "xml"
+
+
+def patch_owl_source_format() -> bool:
+    """Make KGX's OwlSource read a file in the format the file is actually in.
+
+    Wraps ``OwlSource.parse`` rather than reimplementing it: the format is
+    resolved on the way in, and everything else stays KGX's code, so the patch
+    holds across KGX versions and stops mattering once upstream stops hardcoding
+    the format.
+
+    Returns:
+        True if the patch was applied, False if it was already in place.
+    """
+    global _owl_format_patched
+    if _owl_format_patched:
+        return False
+
+    try:
+        from kgx.source.owl_source import OwlSource
+    except ImportError as e:
+        # A patch that cannot be applied has to leave the pipeline exactly as it
+        # found it. Raising here would run at import of the transformer and cost
+        # every ontology, to fix three.
+        logging.warning(f"Could not patch KGX's OwlSource format handling: {e}")
+        return False
+
+    original_parse = OwlSource.parse
+
+    def parse(self, filename: str, format: str = "owl", **kwargs: Any):
+        return original_parse(
+            self, filename, format=owl_source_format(filename, format), **kwargs
+        )
+
+    OwlSource.parse = parse
+    _owl_format_patched = True
+    logging.debug("Patched kgx.source.OwlSource.parse to honour the file's format.")
     return True

--- a/src/kg_bioportal/transformer.py
+++ b/src/kg_bioportal/transformer.py
@@ -22,12 +22,13 @@ from kg_bioportal.config import (
     PER_ONTOLOGY_TIMEOUT_MIN,
 )
 from kg_bioportal.downloader import DOWNLOAD_REPORT_NAME, ONTOLOGY_LIST_NAME
-from kg_bioportal.kgx_patches import patch_mixed_type_sorting
+from kg_bioportal.kgx_patches import patch_mixed_type_sorting, patch_owl_source_format
 from kg_bioportal.robot_utils import initialize_robot, robot_convert, robot_relax
 
 # Applied at import so it is in place for any use of the KGX transform, not just
 # the ones that go through Transformer. See kgx_patches for what and why.
 patch_mixed_type_sorting()
+patch_owl_source_format()
 
 # TODO: Don't repeat steps if the products already exist
 # TODO: Fix KGX hijacking logging
@@ -694,6 +695,28 @@ def pick_ontology_member(
     return sorted(ontology_files or candidates, key=rank)[0][0]
 
 
+# ROBOT errors that mean "the ontology loaded, but this serialization cannot
+# express it". The source is fine; RDF/XML is the problem -- most often an IRI
+# whose local part is not a legal XML element name, which RDF/XML has no way to
+# write. Both spellings ROBOT uses are here: it reports the failure to save as
+# ONTOLOGY STORAGE ERROR, and the offending IRI as INVALID ELEMENT ERROR.
+_SERIALIZATION_ERRORS = (
+    "ONTOLOGY STORAGE ERROR",
+    "INVALID ELEMENT ERROR",
+    "OWLOntologyStorageException",
+)
+
+# What to write instead when RDF/XML cannot hold the ontology. Turtle can write
+# any IRI (it falls back to <...>), and stays RDF all the way to the KGX step --
+# where OWL functional syntax would only move the same wall one step later.
+FALLBACK_SERIALIZATION = ".ttl"
+
+
+def is_serialization_failure(error: str) -> bool:
+    """Whether a ROBOT error is the output format's fault rather than the input's."""
+    return any(marker in error for marker in _SERIALIZATION_ERRORS)
+
+
 # How much of a failure message to keep in the stats. Long enough for a ROBOT
 # exception with its cause chain, short enough that onto_stats.yaml stays
 # readable with a few hundred failures in it.
@@ -1045,29 +1068,70 @@ class Transformer:
         ontology_path = strip_imports(ontology_path)
 
         # Convert
-        converted = robot_convert(
-            robot_path=self.robot_path,
-            input_path=ontology_path,
-            output_path=owl_output_path,
-            robot_env=self.robot_env,
-            timeout=self.timeout_sec,
-        )
+        def convert_to(output_path):
+            return robot_convert(
+                robot_path=self.robot_path,
+                input_path=ontology_path,
+                output_path=output_path,
+                robot_env=self.robot_env,
+                timeout=self.timeout_sec,
+            )
+
+        intermediate_path = owl_output_path
+        converted = convert_to(intermediate_path)
+        if not converted and is_serialization_failure(converted.error):
+            # The ontology loaded; RDF/XML just cannot write it back (#139).
+            # Nothing downstream requires this intermediate to be RDF/XML, so
+            # write the one serialization that can hold it.
+            logging.warning(
+                f"{ontology_name}: RDF/XML cannot express this ontology "
+                f"({converted.error}); retrying as {FALLBACK_SERIALIZATION}."
+            )
+            intermediate_path = os.path.join(
+                workdir, f"{ontology_name}{FALLBACK_SERIALIZATION}"
+            )
+            converted = convert_to(intermediate_path)
         if not converted:
             return TransformOutcome.failed("convert", converted.error)
 
         # ROBOT can write a character into its own output that no XML parser will
         # read back, so `relax` fails on a file `convert` exited 0 over (#141).
-        relax_input_path = strip_xml_illegal_chars(owl_output_path, ontology_name)
+        # Only XML has that problem, and only an XML file is worth rewriting for it.
+        intermediate_ext = os.path.splitext(intermediate_path)[1]
+        relax_input_path = intermediate_path
+        if intermediate_ext != FALLBACK_SERIALIZATION:
+            relax_input_path = strip_xml_illegal_chars(intermediate_path, ontology_name)
 
-        # Relax
-        relaxed_outpath = os.path.join(workdir, f"{ontology_name}_relaxed.owl")
-        relaxed = robot_relax(
-            robot_path=self.robot_path,
-            input_path=relax_input_path,
-            output_path=relaxed_outpath,
-            robot_env=self.robot_env,
-            timeout=self.timeout_sec,
+        # Relax. Its output is what KGX parses, so it keeps the serialization the
+        # ontology could actually be written in.
+        def relax_to(output_path):
+            return robot_relax(
+                robot_path=self.robot_path,
+                input_path=relax_input_path,
+                output_path=output_path,
+                robot_env=self.robot_env,
+                timeout=self.timeout_sec,
+            )
+
+        relaxed_outpath = os.path.join(
+            workdir, f"{ontology_name}_relaxed{intermediate_ext}"
         )
+        relaxed = relax_to(relaxed_outpath)
+        if (
+            not relaxed
+            and is_serialization_failure(relaxed.error)
+            and intermediate_ext != FALLBACK_SERIALIZATION
+        ):
+            # convert could write RDF/XML but relax cannot: same wall, one step
+            # later, and the same way through it.
+            logging.warning(
+                f"{ontology_name}: RDF/XML cannot express the relaxed ontology "
+                f"({relaxed.error}); retrying as {FALLBACK_SERIALIZATION}."
+            )
+            relaxed_outpath = os.path.join(
+                workdir, f"{ontology_name}_relaxed{FALLBACK_SERIALIZATION}"
+            )
+            relaxed = relax_to(relaxed_outpath)
         if not relaxed:
             return TransformOutcome.failed("relax", relaxed.error)
 
@@ -1135,7 +1199,7 @@ class Transformer:
             # Remove the owl files
             # They may not exist if the transform failed
             for path in (
-                owl_output_path,
+                intermediate_path,
                 relax_input_path,
                 relaxed_outpath,
                 stripped_path,

--- a/tests/test_serialization_fallback.py
+++ b/tests/test_serialization_fallback.py
@@ -1,0 +1,294 @@
+"""Some ontologies cannot be written as RDF/XML at all.
+
+ROBOT loads them fine and then cannot save them:
+
+    java.io.IOException: errors#ONTOLOGY STORAGE ERROR Could not save ontology
+    to IRI: file:/…/PHENX.owl
+
+RDF/XML cannot express an IRI whose local part is not a legal XML element name,
+and there is no escaping around it -- rdflib refuses the same graph with "no
+valid way to shorten". Turtle can write any IRI, and stays RDF all the way to
+the KGX step, so the intermediate falls back to it (#139).
+
+Checked against ROBOT 1.9.6, converting an ontology with the property IRI
+<http://example.org/prop/1>: to .owl exits 1 having written 0 bytes; to .ttl
+exits 0; and relax reads that Turtle and writes Turtle happily, while relax
+from Turtle to .owl hits the same wall again -- which is why the relaxed output
+keeps the fallback format rather than going back to RDF/XML.
+"""
+
+import os
+import tempfile
+from unittest import TestCase, mock
+
+from kg_bioportal import kgx_patches
+from kg_bioportal.robot_utils import RobotResult
+from kg_bioportal.transformer import (
+    FALLBACK_SERIALIZATION,
+    Transformer,
+    is_serialization_failure,
+)
+
+# Verbatim from the issue, and from ROBOT 1.9.6 respectively.
+STORAGE_ERROR = (
+    "java.io.IOException: errors#ONTOLOGY STORAGE ERROR Could not save ontology "
+    "to IRI: file:/home/runner/work/kg-bioportal/data/transformed/PHENX/16/PHENX.owl"
+)
+ELEMENT_ERROR = (
+    'java.io.IOException: errors#INVALID ELEMENT ERROR "http://example.org/prop/1" '
+    "contains invalid characters"
+)
+LOAD_ERROR = (
+    "java.lang.IllegalArgumentException: org.semanticweb.owlapi.model."
+    "UnloadableImportException: Could not load imported ontology: <http://dead/>"
+)
+
+RDFXML = """<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#">
+  <owl:Ontology rdf:about="http://example.org/onto"/>
+</rdf:RDF>
+"""
+
+
+class TestFailureClassification(TestCase):
+    """Only a write-side failure earns a retry; everything else fails as before."""
+
+    def test_storage_error_is_a_serialization_failure(self):
+        self.assertTrue(is_serialization_failure(STORAGE_ERROR))
+
+    def test_invalid_element_error_is_a_serialization_failure(self):
+        # ROBOT reports the same underlying problem this way when it can name
+        # the offending IRI.
+        self.assertTrue(is_serialization_failure(ELEMENT_ERROR))
+
+    def test_owlapi_storage_exception_is_a_serialization_failure(self):
+        self.assertTrue(is_serialization_failure(
+            "org.semanticweb.owlapi.model.OWLOntologyStorageException: nope"))
+
+    def test_a_load_failure_is_not(self):
+        # An unresolvable import is the source's problem; another format would
+        # fail identically, and retrying would just cost another ROBOT run.
+        self.assertFalse(is_serialization_failure(LOAD_ERROR))
+
+    def test_a_timeout_is_not(self):
+        self.assertFalse(is_serialization_failure("ROBOT convert timed out after 60s"))
+
+    def test_an_empty_error_is_not(self):
+        self.assertFalse(is_serialization_failure(""))
+
+
+class FallbackTestCase(TestCase):
+    """Drives transform() with ROBOT and KGX faked, recording what was asked for."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.input_dir = os.path.join(self._tmp.name, "raw")
+        self.output_dir = os.path.join(self._tmp.name, "transformed")
+
+        self.txr = Transformer.__new__(Transformer)
+        self.txr.input_dir = self.input_dir
+        self.txr.output_dir = self.output_dir
+        self.txr.timeout_sec = 60
+        self.txr.timeout_min = 1
+        self.txr.max_source_bytes = 0
+        self.txr.robot_path = "/nonexistent/robot"
+        self.txr.robot_env = {}
+
+        self.source = os.path.join(self.input_dir, "ONTO", "1", "onto.owl")
+        os.makedirs(os.path.dirname(self.source), exist_ok=True)
+        with open(self.source, "w") as f:
+            f.write(RDFXML)
+
+        self.convert_outputs = []
+        self.relax_outputs = []
+        self.kgx_input = None
+
+    def run_transform(self, convert_fails_on=(), relax_fails_on=(), error=STORAGE_ERROR):
+        """Run one ontology through; the named extensions fail to be written.
+
+        `convert_fails_on=(".owl",)` models an ontology RDF/XML cannot express.
+        """
+        def writer(record, failing):
+            def run(**kwargs):
+                out = kwargs["output_path"]
+                record.append(out)
+                if os.path.splitext(out)[1] in failing:
+                    return RobotResult(False, error)
+                os.makedirs(os.path.dirname(out), exist_ok=True)
+                with open(out, "w") as f:
+                    f.write(RDFXML)
+                return RobotResult(True)
+            return run
+
+        test = self
+
+        class FakeKGX:
+            def __init__(self, *a, **k):
+                pass
+
+            def transform(self, input_args, output_args):
+                test.kgx_input = input_args["filename"][0]
+                for suffix in ("_nodes.tsv", "_edges.tsv"):
+                    with open(output_args["filename"] + suffix, "w") as fh:
+                        fh.write("id\n")
+
+        with mock.patch("kg_bioportal.transformer.robot_convert",
+                        writer(self.convert_outputs, convert_fails_on)), \
+             mock.patch("kg_bioportal.transformer.robot_relax",
+                        writer(self.relax_outputs, relax_fails_on)), \
+             mock.patch("kg_bioportal.transformer.KGXTransformer", FakeKGX):
+            return self.txr.transform(self.source, compress=False)
+
+    def exts(self, paths):
+        return [os.path.splitext(p)[1] for p in paths]
+
+
+class TestNothingChangesForOntologiesThatWork(FallbackTestCase):
+    """1108 ontologies transform today; none of them may take a different path."""
+
+    def test_convert_is_asked_for_rdfxml_first(self):
+        self.run_transform()
+        self.assertEqual(self.exts(self.convert_outputs), [".owl"])
+
+    def test_a_working_ontology_never_retries(self):
+        outcome = self.run_transform()
+        self.assertTrue(outcome.success)
+        self.assertEqual(len(self.convert_outputs), 1)
+        self.assertEqual(len(self.relax_outputs), 1)
+
+    def test_the_relaxed_output_stays_rdfxml(self):
+        self.run_transform()
+        self.assertEqual(self.exts(self.relax_outputs), [".owl"])
+
+    def test_kgx_is_still_handed_rdfxml(self):
+        self.run_transform()
+        self.assertTrue(self.kgx_input.endswith(".owl"), self.kgx_input)
+
+    def test_a_load_failure_still_fails_without_a_retry(self):
+        outcome = self.run_transform(convert_fails_on=(".owl",), error=LOAD_ERROR)
+        self.assertEqual(outcome.stage, "convert")
+        self.assertEqual(len(self.convert_outputs), 1, "should not have retried")
+        self.assertIn("UnloadableImportException", outcome.detail)
+
+
+class TestFallbackWhenRdfXmlCannotHoldIt(FallbackTestCase):
+    def test_convert_retries_as_turtle(self):
+        self.run_transform(convert_fails_on=(".owl",))
+        self.assertEqual(self.exts(self.convert_outputs), [".owl", FALLBACK_SERIALIZATION])
+
+    def test_the_relaxed_output_keeps_the_fallback_format(self):
+        # Going back to RDF/XML here would hit the same wall one step later.
+        self.run_transform(convert_fails_on=(".owl",))
+        self.assertEqual(self.exts(self.relax_outputs), [FALLBACK_SERIALIZATION])
+
+    def test_kgx_is_handed_the_turtle(self):
+        self.run_transform(convert_fails_on=(".owl",))
+        self.assertTrue(self.kgx_input.endswith(FALLBACK_SERIALIZATION), self.kgx_input)
+
+    def test_the_transform_succeeds(self):
+        self.assertTrue(self.run_transform(convert_fails_on=(".owl",)).success)
+
+    def test_relax_falls_back_on_its_own_account(self):
+        # convert could write RDF/XML; relax could not.
+        self.run_transform(relax_fails_on=(".owl",))
+        self.assertEqual(self.exts(self.relax_outputs), [".owl", FALLBACK_SERIALIZATION])
+        self.assertTrue(self.kgx_input.endswith(FALLBACK_SERIALIZATION), self.kgx_input)
+
+    def test_a_format_neither_can_write_still_fails_as_relax(self):
+        outcome = self.run_transform(relax_fails_on=(".owl", FALLBACK_SERIALIZATION))
+        self.assertFalse(outcome.success)
+        self.assertEqual(outcome.stage, "relax")
+
+    def test_a_format_convert_cannot_write_at_all_fails_as_convert(self):
+        outcome = self.run_transform(convert_fails_on=(".owl", FALLBACK_SERIALIZATION))
+        self.assertFalse(outcome.success)
+        self.assertEqual(outcome.stage, "convert")
+        self.assertIn("ONTOLOGY STORAGE ERROR", outcome.detail)
+
+    def test_the_intermediates_are_cleaned_up(self):
+        self.run_transform(convert_fails_on=(".owl",))
+        workdir = os.path.join(self.output_dir, "ONTO", "1")
+        leftovers = [f for f in os.listdir(workdir)
+                     if f.endswith((".owl", FALLBACK_SERIALIZATION))]
+        self.assertEqual(leftovers, [], f"intermediates left behind: {leftovers}")
+
+
+class TestKgxReadsWhatWeWrote(TestCase):
+    """KGX maps its "owl" format straight to "xml", whatever the file is.
+
+    The patch resolves the format from the file name instead. For .owl that is
+    the same answer rdflib's guess_format gives -- "xml" -- so nothing that
+    parses today parses differently.
+    """
+
+    def test_owl_still_resolves_to_xml(self):
+        self.assertEqual(kgx_patches.owl_source_format("ONTO_relaxed.owl", "owl"), "xml")
+
+    def test_every_intermediate_name_the_pipeline_writes_resolves_to_xml(self):
+        for name in ("ONTO.owl", "ONTO_relaxed.owl", "ONTO_relaxed_noimports.owl",
+                     "ONTO_relaxed_langfix.owl", "ONTO_xmlsafe.owl"):
+            with self.subTest(name=name):
+                self.assertEqual(kgx_patches.owl_source_format(name, "owl"), "xml")
+
+    def test_turtle_resolves_to_turtle(self):
+        self.assertEqual(
+            kgx_patches.owl_source_format("ONTO_relaxed.ttl", "owl"), "turtle")
+
+    def test_an_unguessable_name_falls_back_to_xml(self):
+        # Exactly what KGX does today, so an odd name is no worse off.
+        self.assertEqual(kgx_patches.owl_source_format("ONTO", "owl"), "xml")
+
+    def test_an_explicit_format_is_left_alone(self):
+        self.assertEqual(kgx_patches.owl_source_format("ONTO.owl", "turtle"), "turtle")
+
+    def test_a_missing_format_is_resolved_too(self):
+        self.assertEqual(kgx_patches.owl_source_format("ONTO.ttl", None), "turtle")
+
+
+class TestOwlSourcePatch(TestCase):
+    """The patch has to be applied to KGX itself, and be safe to apply twice."""
+
+    def test_the_patch_reports_it_is_already_in_place(self):
+        # transformer applies it at import; a second call is a no-op, not a
+        # second layer of wrapping.
+        kgx_patches.patch_owl_source_format()
+        self.assertFalse(kgx_patches.patch_owl_source_format())
+
+    def parsed_as(self, filename):
+        """The rdflib format KGX's OwlSource actually parses `filename` with.
+
+        Recorded at the one call that matters -- rdflib's own parse -- and
+        stopped there, so nothing needs the file to exist or KGX to be wired to
+        a real Transformer. parse() touches no attribute of self before that
+        call, which is why a bare object stands in for the source instance.
+        """
+        import rdflib
+
+        from kgx.source.owl_source import OwlSource
+
+        seen = {}
+
+        class Stop(Exception):
+            pass
+
+        class RecordingGraph:
+            def parse(self, source=None, format=None, **kwargs):
+                seen["format"] = format
+                raise Stop
+
+        kgx_patches.patch_owl_source_format()
+        with mock.patch.object(rdflib, "Graph", RecordingGraph):
+            with self.assertRaises(Stop):
+                result = OwlSource.parse(object(), filename, format="owl")
+                if hasattr(result, "__next__"):
+                    next(result)  # parse() is a generator in KGX; make it run
+        return seen["format"]
+
+    def test_owl_source_parses_turtle_as_turtle(self):
+        self.assertEqual(self.parsed_as("ONTO_relaxed.ttl"), "turtle")
+
+    def test_owl_source_still_parses_owl_as_xml(self):
+        # The behaviour every ontology that works today depends on.
+        self.assertEqual(self.parsed_as("ONTO_relaxed.owl"), "xml")


### PR DESCRIPTION
Fixes #139. Takes the issue's option 2 (Turtle) on the trigger from option 3 (only on this specific failure), so the working set is untouched by construction.

## What's happening

ROBOT loads these three fine and then cannot save them — the stack says `saveOntologyFile`, not `updateInputOntology`. **RDF/XML cannot express an IRI whose local part is not a legal XML element name**, and there's no escaping around it. rdflib refuses the identical graph outright:

```
ValueError: This graph cannot be serialized to a strict format because there is
no valid way to shorten http://example.org/prop/1
```

We ask for a `.owl` output, ROBOT maps that to RDF/XML, and the ontology is lost to a format *we* chose.

## Measured, not assumed

Against ROBOT 1.9.6, on an ontology carrying `<http://example.org/prop/1>`:

| command | result |
|---|---|
| `convert --output .owl` | **exit 1**, 0 bytes written |
| `convert --output .ttl` | exit 0 |
| `relax .ttl → .ttl` | exit 0 |
| `relax .ttl → .owl` | **exit 1** |

That last row is why the relaxed output *keeps* the fallback format rather than returning to RDF/XML — the wall is still there one step later. It's also why the issue's option 1 (`.ofn`) doesn't help: KGX parses RDF, so the same limit reappears at the last step.

## The change

Nothing downstream requires the intermediate to be RDF/XML. When a write fails — **and only then** — the same step is retried as Turtle, which can always fall back to `<...>` for an IRI.

That leaves KGX: `OwlSource` maps its format argument (`"owl"`) straight to `"xml"`, so it would read the Turtle with an XML parser. `kgx_patches` gains a patch that resolves the format from the file name instead — which for a `.owl` file is **the same answer**, since rdflib's own `guess_format` maps `.owl` → `"xml"`. A patch that can't be applied logs and returns instead of raising: this one runs at import of the transformer, where an exception would cost every ontology in order to fix three.

## Blast radius on the 1108 that work: nil by construction

The issue asks for a broad re-run to confirm a serialization change doesn't perturb the working set. I can't run 1108 ontologies here — so the design makes the question moot rather than answering it empirically:

- The retry only happens **after a write-side failure**, identified by the two error strings ROBOT uses for it (`ONTOLOGY STORAGE ERROR`, `INVALID ELEMENT ERROR`). A load failure — an unresolvable import, say — is explicitly *not* one: another format would fail identically and the retry would only cost a second ROBOT run.
- The KGX patch resolves `.owl` to exactly what KGX hardcodes today. A test pins this for every intermediate name the pipeline writes (`ONTO.owl`, `ONTO_relaxed.owl`, `ONTO_relaxed_noimports.owl`, `ONTO_relaxed_langfix.owl`, `ONTO_xmlsafe.owl`).

A whole test class asserts the untouched path: RDF/XML asked for first, no second attempt, a relaxed `.owl`, and `.owl` handed to KGX.

## Verification

Real ROBOT through `transform_all`, same ontology both ways:

| | result |
|---|---|
| before | `transform_error_convert` — `INVALID ELEMENT ERROR "http://example.org/prop/1" contains invalid characters` |
| after | `status: OK` |

And the link the fake KGX can't cover — rdflib parses the Turtle `relax` wrote, as `"turtle"` (the format the patch resolves), yielding the `owl:Class` subjects KGX walks, with the unserializable property intact.

28 new tests. Full suite: 247 passed.

**Caveats, stated plainly:** the three real sources (GEOSPECIES, NPO, PHENX) need a BioPortal API key this environment doesn't have, so this shows the mechanism cured rather than those three confirmed. And on the Turtle path an invalid language tag would still reach rdflib, since the sanitizer for those reads `xml:lang` attributes and Turtle spells them differently — that's #140's territory, and no worse than today, where these ontologies produce nothing at all.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JM47TqJy5r9R2T2FgcWJhM)_