### PR TITLE
Balance shards by source size instead of round-robin

### DIFF
--- a/.github/workflows/transform.yml
+++ b/.github/workflows/transform.yml
@@ -66,8 +66,10 @@ jobs:
         run: kgbioportal get-ontology-list -o data/raw -k "$NCBO_API_KEY"
         env:
           NCBO_API_KEY: ${{ secrets.NCBO_API_KEY }}
-      - name: Fetch the current index (for version-skip on a full run)
-        if: ${{ github.event.inputs.ontologies == '' }}
+      - name: Fetch the current index (version-skip, and the sizes shards balance on)
+        # Not just for a full run: a targeted re-run needs the source sizes too,
+        # and it is the case where an unbalanced shard hurts most -- few
+        # ontologies, few shards, one heavyweight setting the wall-clock.
         run: gh release download -p onto_stats.yaml -D prev || echo "No index yet; will transform all."
         env:
           GH_TOKEN: ${{ github.token }}
@@ -76,9 +78,13 @@ jobs:
         # Explicit ontologies input: transform exactly those (no version-skip).
         # Full list: version-skip against the current index — only new/changed
         # BioPortal submissions are (re)transformed; unchanged graphs carry forward.
+        #
+        # Both pass --index: it carries the source sizes the shards are balanced
+        # by, and version-skip applies only to the full list, so an explicit list
+        # is still transformed exactly as given.
         run: |
           if [ -n "${{ github.event.inputs.ontologies }}" ]; then
-            SHARDS=$(kgbioportal shard-list -d "${{ github.event.inputs.ontologies }}" -n "$NUM_SHARDS")
+            SHARDS=$(kgbioportal shard-list -d "${{ github.event.inputs.ontologies }}" -n "$NUM_SHARDS" --index prev/onto_stats.yaml)
           else
             SHARDS=$(kgbioportal shard-list -f data/raw/ontologylist.tsv -n "$NUM_SHARDS" --index prev/onto_stats.yaml)
           fi

--- a/src/kg_bioportal/cli.py
+++ b/src/kg_bioportal/cli.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import statistics
 
 import click
 
@@ -70,6 +71,80 @@ def _load_index_submissions(index_path: str) -> dict:
         if sub and sub != "NA":
             out[entry["id"]] = sub
     return out
+
+
+def load_index_sizes(index_path: str) -> dict:
+    """Read {acronym: source_bytes} from an onto_stats.yaml index.
+
+    The size of an ontology's source is the best predictor of transform cost we
+    already have: in the 2026-08-11 run BDPM was 88 MB and took 328s while
+    FOODON was 40 MB and took 126s. It is a proxy, not a measurement -- if the
+    stats ever carry per-ontology durations, schedule on those instead.
+    """
+    import yaml
+
+    if not index_path or not os.path.exists(index_path):
+        return {}
+    with open(index_path) as f:
+        data = yaml.safe_load(f) or {}
+    sizes = {}
+    for entry in data.get("ontologies", []):
+        try:
+            size = int(entry.get("source_bytes") or 0)
+        except (TypeError, ValueError):
+            continue
+        if size > 0:
+            sizes[entry["id"]] = size
+    return sizes
+
+
+def assign_shards(acronyms: list, num_shards: int, sizes: dict) -> list:
+    """Split acronyms into shards of roughly equal expected cost.
+
+    Round-robin only spreads the heavy ontologies out when size is uncorrelated
+    with position, and in an alphabetical list it is not: on 2026-08-11 the four
+    largest sources sat at indices 3, 9, 15 and 21, all of which are 3 mod 6, so
+    every one of them landed in the same shard. That shard took 13m57s while the
+    lightest took 2m22s, and the run was about 2.5x longer than the work in it
+    (#153).
+
+    Longest-processing-time-first instead: heaviest ontology first, each one
+    onto whichever shard is currently lightest. Ties break on name so the same
+    input always produces the same matrix.
+
+    Without sizes there is nothing to balance on, and this falls back to the
+    round-robin it replaces rather than inventing an order.
+
+    Args:
+        acronyms: The ontologies to shard, in input order.
+        num_shards: How many shards to fill.
+        sizes: {acronym: source_bytes}; entries may be missing.
+
+    Returns:
+        A list of shards, each a list of acronyms. Empty shards are dropped.
+    """
+    n = max(1, min(num_shards, len(acronyms)))
+    buckets = [[] for _ in range(n)]
+
+    known = [sizes[a] for a in acronyms if sizes.get(a)]
+    if not known:
+        for i, acr in enumerate(acronyms):
+            buckets[i % n].append(acr)
+        return [b for b in buckets if b]
+
+    # An ontology the index has never seen is a new submission; the median of
+    # the ones we do know is a better guess than nothing, and does not let a
+    # single unknown dominate the packing the way the maximum would.
+    default = statistics.median(known)
+    weights = {a: sizes.get(a) or default for a in acronyms}
+
+    loads = [0.0] * n
+    for acr in sorted(acronyms, key=lambda a: (-weights[a], a)):
+        lightest = min(range(n), key=lambda i: (loads[i], i))
+        buckets[lightest].append(acr)
+        loads[lightest] += weights[acr]
+
+    return [b for b in buckets if b]
 
 
 @click.group()
