### PR TITLE
Count rdflib's literal warnings instead of printing 36,710 of them

### DIFF
--- a/.claude/skills/kg-bioportal-data/references/data-model.md
+++ b/.claude/skills/kg-bioportal-data/references/data-model.md
@@ -57,6 +57,11 @@ ontologies:
   detail: ''              # non-OK entries only, and only when there is something to
                           #   say: the message from the stage that failed, on one
                           #   line, truncated to 500 characters
+  malformed_literals: 0   # present only when non-zero: literals whose lexical
+                          #   form does not match their declared datatype (e.g.
+                          #   xsd:dateTime '06/09/2012'). A fact about the source,
+                          #   not a transform problem -- the values are kept as
+                          #   written and the graph is unaffected.
   nodecount: 5102         # 0 unless status OK
   edgecount: 8691
   submission_id: '6'      # BioPortal submission id

--- a/docs/kg_site/build_site.py
+++ b/docs/kg_site/build_site.py
@@ -168,6 +168,7 @@ def onto_to_item(o, transform_date):
         "bioportal_url": f"{BP}/ontologies/{oid}",
         "submission_id": o.get("submission_id", "NA"),
         "reason": o.get("reason", ""), "detail": o.get("detail", ""),
+        "malformed_literals": o.get("malformed_literals", 0),
         "transform_date": transform_date or "",
     }
 
@@ -975,6 +976,13 @@ def render_ontology_resource(it):
     # is the difference between "it failed" and knowing what to fix.
     if not ok and it.get("detail"):
         detail_rows.append(drow("Detail", f'<span class="mono">{esc(it["detail"])}</span>'))
