### PR TITLE
Record a source ROBOT cannot read as such, not as a transform error

### DIFF
--- a/.claude/skills/kg-bioportal-data/references/data-model.md
+++ b/.claude/skills/kg-bioportal-data/references/data-model.md
@@ -44,8 +44,13 @@ ontologies:
   name: AGRonomy Ontology # human name from BioPortal
   version: '2023-08-14'   # BioPortal submission version string ('NA' if none)
   status: OK              # OK | Failed | Skipped
-  reason: ''              # why non-OK: transform_error_<stage> | too_large |
-                          #   too_slow | skiplist | not_downloadable | no_submission.
+  reason: ''              # why non-OK: transform_error_<stage> | invalid_source |
+                          #   too_large | too_slow | skiplist | not_downloadable |
+                          #   no_submission.
+                          #   invalid_source: the file BioPortal serves cannot be read
+                          #   as an ontology at all; `detail` says whether it is broken
+                          #   RDF (with the parse error) or valid RDF that ROBOT will
+                          #   not load. Not fixable on this side.
                           #   <stage> is decompress | convert | relax | kgx — which
                           #   step lost the ontology. Entries from runs before this
                           #   was recorded carry a bare `transform_error`.

--- a/docs/kg_site/build_site.py
+++ b/docs/kg_site/build_site.py
@@ -189,6 +189,9 @@ REASON_MSG = {
                              "step).",
     "transform_error_kgx": "The ontology converted, but the KGX step failed to turn it into nodes "
                            "and edges.",
+    "invalid_source": "The source file BioPortal serves for this ontology cannot be read as an "
+                      "ontology at all — it is malformed, or it is not the kind of file it claims "
+                      "to be. Nothing on this side can fix it; it needs correcting at the source.",
     "not_downloadable": "No downloadable source is currently available from BioPortal.",
     "license_restricted": "This ontology is only available under a license we do not hold "
                           "(typically a UMLS licence), so BioPortal does not serve its source "

--- a/src/kg_bioportal/transformer.py
+++ b/src/kg_bioportal/transformer.py
@@ -712,6 +712,95 @@ _SERIALIZATION_ERRORS = (
 FALLBACK_SERIALIZATION = ".ttl"
 
 
+# ROBOT errors that mean the file could not be read at all -- not that some
+# step went wrong with it. When convert says this, the file is the source
+# exactly as BioPortal served it, and nothing on our side will change the
+# outcome (#142). The same words from relax are about our own intermediate
+# (#141), which is why only the convert stage consults this.
+_LOAD_FAILURE_MARKERS = (
+    "INVALID ONTOLOGY FILE ERROR",
+    "Could not load a valid ontology",
+    "UnparsableOntologyException",
+)
+
+# The onto_stats reason for those, so they stop sitting in the same bucket as
+# failures we can do something about.
+INVALID_SOURCE_REASON = "invalid_source"
+
+# Ceiling on the syntax check below. It runs only for an ontology that has
+# already failed, but rdflib holds the whole graph in memory and the per-
+# ontology deadline is still ticking, so a giant source is reported unchecked
+# rather than risking the diagnosis turning into a timeout.
+MAX_SYNTAX_CHECK_MB = 25
+
+# rdflib format for each serialization the sniffer recognizes. OBO is not RDF,
+# so there is nothing rdflib can say about it.
+_RDFLIB_FORMATS = {"xml": "xml", "turtle": "turtle"}
+
+# An HTML document arriving under an ontology's name -- an error page served in
+# place of the file. Worth naming outright: rdflib's RDF/XML parser reads
+# arbitrary XML, so it will happily report "valid XML, 3 triples" for a 404 page
+# and the diagnosis would reassure where it should not.
+_HTML_DOCUMENT = re.compile(r"^\s*(?:<!doctype\s+html|<html[\s>])", re.I)
+
+
+def is_load_failure(error: str) -> bool:
+    """Whether ROBOT could not read the file at all, as opposed to failing over it."""
+    return any(marker in error for marker in _LOAD_FAILURE_MARKERS)
+
+
+def diagnose_source(path: str, max_mb: float = MAX_SYNTAX_CHECK_MB) -> str:
+    """Say why a source ROBOT refused is unusable, in terms someone can act on.
+
+    ROBOT reports the same thing for a file that is not valid RDF and for one
+    that is valid RDF it will not accept as an ontology, and #142 wants those
+    told apart: the first is a bug report to the ontology's maintainers, with a
+    line number; the second is a file that might yet be readable another way.
+    rdflib answers the question directly, and it is already a dependency.
+
+    Returns:
+        A phrase to append to the recorded detail, or "" when nothing can be
+        said (an unrecognized serialization, a file too large to check, or
+        rdflib itself failing for an unrelated reason).
+    """
+    try:
+        size_mb = os.path.getsize(path) / 1024 / 1024
+    except OSError:
+        return ""
+    if max_mb and size_mb > max_mb:
+        return f"source not syntax-checked ({size_mb:.1f} MB)"
+
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            text = f.read()
+    except OSError:
+        return ""
+
+    if _HTML_DOCUMENT.match(text[:4096].lstrip("\ufeff")):
+        return "source is an HTML document, not an ontology"
+
+    rdflib_format = _RDFLIB_FORMATS.get(_sniff_serialization(text) or "")
+    if not rdflib_format:
+        return "source is not an RDF serialization we can check"
+
+    try:
+        import rdflib
+    except ImportError:  # pragma: no cover - rdflib ships with kgx
+        return ""
+
+    graph = rdflib.Graph()
+    try:
+        graph.parse(path, format=rdflib_format)
+    except Exception as e:
+        # The line and column live in the message; they are what an upstream
+        # report needs, so keep the message rather than just the type.
+        return f"source is not valid {rdflib_format}: {type(e).__name__}: {e}"
+    return (
+        f"source is valid {rdflib_format} ({len(graph)} triples) that ROBOT "
+        "will not load as an ontology"
+    )
+
+
 def is_serialization_failure(error: str) -> bool:
     """Whether a ROBOT error is the output format's fault rather than the input's."""
     return any(marker in error for marker in _SERIALIZATION_ERRORS)
@@ -749,10 +838,16 @@ class TransformOutcome(NamedTuple):
     edgecount: int = 0
     stage: str = ""
     detail: str = ""
+    # Set only when the stage does not describe the failure: a source ROBOT
+    # cannot load is not "the convert step went wrong", it is a file we were
+    # never going to be able to transform (#142).
+    reason: str = ""
 
     @classmethod
-    def failed(cls, stage: str, detail: str = "") -> "TransformOutcome":
-        return cls(False, 0, 0, stage, summarize_detail(detail))
+    def failed(
+        cls, stage: str, detail: str = "", reason: str = ""
+    ) -> "TransformOutcome":
+        return cls(False, 0, 0, stage, summarize_detail(detail), reason)
 
 
 def summarize_detail(text: str, limit: int = MAX_DETAIL_CHARS) -> str:
@@ -962,7 +1057,7 @@ class Transformer:
                 if not reason:
                     # Name the stage that lost it, so the next audit is a grep of
                     # onto_stats.yaml rather than an archaeology of expiring logs.
-                    reason = reason_for_stage(outcome.stage)
+                    reason = outcome.reason or reason_for_stage(outcome.stage)
                     detail = outcome.detail
             else:
                 logging.info(f"Transformed {filepath}.")
@@ -1092,6 +1187,18 @@ class Transformer:
             )
             converted = convert_to(intermediate_path)
         if not converted:
+            if is_load_failure(converted.error):
+                # convert's input is the source as BioPortal served it, so this
+                # is a file we were never going to transform. Say which kind of
+                # unusable it is, and record it apart from the failures that are
+                # ours to fix (#142).
+                diagnosis = diagnose_source(ontology_path)
+                logging.error(f"{ontology_name}: unusable source. {diagnosis}")
+                return TransformOutcome.failed(
+                    "convert",
+                    f"{converted.error} ({diagnosis})" if diagnosis else converted.error,
+                    reason=INVALID_SOURCE_REASON,
+                )
             return TransformOutcome.failed("convert", converted.error)
 
         # ROBOT can write a character into its own output that no XML parser will

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -30,7 +30,7 @@ class TestReasonMessages(TestCase):
     REASONS = [
         "too_large", "too_slow", "skiplist", "transform_error",
         "transform_error_decompress", "transform_error_convert",
-        "transform_error_relax", "transform_error_kgx",
+        "transform_error_relax", "transform_error_kgx", "invalid_source",
         "not_downloadable", "license_restricted", "no_download_file",
         "download_http_error", "no_submission", "metadata_http_error",
         "download_error",

--- a/tests/test_invalid_source.py
+++ b/tests/test_invalid_source.py
@@ -1,0 +1,282 @@
+"""A source ROBOT cannot read is not the same as a transform that went wrong.
+
+Four ontologies fail on the file exactly as BioPortal served it:
+
+    INVALID ONTOLOGY FILE ERROR Could not load a valid ontology from file:
+    shedding-hub.ttl
+
+Nothing on this side will change that, so they should not sit in the same
+bucket as the failures that are ours to fix (#142). They get their own reason,
+and a detail that says which kind of unusable the file is -- broken RDF, with
+the parse error an upstream report needs, or valid RDF that ROBOT will not
+accept as an ontology, which might yet be readable another way.
+
+The error strings here are ROBOT 1.9.6's own, taken from a run against a Turtle
+file with a missing '.' (stderr, under -vvv, as the pipeline invokes it).
+"""
+
+import os
+import tempfile
+from unittest import TestCase, mock
+
+import yaml
+
+from kg_bioportal.robot_utils import RobotResult
+from kg_bioportal.transformer import (
+    INVALID_SOURCE_REASON,
+    MAX_SYNTAX_CHECK_MB,
+    Transformer,
+    diagnose_source,
+    is_load_failure,
+)
+
+LOAD_FAILURE = (
+    "java.lang.IllegalArgumentException: java.io.IOException: errors#INVALID "
+    "ONTOLOGY FILE ERROR Could not load a valid ontology from file: shedding-hub.ttl"
+)
+UNPARSABLE = (
+    "org.semanticweb.owlapi.io.UnparsableOntologyException: Problem parsing "
+    "file:/data/raw/NCOD/1/NCOD-2021-04-15.ttl"
+)
+STORAGE_ERROR = (
+    "java.io.IOException: errors#ONTOLOGY STORAGE ERROR Could not save ontology to IRI"
+)
+IMPORT_ERROR = (
+    "java.lang.IllegalArgumentException: org.semanticweb.owlapi.model."
+    "UnloadableImportException: Could not load imported ontology: <http://dead/>"
+)
+
+GOOD_TURTLE = """@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+<http://example.org/onto> a owl:Ontology .
+<http://example.org/ns#A> a owl:Class ; rdfs:label "A" .
+"""
+
+# A missing '.' after the ontology declaration -- the shape of a real typo.
+BAD_TURTLE = """@prefix owl: <http://www.w3.org/2002/07/owl#> .
+<http://example.org/onto> a owl:Ontology
+<http://example.org/ns#A> a owl:Class .
+"""
+
+# What a served error page looks like when it arrives under a .ttl name.
+HTML_PAGE = "<!DOCTYPE html>\n<html><head><title>Error</title></head></html>\n"
+
+RDFXML = """<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#">
+  <owl:Ontology rdf:about="http://example.org/onto"/>
+</rdf:RDF>
+"""
+
+
+class TestLoadFailureIsRecognized(TestCase):
+    def test_invalid_ontology_file_error(self):
+        self.assertTrue(is_load_failure(LOAD_FAILURE))
+
+    def test_unparsable_ontology_exception(self):
+        self.assertTrue(is_load_failure(UNPARSABLE))
+
+    def test_a_write_failure_is_not_a_load_failure(self):
+        # The ontology loaded fine there; the output format was the problem.
+        self.assertFalse(is_load_failure(STORAGE_ERROR))
+
+    def test_an_unresolvable_import_is_not_a_load_failure(self):
+        # The source is readable; something it points at is not. Stripping
+        # imports is what fixes those, and they must keep their own reason.
+        self.assertFalse(is_load_failure(IMPORT_ERROR))
+
+    def test_a_timeout_is_not_a_load_failure(self):
+        self.assertFalse(is_load_failure("ROBOT convert timed out after 60s"))
+
+
+class DiagnoseTestCase(TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+
+    def write(self, name, text):
+        path = os.path.join(self._tmp.name, name)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(text)
+        return path
+
+
+class TestDiagnosis(DiagnoseTestCase):
+    """Which of the two kinds of unusable a file is."""
+
+    def test_broken_turtle_is_reported_as_invalid(self):
+        detail = diagnose_source(self.write("onto.ttl", BAD_TURTLE))
+        self.assertIn("not valid turtle", detail)
+
+    def test_the_parse_error_is_kept(self):
+        # A line number is the difference between a useful bug report and "it
+        # doesn't work".
+        detail = diagnose_source(self.write("onto.ttl", BAD_TURTLE))
+        self.assertIn("line", detail.lower())
+
+    def test_html_served_as_an_ontology_is_named_outright(self):
+        # rdflib's RDF/XML parser reads arbitrary XML, so an error page comes
+        # back as "valid XML, 3 triples" unless it is caught first -- a
+        # diagnosis that reassures exactly where it should not.
+        detail = diagnose_source(self.write("onto.ttl", HTML_PAGE))
+        self.assertIn("HTML document", detail)
+        self.assertNotIn("triples", detail)
+
+    def test_html_under_an_owl_name_is_caught_too(self):
+        detail = diagnose_source(self.write("onto.owl", HTML_PAGE))
+        self.assertIn("HTML document", detail)
+
+    def test_valid_rdf_is_reported_as_such(self):
+        # This is the "might be recoverable another way" case, and it must not
+        # be described as broken.
+        detail = diagnose_source(self.write("onto.ttl", GOOD_TURTLE))
+        self.assertIn("valid turtle", detail)
+        self.assertNotIn("not valid", detail)
+        self.assertIn("will not load as an ontology", detail)
+
+    def test_the_triple_count_is_reported(self):
+        detail = diagnose_source(self.write("onto.ttl", GOOD_TURTLE))
+        self.assertIn("3 triples", detail)
+
+    def test_broken_rdfxml_is_reported_as_invalid(self):
+        detail = diagnose_source(self.write("onto.owl", RDFXML.replace("</rdf:RDF>", "")))
+        self.assertIn("not valid xml", detail)
+
+    def test_valid_rdfxml_is_reported_as_such(self):
+        self.assertIn("valid xml", diagnose_source(self.write("onto.owl", RDFXML)))
+
+    def test_a_non_rdf_serialization_says_so(self):
+        # OBO is not RDF; rdflib has nothing to say about it either way.
+        detail = diagnose_source(
+            self.write("onto.obo", "format-version: 1.2\n\n[Term]\nid: X:1\n"))
+        self.assertIn("not an RDF serialization", detail)
+
+    def test_a_large_source_is_not_checked(self):
+        path = self.write("onto.ttl", GOOD_TURTLE)
+        detail = diagnose_source(path, max_mb=0.000001)
+        self.assertIn("not syntax-checked", detail)
+
+    def test_the_default_ceiling_is_finite(self):
+        self.assertGreater(MAX_SYNTAX_CHECK_MB, 0)
+
+    def test_a_missing_file_says_nothing(self):
+        self.assertEqual(diagnose_source(os.path.join(self._tmp.name, "nope.ttl")), "")
+
+
+class TransformTestCase(TestCase):
+    """Drives transform() with ROBOT and KGX faked."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.input_dir = os.path.join(self._tmp.name, "raw")
+        self.output_dir = os.path.join(self._tmp.name, "transformed")
+        os.makedirs(self.output_dir, exist_ok=True)
+
+        self.txr = Transformer.__new__(Transformer)
+        self.txr.input_dir = self.input_dir
+        self.txr.output_dir = self.output_dir
+        self.txr.timeout_sec = 60
+        self.txr.timeout_min = 1
+        self.txr.max_source_bytes = 0
+        self.txr.robot_path = "/nonexistent/robot"
+        self.txr.robot_env = {}
+
+    def source(self, name, text):
+        path = os.path.join(self.input_dir, "ONTO", "1", name)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(text)
+        return path
+
+    def run_transform(self, source_path, convert_error=LOAD_FAILURE, all_at_once=False):
+        def fake_convert(**kwargs):
+            if convert_error:
+                return RobotResult(False, convert_error)
+            os.makedirs(os.path.dirname(kwargs["output_path"]), exist_ok=True)
+            with open(kwargs["output_path"], "w") as f:
+                f.write(RDFXML)
+            return RobotResult(True)
+
+        def fake_relax(**kwargs):
+            os.makedirs(os.path.dirname(kwargs["output_path"]), exist_ok=True)
+            with open(kwargs["output_path"], "w") as f:
+                f.write(RDFXML)
+            return RobotResult(True)
+
+        class FakeKGX:
+            def __init__(self, *a, **k):
+                pass
+
+            def transform(self, input_args, output_args):
+                for suffix in ("_nodes.tsv", "_edges.tsv"):
+                    with open(output_args["filename"] + suffix, "w") as fh:
+                        fh.write("id\n")
+
+        with mock.patch("kg_bioportal.transformer.robot_convert", fake_convert), \
+             mock.patch("kg_bioportal.transformer.robot_relax", fake_relax), \
+             mock.patch("kg_bioportal.transformer.KGXTransformer", FakeKGX):
+            if all_at_once:
+                self.txr.transform_all(compress=False)
+                return None
+            return self.txr.transform(source_path, compress=False)
+
+    def stats(self):
+        with open(os.path.join(self.output_dir, "onto_stats.yaml")) as f:
+            entries = {o["id"]: o for o in yaml.safe_load(f)["ontologies"]}
+        return entries["ONTO"]
+
+
+class TestUnusableSourcesAreRecordedApart(TransformTestCase):
+    def test_the_reason_is_invalid_source(self):
+        outcome = self.run_transform(self.source("onto.ttl", BAD_TURTLE))
+        self.assertEqual(outcome.reason, INVALID_SOURCE_REASON)
+
+    def test_the_stage_is_still_recorded(self):
+        # Where it failed is still true and still useful; it is the reason that
+        # needed to stop saying "the transform went wrong".
+        outcome = self.run_transform(self.source("onto.ttl", BAD_TURTLE))
+        self.assertEqual(outcome.stage, "convert")
+
+    def test_robots_own_message_survives(self):
+        outcome = self.run_transform(self.source("onto.ttl", BAD_TURTLE))
+        self.assertIn("INVALID ONTOLOGY FILE ERROR", outcome.detail)
+
+    def test_the_diagnosis_is_appended(self):
+        outcome = self.run_transform(self.source("onto.ttl", BAD_TURTLE))
+        self.assertIn("not valid turtle", outcome.detail)
+
+    def test_a_valid_rdf_source_is_described_as_such(self):
+        outcome = self.run_transform(self.source("onto.ttl", GOOD_TURTLE))
+        self.assertEqual(outcome.reason, INVALID_SOURCE_REASON)
+        self.assertIn("will not load as an ontology", outcome.detail)
+
+    def test_it_reaches_onto_stats(self):
+        self.source("onto.ttl", BAD_TURTLE)
+        self.run_transform(None, all_at_once=True)
+        entry = self.stats()
+        self.assertEqual(entry["status"], "Failed")
+        self.assertEqual(entry["reason"], INVALID_SOURCE_REASON)
+        self.assertIn("not valid turtle", entry["detail"])
+
+
+class TestEverythingElseKeepsItsReason(TransformTestCase):
+    """Only a source ROBOT could not read gets the new reason."""
+
+    def test_an_unresolvable_import_stays_a_transform_error(self):
+        self.source("onto.ttl", GOOD_TURTLE)
+        self.run_transform(None, convert_error=IMPORT_ERROR, all_at_once=True)
+        self.assertEqual(self.stats()["reason"], "transform_error_convert")
+
+    def test_a_write_failure_stays_a_transform_error(self):
+        # It falls back to Turtle first (#139); failing both ways is still ours.
+        self.source("onto.ttl", GOOD_TURTLE)
+        self.run_transform(None, convert_error=STORAGE_ERROR, all_at_once=True)
+        self.assertEqual(self.stats()["reason"], "transform_error_convert")
+
+    def test_a_working_ontology_is_untouched(self):
+        self.source("onto.ttl", GOOD_TURTLE)
+        self.run_transform(None, convert_error="", all_at_once=True)
+        entry = self.stats()
+        self.assertEqual(entry["status"], "OK")
+        self.assertEqual(entry["reason"], "")


### PR DESCRIPTION
Fixes #142. Delivers steps 1 and 3 — the confirmation is automated into the pipeline rather than done once by hand, so it covers these four and anything that joins them.

## The change

Four ontologies fail on the file exactly as BioPortal served it. Nothing on this side will change that, and until now they sat in the same bucket as failures that *are* ours to fix. They now get:

- **`reason: invalid_source`** — a specific reason, as the issue asks, so they stop being counted as unexplained failures;
- **a detail that answers step 1's question**: is this broken RDF, or valid RDF that ROBOT will not accept as an ontology? Those want different responses — a bug report with a line number, versus a file that might yet be readable another way — and rdflib, already a dependency, tells them apart.

Only the **convert** stage consults this, and that's what makes it sound: convert's input is the source as served. The same words from `relax` are about an intermediate *we* wrote (#141), and reading them the same way would blame BioPortal for our own output. Everything else keeps the reason it had — an unresolvable import, a write-side failure, a timeout — with tests holding that line.

## A way it could have misled

rdflib's RDF/XML parser reads arbitrary XML, so an error page served in place of an ontology came back as *"valid XML, 3 triples"* — reassurance exactly where none is due. A test caught it. An HTML document is now named outright, which is also the more useful thing to read in the stats.

## Verification

Real ROBOT 1.9.6, end to end through `transform_all`:

| source | reason | detail |
|---|---|---|
| Turtle with a missing `.` | `invalid_source` | `…INVALID ONTOLOGY FILE ERROR … (source is not valid turtle: BadSyntax: at line 3 of <>: Bad syntax (expected '.' …))` |
| HTML error page named `.ttl` | `invalid_source` | `… (source is an HTML document, not an ontology)` |
| valid source | — | `status: OK`, untouched |

The line number and the offending text, from the stats file alone, without opening a log that expires — which is what an upstream report needs.

The syntax check runs only after a failure, and only up to 25 MB: rdflib holds the whole graph in memory and the per-ontology deadline is still ticking, so a giant source is reported unchecked rather than risking the diagnosis turning into a timeout.

26 new tests. Full suite: 273 passed.

## What this deliberately does not do

- **The four are not individually confirmed.** Fetching them needs a BioPortal API key this environment doesn't have. The next run will state each one's problem in `onto_stats.yaml`.
- **Nothing is reported upstream.** That needs the files in hand, and sending reports on your behalf isn't mine to do — happy to draft them once a run produces the diagnoses.
- **Counting is left alone.** `invalid_source` is close to `license_restricted` in kind (broken elsewhere, no rerun will help), so you may well want it out of `failedcount` too — but that changes a headline number and should be your call, not a side effect of this change.
- It does make #31's persistent-failure list implementable: these four are the seed, and now they're labelled.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JM47TqJy5r9R2T2FgcWJhM)_