@@ -377,13 +452,23 @@ def shard_list(ontology_file, ontologies, num_shards, use_skiplist, index_path) 
     if use_skiplist:
         acronyms = [a for a in acronyms if not is_skiplisted(a)]
 
-    # Round-robin so heavy ontologies spread across shards rather than clumping.
-    n = max(1, min(num_shards, len(acronyms)))
-    buckets = [[] for _ in range(n)]
-    for i, acr in enumerate(acronyms):
-        buckets[i % n].append(acr)
+    # Balance the shards by expected cost, so no runner sits idle while another
+    # works through every heavyweight in the run.
+    sizes = load_index_sizes(index_path)
+    buckets = assign_shards(acronyms, num_shards, sizes)
 
-    shards = [" ".join(b) for b in buckets if b]
+    if buckets and sizes:
+        loads = [
+            sum(sizes.get(a, 0) for a in b) / 1024 / 1024 for b in buckets
+        ]
+        click.echo(
+            f"sharding: {len(buckets)} shards of {min(loads):.0f}-{max(loads):.0f} MB "
+            f"(by source size; {sum(1 for a in acronyms if a not in sizes)} "
+            "unknown weighted at the median).",
+            err=True,
+        )
+
+    shards = [" ".join(b) for b in buckets]
     click.echo(json.dumps(shards))
 
     return None