+    # A data-quality fact about the source, not a problem with the transform:
+    # literals whose lexical form does not match the datatype they declare.
+    if it.get("malformed_literals"):
+        detail_rows.append(drow(
+            "Malformed literals",
+            f'{commafy(it["malformed_literals"])} <span class="muted">'
+            "(lexical form does not match the declared datatype; kept as written)</span>"))
     detail_rows += [
         drow("Version", esc(ver or "—")),
         drow("Submission", f'<span class="mono">{esc(sub)}</span>'),

--- a/src/kg_bioportal/transformer.py
+++ b/src/kg_bioportal/transformer.py
@@ -842,12 +842,21 @@ class TransformOutcome(NamedTuple):
     # cannot load is not "the convert step went wrong", it is a file we were
     # never going to be able to transform (#142).
     reason: str = ""
+    # Literals whose lexical form does not match their declared datatype -- a
+    # data-quality fact about the source, counted rather than logged (#152).
+    malformed_literals: int = 0
 
     @classmethod
     def failed(
-        cls, stage: str, detail: str = "", reason: str = ""
+        cls,
+        stage: str,
+        detail: str = "",
+        reason: str = "",
+        malformed_literals: int = 0,
     ) -> "TransformOutcome":
-        return cls(False, 0, 0, stage, summarize_detail(detail), reason)
+        return cls(
+            False, 0, 0, stage, summarize_detail(detail), reason, malformed_literals
+        )
 
 
 def summarize_detail(text: str, limit: int = MAX_DETAIL_CHARS) -> str:
@@ -860,6 +869,109 @@ def summarize_detail(text: str, limit: int = MAX_DETAIL_CHARS) -> str:
     if len(collapsed) <= limit:
         return collapsed
     return collapsed[: limit - 3].rstrip() + "..."
+
+
+# rdflib logs one warning per literal whose lexical form does not match its
+# declared datatype, with exc_info, so each costs two formatted tracebacks. One
+# ontology (BDPM, which types DD/MM/YYYY dates as xsd:dateTime) produced 36,710
+# of them in a single run -- about 95% of that shard's half-million log lines,
+# burying everything else in it (#152).
+_LITERAL_WARNING = "Failed to convert Literal lexical form to value"
+
+# The datatype is in the message; the offending value is only in the exception.
+_WARNING_DATATYPE = re.compile(r"Datatype=(\S+?),")
+_QUOTED_VALUE = re.compile(r"'([^']*)'")
+
+# Namespaces worth abbreviating in the summary line. XSD is essentially all of
+# them in practice, since it owns the datatypes with lexical rules.
+_DATATYPE_PREFIXES = {
+    "http://www.w3.org/2001/XMLSchema#": "xsd:",
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#": "rdf:",
+}
+
+
+def abbreviate_datatype(iri: str) -> str:
+    """``...XMLSchema#dateTime`` -> ``xsd:dateTime``, for a readable summary."""
+    for namespace, prefix in _DATATYPE_PREFIXES.items():
+        if iri.startswith(namespace):
+            return prefix + iri[len(namespace):]
+    return iri
+
+
+class LiteralConversionTally(logging.Filter):
+    """Counts rdflib's per-literal warnings instead of letting them print.
+
+    "This ontology has 36,710 literals whose lexical form does not match their
+    declared datatype" is a real fact about the source. Emitted once with a
+    count it is information; emitted 36,710 times with tracebacks it is noise
+    that hides every other line in the run -- and costs real time to format.
+
+    Only that one message is intercepted. Anything else rdflib's term logger has
+    to say still comes through.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.count = 0
+        self.by_datatype: dict = {}
+        self.example = ""
+
+    def filter(self, record: "logging.LogRecord") -> bool:
+        if record.levelno < logging.WARNING:
+            return True
+        try:
+            message = record.getMessage()
+        except Exception:  # a record we cannot even format is not ours to judge
+            return True
+        if _LITERAL_WARNING not in message:
+            return True
+
+        self.count += 1
+        match = _WARNING_DATATYPE.search(message)
+        datatype = abbreviate_datatype(match.group(1)) if match else "(no datatype)"
+        self.by_datatype[datatype] = self.by_datatype.get(datatype, 0) + 1
+        if not self.example:
+            self.example = self._describe(datatype, record)
+        return False  # counted; do not emit
+
+    @staticmethod
+    def _describe(datatype: str, record: "logging.LogRecord") -> str:
+        """One example, for a summary that names the actual problem."""
+        exception = record.exc_info[1] if record.exc_info else None
+        while exception is not None:
+            quoted = _QUOTED_VALUE.search(str(exception))
+            if quoted:
+                return f"{datatype} {quoted.group(0)}"
+            exception = exception.__cause__ or exception.__context__
+        return datatype
+
+    def summary(self) -> str:
+        """One line describing everything this tally swallowed."""
+        if not self.count:
+            return ""
+        worst = sorted(self.by_datatype.items(), key=lambda kv: (-kv[1], kv[0]))
+        datatypes = ", ".join(f"{name} x{n}" for name, n in worst[:3])
+        if len(worst) > 3:
+            datatypes += f", and {len(worst) - 3} more"
+        example = f" (e.g. {self.example})" if self.example else ""
+        return (
+            f"{self.count} literal(s) whose lexical form does not match their "
+            f"datatype [{datatypes}]{example}; values kept as written."
+        )
+
+    @contextmanager
+    def installed(self):
+        """Intercept the warnings for the duration of the block.
+
+        A filter on the logger itself drops the record before any handler sees
+        it, so nothing formats the tracebacks that make these expensive.
+        """
+        logger = logging.getLogger("rdflib.term")
+        logger.addFilter(self)
+        try:
+            yield self
+        finally:
+            logger.removeFilter(self)
 
 
 class TransformTimeout(Exception):
@@ -1077,6 +1189,9 @@ class Transformer:
             # entry would be a thousand lines of noise in the index.
             if detail:
                 entry["detail"] = detail
+            # Same reasoning: recorded only for the ontologies that have any.
+            if outcome.malformed_literals:
+                entry["malformed_literals"] = outcome.malformed_literals
             onto_log[ontology_name] = entry
 
         # Write total stats to a yaml
@@ -1274,15 +1389,19 @@ class Transformer:
         # Constructing the transformer is inside the try as well: it is part of
         # the KGX stage, and an exception raised out here would take down the
         # whole shard instead of costing one ontology.
+        literals = LiteralConversionTally()
         try:
-            txr = KGXTransformer(stream=True)
-            txr.transform(
-                input_args=input_args,
-                output_args=output_args,
-            )
+            with literals.installed():
+                txr = KGXTransformer(stream=True)
+                txr.transform(
+                    input_args=input_args,
+                    output_args=output_args,
+                )
             logging.info(
                 f"Nodes and edges written to {nodefilename} and {edgefilename}."
             )
+            if literals.count:
+                logging.warning(f"{ontology_name}: {literals.summary()}")
             # Get length of nodefile
             with open(nodefilename, "r") as f:
                 nodecount = len(f.readlines()) - 1
@@ -1323,9 +1442,17 @@ class Transformer:
             )
             # The exception type carries as much as its message does when the
             # message is empty, which some of KGX's are.
-            return TransformOutcome.failed("kgx", f"{type(e).__name__}: {e}")
+            if literals.count:
+                logging.warning(f"{ontology_name}: {literals.summary()}")
+            return TransformOutcome.failed(
+                "kgx",
+                f"{type(e).__name__}: {e}",
+                malformed_literals=literals.count,
+            )
 
-        return TransformOutcome(True, nodecount, edgecount)
+        return TransformOutcome(
+            True, nodecount, edgecount, malformed_literals=literals.count
+        )
 
     def decompress(self, ontology_path: str, ontology_name: str) -> str:
         """Decompresses a downloaded ontology archive.

--- a/src/kg_bioportal/transformer.py
+++ b/src/kg_bioportal/transformer.py
@@ -878,9 +878,46 @@ def summarize_detail(text: str, limit: int = MAX_DETAIL_CHARS) -> str:
 # burying everything else in it (#152).
 _LITERAL_WARNING = "Failed to convert Literal lexical form to value"
 
-# The datatype is in the message; the offending value is only in the exception.
+# The datatype is in the message; the offending value is in neither the message
+# nor, reliably, the exception text -- see _offending_value.
 _WARNING_DATATYPE = re.compile(r"Datatype=(\S+?),")
 _QUOTED_VALUE = re.compile(r"'([^']*)'")
+
+
+def _offending_value(record: "logging.LogRecord") -> Optional[str]:
+    """The literal rdflib could not convert, from the frame that failed.
+
+    Read out of the traceback rather than out of the exception's prose, because
+    the prose depends on which converter is installed and does not reliably put
+    the value first. rdflib's own ``_castLexicalToPython(lexical, datatype)`` is
+    the frame the exception was raised in, so its ``lexical`` is exactly the
+    value, whatever converter raised:
+
+        isodate:        "ISO 8601 time designator 'T' missing. Unable to parse
+                         datetime string '06/09/2012'"     <- 'T' comes first
+        fromisoformat:  "Invalid isoformat string: '06/09/2012'"
+
+    Falls back to the longest quoted run in the exception chain, for a future
+    rdflib that names the variable something else -- longest rather than first
+    for the same reason: 'T' is quoted too.
+    """
+    if not record.exc_info:
+        return None
+    _, exception, traceback = record.exc_info
+
+    while traceback is not None:
+        lexical = traceback.tb_frame.f_locals.get("lexical")
+        if isinstance(lexical, str):
+            return lexical
+        traceback = traceback.tb_next
+
+    best = None
+    while exception is not None:
+        for quoted in _QUOTED_VALUE.findall(str(exception)):
+            if best is None or len(quoted) > len(best):
+                best = quoted
+        exception = exception.__cause__ or exception.__context__
+    return best
 
 # Namespaces worth abbreviating in the summary line. XSD is essentially all of
 # them in practice, since it owns the datatypes with lexical rules.
@@ -937,13 +974,8 @@ class LiteralConversionTally(logging.Filter):
     @staticmethod
     def _describe(datatype: str, record: "logging.LogRecord") -> str:
         """One example, for a summary that names the actual problem."""
-        exception = record.exc_info[1] if record.exc_info else None
-        while exception is not None:
-            quoted = _QUOTED_VALUE.search(str(exception))
-            if quoted:
-                return f"{datatype} {quoted.group(0)}"
-            exception = exception.__cause__ or exception.__context__
-        return datatype
+        value = _offending_value(record)
+        return f"{datatype} {value!r}" if value is not None else datatype
 
     def summary(self) -> str:
         """One line describing everything this tally swallowed."""

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -110,6 +110,23 @@ class TestFailureDetail(TestCase):
         self.assertNotIn("<http://x/y>", html)
         self.assertIn("&lt;http://x/y&gt;", html)
 
+    def test_malformed_literal_counts_are_shown(self):
+        html = bs.render_ontology_resource(item(
+            "BDPM", "OK", nodecount=41274, edgecount=253806,
+            malformed_literals=36710))
+        self.assertIn("Malformed literals", html)
+        self.assertIn("36,710", html)
+
+    def test_the_literal_count_is_not_presented_as_a_failure(self):
+        # The graph is fine; the values are kept as written.
+        html = bs.render_ontology_resource(item(
+            "BDPM", "OK", nodecount=1, edgecount=1, malformed_literals=5))
+        self.assertIn("kept as written", html)
+
+    def test_an_ontology_with_no_bad_literals_shows_no_such_row(self):
+        html = bs.render_ontology_resource(item("AGRO", "OK", nodecount=5, edgecount=6))
+        self.assertNotIn("Malformed literals", html)
+
     def test_an_ok_ontology_shows_no_detail_row(self):
         html = bs.render_ontology_resource(item("AGRO", "OK", nodecount=5, edgecount=6))
         self.assertNotIn(">Detail<", html)

--- a/tests/test_literal_tally.py
+++ b/tests/test_literal_tally.py
@@ -27,6 +27,7 @@ from kg_bioportal.robot_utils import RobotResult
 from kg_bioportal.transformer import (
     LiteralConversionTally,
     Transformer,
+    _offending_value,
     abbreviate_datatype,
 )
 
@@ -123,6 +124,75 @@ class TestNothingIsPrinted(TestCase):
         record = logging.LogRecord(
             "rdflib.term", logging.WARNING, __file__, 1, "%d", ("not an int",), None)
         self.assertTrue(tally.filter(record))
+
+
+class TestTheExampleIsTheValue(TestCase):
+    """Which quoted string is the offending literal depends on the environment.
+
+    rdflib picks its dateTime converter from what is installed, and the two
+    phrase the failure differently:
+
+        isodate:       "ISO 8601 time designator 'T' missing. Unable to parse
+                        datetime string '06/09/2012'"
+        fromisoformat: "Invalid isoformat string: '06/09/2012'"
+
+    Taking the first quoted run gives 'T' on the isodate stack -- which is the
+    one the pipeline actually runs on. So the value is read from the frame that
+    failed, and these pin both shapes regardless of which is installed here.
+    """
+
+    def record_for(self, exception, lexical=None):
+        """A warning record like rdflib's, optionally with a real frame."""
+        def cast(lexical):  # stands in for rdflib's _castLexicalToPython
+            raise exception
+
+        try:
+            if lexical is None:
+                raise exception
+            cast(lexical)
+        except Exception:
+            import sys
+
+            return logging.LogRecord(
+                "rdflib.term", logging.WARNING, __file__, 1,
+                "Failed to convert Literal lexical form to value. "
+                "Datatype=http://www.w3.org/2001/XMLSchema#dateTime, Converter=x",
+                (), sys.exc_info())
+
+    def test_the_isodate_phrasing_does_not_yield_the_designator(self):
+        record = self.record_for(
+            ValueError("ISO 8601 time designator 'T' missing. Unable to parse "
+                       "datetime string '06/09/2012'"),
+            lexical="06/09/2012")
+        self.assertEqual(_offending_value(record), "06/09/2012")
+
+    def test_the_fromisoformat_phrasing_works_too(self):
+        record = self.record_for(
+            ValueError("Invalid isoformat string: '06/09/2012'"),
+            lexical="06/09/2012")
+        self.assertEqual(_offending_value(record), "06/09/2012")
+
+    def test_without_a_frame_the_longest_quoted_run_wins(self):
+        # The fallback, for an rdflib that names the variable something else.
+        record = self.record_for(
+            ValueError("ISO 8601 time designator 'T' missing. Unable to parse "
+                       "datetime string '06/09/2012'"))
+        self.assertEqual(_offending_value(record), "06/09/2012")
+
+    def test_a_record_with_no_exception_has_no_value(self):
+        record = logging.LogRecord(
+            "rdflib.term", logging.WARNING, __file__, 1, "msg", (), None)
+        self.assertIsNone(_offending_value(record))
+
+    def test_the_summary_survives_a_value_it_cannot_find(self):
+        tally = LiteralConversionTally()
+        record = logging.LogRecord(
+            "rdflib.term", logging.WARNING, __file__, 1,
+            "Failed to convert Literal lexical form to value. "
+            "Datatype=http://www.w3.org/2001/XMLSchema#dateTime, Converter=x",
+            (), None)
+        self.assertFalse(tally.filter(record))
+        self.assertIn("xsd:dateTime", tally.summary())
 
 
 class TestSummary(TestCase):

--- a/tests/test_literal_tally.py
+++ b/tests/test_literal_tally.py
@@ -1,0 +1,259 @@
+"""One ontology's warnings should not bury a whole shard's log.
+
+BDPM types its dates as xsd:dateTime and writes them DD/MM/YYYY, so rdflib
+warned once per literal -- 36,710 times, each with exc_info, which is two
+formatted tracebacks apiece. That was about 95% of that shard's 515,366 log
+lines, and a real ROBOT or KGX error in the same shard was one line among half
+a million (#152).
+
+None of it was a failure: rdflib keeps the lexical form and BDPM transformed
+fine. So the fix counts rather than silences -- the same fact, said once, and
+carried into the stats where it is a data-quality signal about the source
+rather than noise.
+
+The rdflib warning these tests exercise is the real one: the fixtures are
+parsed by rdflib, not hand-built log records.
+"""
+
+import logging
+import os
+import tempfile
+from unittest import TestCase, mock
+
+import rdflib
+import yaml
+
+from kg_bioportal.robot_utils import RobotResult
+from kg_bioportal.transformer import (
+    LiteralConversionTally,
+    Transformer,
+    abbreviate_datatype,
+)
+
+# Dates written the way BDPM writes them, declared as xsd:dateTime.
+BAD_LITERALS = """@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex: <http://example.org/ns#> .
+ex:a ex:date "06/09/2012"^^xsd:dateTime .
+ex:b ex:date "31/12/2024"^^xsd:dateTime .
+ex:c ex:count "not-a-number"^^xsd:integer .
+ex:d ex:date "2012-06-09T00:00:00"^^xsd:dateTime .
+"""
+
+RDFXML = """<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#">
+  <owl:Ontology rdf:about="http://example.org/onto"/>
+</rdf:RDF>
+"""
+
+
+def parse_with(tally):
+    """Parse the fixture with the tally installed, as the transform does."""
+    with tally.installed():
+        graph = rdflib.Graph()
+        graph.parse(data=BAD_LITERALS, format="turtle")
+    return graph
+
+
+class TestTallyCounts(TestCase):
+    def setUp(self):
+        self.tally = LiteralConversionTally()
+        self.graph = parse_with(self.tally)
+
+    def test_every_bad_literal_is_counted(self):
+        self.assertEqual(self.tally.count, 3)
+
+    def test_a_well_formed_literal_is_not_counted(self):
+        # The fourth triple's date is a valid xsd:dateTime.
+        self.assertEqual(len(self.graph), 4)
+
+    def test_the_datatypes_are_broken_down(self):
+        self.assertEqual(self.tally.by_datatype,
+                         {"xsd:dateTime": 2, "xsd:integer": 1})
+
+    def test_an_example_names_the_offending_value(self):
+        # The value is only in the exception, not in rdflib's message, and it
+        # is the thing that tells a maintainer what to fix.
+        self.assertIn("06/09/2012", self.tally.example)
+        self.assertIn("xsd:dateTime", self.tally.example)
+
+    def test_a_clean_graph_counts_nothing(self):
+        tally = LiteralConversionTally()
+        with tally.installed():
+            rdflib.Graph().parse(
+                data='<http://example.org/a> <http://example.org/b> "plain" .',
+                format="turtle")
+        self.assertEqual(tally.count, 0)
+        self.assertEqual(tally.summary(), "")
+
+
+class TestNothingIsPrinted(TestCase):
+    """The point of the exercise: the log stops carrying 36,710 tracebacks."""
+
+    def test_the_warnings_do_not_reach_a_handler(self):
+        tally = LiteralConversionTally()
+        with self.assertLogs("rdflib.term", level="DEBUG") as captured:
+            logging.getLogger("rdflib.term").debug("marker")  # so assertLogs has one
+            parse_with(tally)
+        self.assertEqual(captured.output, ["DEBUG:rdflib.term:marker"])
+        self.assertEqual(tally.count, 3)
+
+    def test_the_warnings_come_back_after_the_block(self):
+        # The filter is removed again: a later ontology's warnings are not
+        # silently swallowed by a tally nobody is reading.
+        tally = LiteralConversionTally()
+        parse_with(tally)
+        with self.assertLogs("rdflib.term", level="WARNING") as captured:
+            rdflib.Graph().parse(data=BAD_LITERALS, format="turtle")
+        self.assertTrue(captured.output)
+
+    def test_other_warnings_from_the_same_logger_still_print(self):
+        # rdflib.term also warns about things like an IRI that will not
+        # serialize -- suppressing those would hide a real problem.
+        tally = LiteralConversionTally()
+        with tally.installed():
+            with self.assertLogs("rdflib.term", level="WARNING") as captured:
+                logging.getLogger("rdflib.term").warning(
+                    "does not look like a valid URI, trying to serialize this will break.")
+        self.assertEqual(len(captured.output), 1)
+        self.assertEqual(tally.count, 0)
+
+    def test_a_record_that_cannot_be_formatted_is_left_alone(self):
+        tally = LiteralConversionTally()
+        record = logging.LogRecord(
+            "rdflib.term", logging.WARNING, __file__, 1, "%d", ("not an int",), None)
+        self.assertTrue(tally.filter(record))
+
+
+class TestSummary(TestCase):
+    def test_the_summary_says_the_count(self):
+        tally = LiteralConversionTally()
+        parse_with(tally)
+        self.assertIn("3 literal", tally.summary())
+
+    def test_the_summary_names_the_datatypes(self):
+        tally = LiteralConversionTally()
+        parse_with(tally)
+        self.assertIn("xsd:dateTime x2", tally.summary())
+
+    def test_the_summary_says_the_values_are_kept(self):
+        # It is not a failure and should not read like one.
+        tally = LiteralConversionTally()
+        parse_with(tally)
+        self.assertIn("kept as written", tally.summary())
+
+    def test_the_summary_is_one_line(self):
+        tally = LiteralConversionTally()
+        parse_with(tally)
+        self.assertNotIn("\n", tally.summary())
+
+    def test_many_datatypes_are_truncated(self):
+        tally = LiteralConversionTally()
+        tally.count = 10
+        tally.by_datatype = {f"xsd:t{i}": 1 for i in range(6)}
+        self.assertIn("and 3 more", tally.summary())
+
+
+class TestAbbreviation(TestCase):
+    def test_xsd_is_abbreviated(self):
+        self.assertEqual(
+            abbreviate_datatype("http://www.w3.org/2001/XMLSchema#dateTime"),
+            "xsd:dateTime")
+
+    def test_an_unknown_namespace_is_left_whole(self):
+        self.assertEqual(abbreviate_datatype("http://example.org/my#type"),
+                         "http://example.org/my#type")
+
+
+class TestItReachesTheStats(TestCase):
+    """The count is per-ontology data quality, so it belongs in the index."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.input_dir = os.path.join(self._tmp.name, "raw")
+        self.output_dir = os.path.join(self._tmp.name, "transformed")
+        os.makedirs(self.output_dir, exist_ok=True)
+
+        self.txr = Transformer.__new__(Transformer)
+        self.txr.input_dir = self.input_dir
+        self.txr.output_dir = self.output_dir
+        self.txr.timeout_sec = 60
+        self.txr.timeout_min = 1
+        self.txr.max_source_bytes = 0
+        self.txr.robot_path = "/nonexistent/robot"
+        self.txr.robot_env = {}
+
+        self.source = os.path.join(self.input_dir, "ONTO", "1", "onto.owl")
+        os.makedirs(os.path.dirname(self.source), exist_ok=True)
+        with open(self.source, "w") as f:
+            f.write(RDFXML)
+
+    def run_transform(self, warnings=0, kgx_raises=None, all_at_once=False):
+        """Run one ontology through; KGX emits `warnings` bad literals."""
+        def robot(**kwargs):
+            os.makedirs(os.path.dirname(kwargs["output_path"]), exist_ok=True)
+            with open(kwargs["output_path"], "w") as f:
+                f.write(RDFXML)
+            return RobotResult(True)
+
+        class FakeKGX:
+            def __init__(self, *a, **k):
+                pass
+
+            def transform(self, input_args, output_args):
+                # Emit the real rdflib warning, the real number of times.
+                for i in range(warnings):
+                    rdflib.Graph().parse(
+                        data='@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n'
+                             f'<http://example.org/{i}> <http://example.org/d> '
+                             '"06/09/2012"^^xsd:dateTime .',
+                        format="turtle")
+                if kgx_raises is not None:
+                    raise kgx_raises
+                for suffix in ("_nodes.tsv", "_edges.tsv"):
+                    with open(output_args["filename"] + suffix, "w") as fh:
+                        fh.write("id\n")
+
+        with mock.patch("kg_bioportal.transformer.robot_convert", robot), \
+             mock.patch("kg_bioportal.transformer.robot_relax", robot), \
+             mock.patch("kg_bioportal.transformer.KGXTransformer", FakeKGX):
+            if all_at_once:
+                self.txr.transform_all(compress=False)
+                return None
+            return self.txr.transform(self.source, compress=False)
+
+    def stats(self):
+        with open(os.path.join(self.output_dir, "onto_stats.yaml")) as f:
+            return {o["id"]: o for o in yaml.safe_load(f)["ontologies"]}["ONTO"]
+
+    def test_the_count_reaches_the_outcome(self):
+        outcome = self.run_transform(warnings=5)
+        self.assertTrue(outcome.success)
+        self.assertEqual(outcome.malformed_literals, 5)
+
+    def test_the_count_reaches_onto_stats(self):
+        self.run_transform(warnings=5, all_at_once=True)
+        self.assertEqual(self.stats()["malformed_literals"], 5)
+
+    def test_a_clean_ontology_carries_no_field(self):
+        # A zero on every one of 1135 OK entries would be noise in the index.
+        self.run_transform(warnings=0, all_at_once=True)
+        self.assertNotIn("malformed_literals", self.stats())
+
+    def test_the_ontology_still_transforms(self):
+        # This is not a failure mode: the graph is fine, the literals are kept.
+        self.run_transform(warnings=3, all_at_once=True)
+        self.assertEqual(self.stats()["status"], "OK")
+
+    def test_a_kgx_failure_still_reports_what_it_counted(self):
+        outcome = self.run_transform(warnings=4, kgx_raises=ValueError("boom"))
+        self.assertEqual(outcome.stage, "kgx")
+        self.assertEqual(outcome.malformed_literals, 4)
+
+    def test_one_line_is_logged_not_thousands(self):
+        with self.assertLogs("root", level="WARNING") as captured:
+            self.run_transform(warnings=25)
+        summaries = [line for line in captured.output if "lexical form" in line]
+        self.assertEqual(len(summaries), 1, captured.output)
+        self.assertIn("25 literal", summaries[0])


### PR DESCRIPTION
Fixes #152, taking the tally rather than the one-line suppression — the count is a real fact about the source and worth keeping.

## What it does

A filter on the `rdflib.term` logger intercepts that one message, tallies it by datatype, and keeps one example. A filter on the *logger* drops the record before any handler sees it, so nothing formats the tracebacks that make these expensive. One line per ontology:

```
BDPM: 36710 literal(s) whose lexical form does not match their datatype
[xsd:dateTime x36710] (e.g. xsd:dateTime '06/09/2012'); values kept as written.
```

The count goes into `onto_stats.yaml` alongside the fields from #134, and onto the ontology's page on the site, worded so it doesn't read as a failure — because it isn't one. rdflib keeps the lexical form; BDPM transformed fine (41,274 nodes, 253,806 edges).

## Getting the example right — CI caught a real defect here

rdflib's message carries the *datatype* but not the offending *value*. My first version scraped the value out of the exception text, taking the first quoted run. **CI failed**, and it was the code that was wrong, not the test.

rdflib picks its dateTime converter **by Python version** — `datetime.fromisoformat` on 3.11+, `isodate.parse_datetime` below — and the two word the failure differently:

```
fromisoformat   Invalid isoformat string: '06/09/2012'
isodate         ISO 8601 time designator 'T' missing. Unable to parse datetime string '06/09/2012'
```

On the isodate path the first quoted run is `'T'`, so the summary would have read `e.g. xsd:dateTime 'T'` — useless, and on exactly the stack that matters: CI runs Python 3.10, and so does the transform workflow. My sandbox is 3.11, which is why it passed locally.

The fix reads the value from the **traceback** instead: rdflib raises from inside `_castLexicalToPython(lexical, datatype)`, so that frame's `lexical` *is* the value, whatever converter failed and however it phrases things. The prose scan stays as a fallback for a future rdflib that renames the variable — now taking the longest quoted run rather than the first, since `'T'` is quoted too.

Verified by reproducing CI's path locally with the real isodate exception raised from a frame shaped like rdflib's: old code answered `'T'`, this answers `'06/09/2012'`. Both message shapes are pinned by tests, so neither Python version can regress the other.

## Measured at BDPM's own scale

36,710 literals, same fixture, log captured to a buffer:

| | time | log |
|---|---|---|
| warnings printed (today) | 10.84 s | 16.23 MB, 220,260 lines |
| warnings counted (this PR) | 8.12 s | none |
| *parsing the same literals when well formed* | *7.76 s* | *—* |

So the logging overhead drops from 3.08 s to 0.36 s. The real run's logs were larger still — ~490k lines rather than 220k — because its rdflib emitted two tracebacks per warning where mine emits one.

## Kept narrow

- **Only that message is intercepted.** Anything else `rdflib.term` says still prints — including the "does not look like a valid URI, trying to serialize this will break" warning, which is a genuine problem and would be a bad thing to have silenced. A test holds that line.
- **The filter is removed at the end of the block**, so a later ontology's warnings aren't swallowed by a tally nobody reads. Also tested.
- **Written only when non-zero.** A `malformed_literals: 0` on each of 1135 OK entries would be its own kind of noise.
- A record that can't even be formatted is passed through rather than judged.

## Tests

27 new. The core ones drive **real rdflib parses** rather than hand-built log records, so they exercise the actual message, the actual `exc_info` chain, and the actual suppression path; the value-extraction ones cover both converters' phrasings explicitly, since the environment decides which you get. Together they cover the count and per-datatype breakdown, the example, that nothing reaches a handler, that unrelated warnings still do, that the filter is uninstalled afterwards, the summary's wording, and the count reaching `onto_stats.yaml` (including on a KGX failure, where it's still true). Plus 3 for the site rendering. Full suite: 329 passed.

## Not done here

BDPM's dates are wrong at source and worth reporting to its maintainers via BioPortal, as the issue notes. That needs a person to send it — happy to draft it.