--- a/tests/test_shard_balance.py
+++ b/tests/test_shard_balance.py
@@ -1,0 +1,261 @@
+"""Shards have to be balanced by cost, not by count.
+
+In the 2026-08-11 run the slowest shard took 13m57s and the fastest 2m22s for
+the same 30 ontologies: round-robin is not size-aware, and the heavy ontologies
+happened to land together. The run took about 2.5x as long as the work in it
+(#153).
+
+That run is the fixture. RUN_2026_08_11 holds the six shards exactly as they
+were reported, and the sizes sum to each shard's reported total, with the four
+named heavyweights at their reported sizes -- so the packing is measured
+against the case that motivated it rather than a shape invented to suit the
+fix. (The individual sizes within a shard are apportioned, not measured, and
+the input order that produced those shards is not recoverable from the report,
+so the tests compare against the assignment that actually ran rather than
+recomputing round-robin over a guessed order.)
+"""
+
+import json
+import os
+import tempfile
+from unittest import TestCase
+
+import yaml
+from click.testing import CliRunner
+
+from kg_bioportal.cli import assign_shards, load_index_sizes, main
+
+MB = 1024 * 1024
+
+# The six shards that ran on 2026-08-11, with their reported duration and total
+# source size. Sizes below sum to each shard's total; BDPM, FOODON, ICEO and RBO
+# are the four the issue names individually.
+RUN_SHARDS = {
+    # duration, total MB, members with their MB
+    "13m57s": {"BDPM": 88, "FOODON": 40, "ICEO": 37, "RBO": 29, "OCDARWN": 1},
+    "4m59s-a": {"ADHER_INTCARE_EN": 2, "EMIF-AD": 8, "FYPO": 60, "NMDCO": 12, "CTX": 2},
+    "4m59s-b": {"CDO": 3, "FOVT": 44, "KISAO": 5, "VALUESETS": 6, "OCRE": 2},
+    "4m02s": {"DOVES": 42, "FRMO": 3, "MAXO": 15, "WWECA": 6, "ROR": 2},
+    "3m08s": {"ADHER_INTCARE_SP": 2, "EO": 9, "GSSO": 17, "OAE": 4, "HGNC-NR": 2},
+    "2m22s": {"AFPO": 1, "EPO": 3, "HANCESTRO": 6, "ONTOPSYCARE": 2, "ICPS": 2},
+}
+RUN_2026_08_11 = {a: mb for shard in RUN_SHARDS.values() for a, mb in shard.items()}
+ALPHABETICAL = sorted(RUN_2026_08_11)
+
+# The reported per-shard totals, as a check that the apportioned sizes add up.
+REPORTED_TOTALS = {"13m57s": 195, "4m59s-a": 84, "4m59s-b": 60,
+                   "4m02s": 68, "3m08s": 34, "2m22s": 14}
+
+
+def sizes_in_bytes(mb_by_acronym):
+    return {a: mb * MB for a, mb in mb_by_acronym.items()}
+
+
+def spread(buckets, sizes):
+    """Heaviest shard over lightest, the number that matters for wall-clock."""
+    loads = [sum(sizes.get(a, 0) for a in b) for b in buckets]
+    return max(loads) / max(1, min(loads))
+
+
+class TestBalance(TestCase):
+    def setUp(self):
+        self.sizes = sizes_in_bytes(RUN_2026_08_11)
+
+    def test_the_fixture_matches_the_reported_run(self):
+        # Not a test of the fix: it holds the fixture to the numbers in the
+        # report, so the improvement below is measured against something real.
+        for name, members in RUN_SHARDS.items():
+            self.assertEqual(sum(members.values()), REPORTED_TOTALS[name], name)
+
+    def test_the_run_that_happened_was_badly_unbalanced(self):
+        as_run = [list(members) for members in RUN_SHARDS.values()]
+        self.assertGreater(spread(as_run, self.sizes), 10.0)
+
+    def test_the_packing_is_close_to_even(self):
+        buckets = assign_shards(ALPHABETICAL, 6, self.sizes)
+        self.assertLess(spread(buckets, self.sizes), 1.3)
+
+    def test_the_heavyweights_are_split_up(self):
+        # BDPM, FYPO, FOVT and DOVES are the four largest; no two should share.
+        buckets = assign_shards(ALPHABETICAL, 6, self.sizes)
+        for bucket in buckets:
+            heavy = [a for a in bucket if a in ("BDPM", "FYPO", "FOVT", "DOVES")]
+            self.assertLessEqual(len(heavy), 1, f"{heavy} share a shard")
+
+    def test_the_biggest_shard_is_near_the_ideal(self):
+        buckets = assign_shards(ALPHABETICAL, 6, self.sizes)
+        ideal = sum(self.sizes.values()) / 6
+        heaviest = max(sum(self.sizes[a] for a in b) for b in buckets)
+        # LPT's worst case is 4/3 of optimal; nothing here should approach it.
+        self.assertLess(heaviest, ideal * 1.34)
+
+
+class TestNothingIsLost(TestCase):
+    def setUp(self):
+        self.sizes = sizes_in_bytes(RUN_2026_08_11)
+
+    def test_every_ontology_is_scheduled_exactly_once(self):
+        buckets = assign_shards(ALPHABETICAL, 6, self.sizes)
+        scheduled = [a for b in buckets for a in b]
+        self.assertEqual(sorted(scheduled), ALPHABETICAL)
+        self.assertEqual(len(scheduled), len(set(scheduled)))
+
+    def test_no_empty_shards_are_emitted(self):
+        buckets = assign_shards(["A", "B"], 6, {"A": MB, "B": MB})
+        self.assertTrue(all(buckets))
+        self.assertEqual(len(buckets), 2)
+
+    def test_more_shards_than_ontologies_is_fine(self):
+        buckets = assign_shards(["A"], 20, {"A": MB})
+        self.assertEqual(buckets, [["A"]])
+
+    def test_a_single_shard_holds_everything(self):
+        buckets = assign_shards(ALPHABETICAL, 1, self.sizes)
+        self.assertEqual(sorted(buckets[0]), ALPHABETICAL)
+
+    def test_no_ontologies_gives_no_shards(self):
+        self.assertEqual(assign_shards([], 6, {}), [])
+
+    def test_the_assignment_is_deterministic(self):
+        # The matrix has to be reproducible: same input, same shards.
+        first = assign_shards(ALPHABETICAL, 6, self.sizes)
+        for _ in range(3):
+            self.assertEqual(assign_shards(ALPHABETICAL, 6, self.sizes), first)
+
+    def test_input_order_does_not_change_the_packing(self):
+        # Alphabetical order is exactly what made round-robin fail; the result
+        # should not depend on it.
+        shuffled = list(reversed(ALPHABETICAL))
+        self.assertEqual(
+            assign_shards(shuffled, 6, self.sizes),
+            assign_shards(ALPHABETICAL, 6, self.sizes),
+        )
+
+
+class TestUnknownSizes(TestCase):
+    def test_without_any_sizes_it_falls_back_to_round_robin(self):
+        # No index, nothing to balance on: keep the behaviour that was there,
+        # rather than inventing an order.
+        acronyms = [f"O{i}" for i in range(10)]
+        self.assertEqual(
+            assign_shards(acronyms, 3, {}),
+            [acronyms[0::3], acronyms[1::3], acronyms[2::3]],
+        )
+
+    def test_an_unknown_ontology_is_still_scheduled(self):
+        sizes = {"BIG": 100 * MB, "SMALL": MB}
+        buckets = assign_shards(["BIG", "SMALL", "NEW"], 2, sizes)
+        self.assertIn("NEW", [a for b in buckets for a in b])
+
+    def test_an_unknown_ontology_does_not_dominate(self):
+        # A new submission is weighted at the median, not the maximum -- one
+        # unknown should not be treated as if it were the heaviest thing here.
+        sizes = sizes_in_bytes(RUN_2026_08_11)
+        buckets = assign_shards(ALPHABETICAL + ["NEW"], 6, sizes)
+        with_new = next(b for b in buckets if "NEW" in b)
+        self.assertGreater(len(with_new), 1, "the unknown was treated as a giant")
+
+    def test_sizes_for_ontologies_not_in_the_run_are_ignored(self):
+        buckets = assign_shards(["A", "B"], 2, {"A": MB, "B": MB, "ZZZ": 500 * MB})
+        self.assertEqual(sorted(a for b in buckets for a in b), ["A", "B"])
+
+
+class TestIndexSizes(TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+
+    def write_index(self, entries):
+        path = os.path.join(self._tmp.name, "onto_stats.yaml")
+        with open(path, "w") as f:
+            yaml.dump({"ontologies": entries}, f, sort_keys=False)
+        return path
+
+    def test_sizes_are_read_from_the_index(self):
+        path = self.write_index([
+            {"id": "BDPM", "source_bytes": 88 * MB, "submission_id": "3"},
+            {"id": "AFPO", "source_bytes": MB, "submission_id": "1"},
+        ])
+        self.assertEqual(load_index_sizes(path), {"BDPM": 88 * MB, "AFPO": MB})
+
+    def test_entries_without_a_size_are_skipped(self):
+        # Skiplisted and never-downloaded entries carry 0.
+        path = self.write_index([
+            {"id": "GIANT", "source_bytes": 0},
+            {"id": "REAL", "source_bytes": MB},
+        ])
+        self.assertEqual(load_index_sizes(path), {"REAL": MB})
+
+    def test_a_junk_size_is_skipped_not_raised(self):
+        path = self.write_index([
+            {"id": "ODD", "source_bytes": "not a number"},
+            {"id": "REAL", "source_bytes": MB},
+        ])
+        self.assertEqual(load_index_sizes(path), {"REAL": MB})
+
+    def test_a_missing_index_is_empty_not_an_error(self):
+        self.assertEqual(load_index_sizes(os.path.join(self._tmp.name, "nope.yaml")), {})
+
+    def test_no_index_path_is_empty(self):
+        self.assertEqual(load_index_sizes(""), {})
+
+
+class TestShardListCommand(TestCase):
+    """The command still emits only JSON on stdout -- it is a job output."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.runner = CliRunner()
+
+    def index(self, mb_by_acronym):
+        path = os.path.join(self._tmp.name, "onto_stats.yaml")
+        with open(path, "w") as f:
+            yaml.dump({"ontologies": [
+                {"id": a, "source_bytes": mb * MB, "submission_id": "1"}
+                for a, mb in mb_by_acronym.items()
+            ]}, f, sort_keys=False)
+        return path
+
+    def run_shard(self, *args):
+        result = self.runner.invoke(main, ["shard-list", *args], catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0, result.output)
+        return result
+
+    def test_stdout_is_only_json(self):
+        result = self.run_shard("--ontologies", "A B C D", "--num_shards", "2")
+        self.assertEqual(len(json.loads(result.stdout.strip())), 2)
+
+    def test_shards_are_balanced_when_an_index_is_given(self):
+        index = self.index(RUN_2026_08_11)
+        result = self.run_shard(
+            "--ontologies", " ".join(ALPHABETICAL), "--num_shards", "6",
+            "--index", index,
+        )
+        shards = json.loads(result.stdout.strip())
+        self.assertEqual(len(shards), 6)
+        sizes = sizes_in_bytes(RUN_2026_08_11)
+        self.assertLess(spread([s.split() for s in shards], sizes), 1.3)
+
+    def test_every_ontology_survives_the_command(self):
+        index = self.index(RUN_2026_08_11)
+        result = self.run_shard(
+            "--ontologies", " ".join(ALPHABETICAL), "--num_shards", "6",
+            "--index", index,
+        )
+        scheduled = " ".join(json.loads(result.stdout.strip())).split()
+        self.assertEqual(sorted(scheduled), ALPHABETICAL)
+
+    def test_an_explicit_list_is_never_version_skipped(self):
+        # The workflow passes --index on both paths, for the sizes. Version-skip
+        # must still apply only to the full list, or a targeted re-run of an
+        # unchanged ontology would silently transform nothing.
+        index = self.index(RUN_2026_08_11)
+        result = self.run_shard(
+            "--ontologies", "BDPM FOODON", "--num_shards", "2", "--index", index)
+        scheduled = " ".join(json.loads(result.stdout.strip())).split()
+        self.assertEqual(sorted(scheduled), ["BDPM", "FOODON"])
+
+    def test_it_works_without_an_index(self):
+        result = self.run_shard("--ontologies", "A B C D E", "--num_shards", "2")
+        self.assertEqual(json.loads(result.stdout.strip()), ["A C E", "B D"])


### PR DESCRIPTION
Fixes #153, taking the suggested approach: LPT bin-packing weighted by `source_bytes` from the index.

## The result, on that run's own numbers

| | shard totals (MB) | spread |
|---|---|---|
| as it ran | 14, 34, 60, 68, 84, **195** | **13.9×** |
| after packing | 73, 73, 73, 74, 74, **88** | **1.21×** |

The heaviest is 88 MB against an ideal of 76 because **BDPM alone is 88 MB** and no packing splits a single ontology. At the heavy shard's own rate that's about 6 minutes rather than 14.

## The change

Heaviest ontology first, each onto whichever shard is currently lightest, ties broken on name so the same input always produces the same matrix. Weights come from `source_bytes` in the index the run already downloads. An ontology the index has never seen is a new submission, weighted at the **median** of the known sizes rather than the maximum, so one unknown can't dominate the packing.

Without an index there's nothing to balance on, and the assignment falls back to the round-robin it replaces rather than inventing an order.

## Two workflow changes, so it reaches the case that needs it most

The issue notes this bites hardest on targeted re-runs — and that path passed **no `--index` at all**, while the step that downloads the index was itself gated to full runs. So the case with few ontologies, few shards, and one heavyweight setting the wall-clock got no balancing whatsoever. Both now run on either path.

Passing `--index` on the targeted path does **not** turn on version-skip: that applies only to a full list read from the ontology file. A test holds that line — a targeted re-run that silently transformed nothing would be a much worse bug than a slow one.

## About the fixture

The tests use that run: the six shards exactly as reported, with sizes that sum to each shard's published total and the four named heavyweights (BDPM 88, FOODON 40, ICEO 37, RBO 29) at their published sizes. Two honest limits, both noted in the test module:

- the sizes *within* a shard are apportioned, not measured;
- the input order that produced those shards isn't recoverable — I checked, and the six rows don't interleave back into alphabetical order, so the issue's index arithmetic (3, 9, 15, 21 mod 6) can't be reconstructed from the report. The tests therefore compare against **the assignment that actually ran**, rather than recomputing round-robin over a guessed order.

26 new tests, covering the packing quality, that nothing is lost or duplicated, determinism, independence from input order, unknown sizes, index parsing (including junk `source_bytes`), and that the command still prints only JSON on stdout. Full suite: 299 passed.

As the issue says, `source_bytes` is a proxy: BDPM is 88 MB / 328s while FOODON is 40 MB / 126s, so it tracks well here. Now that #157 records per-ontology detail, recording transform duration in the stats would let a later run schedule on measured cost instead — a natural follow-up, not needed for this.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JM47TqJy5r9R2T2FgcWJhM)_