### PR TITLE
Retry what failed, so a fix reaches the ontologies it fixes

### DIFF
--- a/src/kg_bioportal/cli.py
+++ b/src/kg_bioportal/cli.py
@@ -53,11 +53,17 @@ def _read_ontology_submissions(ontology_file: str) -> dict:
 
 
 def _load_index_submissions(index_path: str) -> dict:
-    """Read {acronym: submission_id} from an onto_stats.yaml index.
+    """Read {acronym: submission_id} for the entries worth carrying forward.
 
-    Only entries with a concrete submission_id are returned (skiplisted / no-
-    submission entries use 'NA' and are excluded), so a later run always treats
-    those as needing a transform.
+    Version-skip exists so a run only (re)transforms what changed. What it must
+    carry forward is a graph we *have*: an entry that failed has no artifact, so
+    skipping it keeps it missing until BioPortal happens to publish a new
+    submission -- which means a fix to this pipeline never reaches the
+    ontologies it fixes. So only OK entries are returned; anything else is
+    treated as needing a transform.
+
+    Entries with no concrete submission_id ('NA' -- skiplisted, or never
+    downloaded) are excluded too, as they always were.
     """
     import yaml
 
@@ -67,6 +73,8 @@ def _load_index_submissions(index_path: str) -> dict:
         data = yaml.safe_load(f) or {}
     out = {}
     for entry in data.get("ontologies", []):
+        if entry.get("status") != "OK":
+            continue  # no artifact to carry forward; try it again
         sub = str(entry.get("submission_id") or "").strip()
         if sub and sub != "NA":
             out[entry["id"]] = sub
@@ -413,9 +421,11 @@ def transform(input_dir, output_dir, compress, timeout_min, max_source_mb) -> No
     "index_path",
     required=False,
     type=click.Path(),
-    help="Path to the current onto_stats.yaml index. If given (with --ontology_file), "
-    "only ontologies whose BioPortal submission_id differs from the index are sharded "
-    "(version-skip); unchanged ones carry forward via the finalize seed.",
+    help="Path to the current onto_stats.yaml index. Supplies the source sizes the "
+    "shards are balanced by. With --ontology_file it also version-skips: an "
+    "ontology is sharded unless the index already holds a graph for it (status OK) "
+    "at the submission BioPortal is serving now. Those carry forward via the "
+    "finalize seed; everything else, including previous failures, is retried.",
 )
 def shard_list(ontology_file, ontologies, num_shards, use_skiplist, index_path) -> None:
     """Splits the ontology list into N shards and prints them as JSON.
@@ -433,8 +443,9 @@ def shard_list(ontology_file, ontologies, num_shards, use_skiplist, index_path) 
     else:
         raise click.UsageError("Provide --ontologies or --ontology_file.")
 
-    # Version-skip: only (re)transform ontologies that are new or whose BioPortal
-    # submission changed vs the current index. Applies only to the full list.
+    # Version-skip: only (re)transform ontologies that are new, whose BioPortal
+    # submission changed vs the current index, or that have no graph to carry
+    # forward. Applies only to the full list.
     if index_path and current_subs:
         index_subs = _load_index_submissions(index_path)
         if index_subs:
@@ -445,7 +456,8 @@ def shard_list(ontology_file, ontologies, num_shards, use_skiplist, index_path) 
             ]
             click.echo(
                 f"version-skip: {before - len(acronyms)} unchanged skipped, "
-                f"{len(acronyms)} to transform.",
+                f"{len(acronyms)} to transform (including anything that has no "
+                "graph in the index yet).",
                 err=True,
             )
 

--- a/tests/test_version_skip.py
+++ b/tests/test_version_skip.py
@@ -1,0 +1,177 @@
+"""A run should skip what it already has, not what it failed to build.
+
+Version-skip stops a monthly run re-transforming 1100 unchanged ontologies. It
+did that by comparing submission ids alone, which also skipped every *failed*
+ontology whose submission had not moved -- so a failure was carried forward as
+if it were a graph, and a fix to this pipeline could never reach the ontologies
+it fixed. The five transform fixes in #138, #139, #141, #142 and #152 would
+have gone to nothing on the next scheduled run: those ontologies' submissions
+have not changed, so none of them would have been retried.
+
+What is worth carrying forward is an artifact we have. Anything else gets
+another go.
+"""
+
+import json
+import os
+import tempfile
+from unittest import TestCase
+
+import yaml
+from click.testing import CliRunner
+
+from kg_bioportal.cli import main
+
+
+def entry(oid, status="OK", submission="1", reason="", **kw):
+    e = {
+        "id": oid, "status": status, "reason": reason, "name": oid,
+        "submission_id": submission, "source_bytes": 1000,
+        "nodecount": 10 if status == "OK" else 0,
+        "edgecount": 20 if status == "OK" else 0,
+    }
+    e.update(kw)
+    return e
+
+
+class VersionSkipTestCase(TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.runner = CliRunner()
+
+    def index(self, entries):
+        path = os.path.join(self._tmp.name, "onto_stats.yaml")
+        with open(path, "w") as f:
+            yaml.dump({"ontologies": entries}, f, sort_keys=False)
+        return path
+
+    def bioportal_list(self, submissions):
+        """The ontology list as BioPortal currently serves it."""
+        path = os.path.join(self._tmp.name, "ontologylist.tsv")
+        with open(path, "w") as f:
+            f.write("id\tname\tversion\tsubmission_id\n")
+            for acr, sub in submissions.items():
+                f.write(f"{acr}\tname\tv1\t{sub}\n")
+        return path
+
+    def scheduled(self, entries, submissions):
+        """The acronyms a scheduled run would transform."""
+        result = self.runner.invoke(
+            main,
+            ["shard-list", "-f", self.bioportal_list(submissions), "-n", "5",
+             "--index", self.index(entries)],
+            catch_exceptions=False,
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        return sorted(" ".join(json.loads(result.stdout.strip())).split())
+
+
+class TestWhatIsCarriedForward(VersionSkipTestCase):
+    def test_an_unchanged_ok_ontology_is_skipped(self):
+        # The whole point of version-skip: 1100 graphs do not get rebuilt.
+        self.assertEqual(
+            self.scheduled([entry("AGRO")], {"AGRO": "1"}), [])
+
+    def test_a_changed_ok_ontology_is_transformed(self):
+        self.assertEqual(
+            self.scheduled([entry("AGRO", submission="1")], {"AGRO": "2"}), ["AGRO"])
+
+    def test_an_ontology_not_in_the_index_is_transformed(self):
+        self.assertEqual(self.scheduled([entry("AGRO")], {"NEW": "1"}), ["NEW"])
+
+
+class TestFailuresAreRetried(VersionSkipTestCase):
+    """The change: a failure has no artifact, so it is not worth keeping."""
+
+    def test_a_transform_failure_is_retried(self):
+        # This is the case that matters: FYPO failed, BioPortal has not
+        # republished it, and a fix landed on our side in the meantime.
+        self.assertEqual(
+            self.scheduled(
+                [entry("FYPO", status="Failed", reason="transform_error_relax")],
+                {"FYPO": "1"}),
+            ["FYPO"])
+
+    def test_every_transform_error_stage_is_retried(self):
+        stages = ["decompress", "convert", "relax", "kgx"]
+        entries = [entry(f"O{i}", status="Failed", reason=f"transform_error_{s}")
+                   for i, s in enumerate(stages)]
+        self.assertEqual(
+            self.scheduled(entries, {f"O{i}": "1" for i in range(len(stages))}),
+            sorted(f"O{i}" for i in range(len(stages))))
+
+    def test_a_skipped_ontology_is_retried(self):
+        # too_slow and too_large are worth another go: the gates are configurable
+        # and the runner's capacity changes.
+        self.assertEqual(
+            self.scheduled(
+                [entry("ROR", status="Skipped", reason="too_large")], {"ROR": "1"}),
+            ["ROR"])
+
+    def test_an_unusable_source_is_retried(self):
+        # Cheap: it fails again at convert in seconds, and if the maintainers
+        # fix the file without a new submission, we pick it up.
+        self.assertEqual(
+            self.scheduled(
+                [entry("NCOD", status="Failed", reason="invalid_source")],
+                {"NCOD": "1"}),
+            ["NCOD"])
+
+    def test_a_licensed_ontology_is_retried_but_costs_nothing(self):
+        # No source is served, so it stops at download. Keeping it in the run
+        # means a licence that becomes available is noticed.
+        self.assertEqual(
+            self.scheduled(
+                [entry("NDDF", status="Failed", reason="license_restricted")],
+                {"NDDF": "1"}),
+            ["NDDF"])
+
+    def test_a_download_failure_was_already_retried(self):
+        # These carry submission_id NA, so they were never skipped; the change
+        # does not alter them.
+        self.assertEqual(
+            self.scheduled(
+                [entry("X", status="Failed", reason="no_download_file",
+                       submission="NA")],
+                {"X": "3"}),
+            ["X"])
+
+
+class TestTheMixedRun(VersionSkipTestCase):
+    """What a real monthly run looks like after the change."""
+
+    def setUp(self):
+        super().setUp()
+        self.entries = [
+            entry("AGRO"),                                     # fine, unchanged
+            entry("CHEBI"),                                    # fine, unchanged
+            entry("UBERON", submission="4"),                   # fine, republished
+            entry("FYPO", status="Failed", reason="transform_error_kgx"),
+            entry("ELD", status="Failed", reason="transform_error_relax"),
+            entry("ROR", status="Skipped", reason="too_large"),
+        ]
+        self.submissions = {"AGRO": "1", "CHEBI": "1", "UBERON": "5",
+                            "FYPO": "1", "ELD": "1", "ROR": "1", "BRANDNEW": "1"}
+
+    def test_only_the_working_unchanged_graphs_are_skipped(self):
+        self.assertEqual(
+            self.scheduled(self.entries, self.submissions),
+            ["BRANDNEW", "ELD", "FYPO", "ROR", "UBERON"])
+
+    def test_the_count_of_skips_is_reported(self):
+        result = self.runner.invoke(
+            main,
+            ["shard-list", "-f", self.bioportal_list(self.submissions), "-n", "5",
+             "--index", self.index(self.entries)],
+            catch_exceptions=False,
+        )
+        self.assertIn("2 unchanged skipped", result.stderr)
+
+    def test_a_run_with_nothing_to_do_is_still_a_no_op(self):
+        # A month where nothing changed and nothing failed must stay empty, or
+        # the scheduled run stops being free.
+        self.assertEqual(
+            self.scheduled([entry("AGRO"), entry("CHEBI")],
+                           {"AGRO": "1", "CHEBI": "1"}),
+            [])


### PR DESCRIPTION
Found while investigating #31, which asked for the opposite. That behaviour turned out to already exist — in this code — and to be a problem.

## The bug

Version-skip compared submission ids alone, so an ontology that **failed** was carried forward exactly like one that succeeded. But there's no artifact behind a failure, and the effect is that **a fix to this pipeline never reaches the ontologies it fixes** — they stay broken until BioPortal happens to publish a new submission, which for a stable ontology may be never.

Not hypothetical. Verified against the current CLI:

```
index: FYPO  Failed / transform_error_relax, submission 3
list:  FYPO  submission 3
→ version-skip: 2 unchanged skipped, 1 to transform.
→ shards: ["NEWONE"]          # FYPO not retried
```

The five transform fixes merged today (#138, #139, #141, #142, #152) all target ontologies whose submissions haven't changed. **The next scheduled run would have skipped every one of them**, and none of those fixes would have shown up.

## The change

Version-skip now carries forward only what it has a graph for: an index entry with `status: OK`, at the submission BioPortal serves now. Anything else gets another go.

## What it costs

109 ontologies added to a monthly run, 8% of 1292:

| reason | count | cost |
|---|---:|---|
| `transform_error` | 36 | 11 MB of source — the ones just fixed |
| `no_download_file` | 36 | stops at the metadata call |
| `too_large` | 29 | see below |
| `license_restricted` | 8 | no source is served |

The 29 `too_large` entries total 5.8 GB of *source*, but don't cost that: the downloader checks `Content-Length` first and skips without fetching, and otherwise streams with a hard abort at the cap. Each costs a header check, or at most `max_source_mb`. It also means **raising the gate (#118) picks them up by itself**, instead of needing a hand-driven re-run.

The 48 entries whose `submission_id` is `NA` were never skipped in the first place — unaffected.

## One behaviour change worth your attention

**A month in which nothing changed is no longer a clean no-op**, because the standing failures are retried. In practice a month where none of 1292 ontologies republishes doesn't happen, and the alternative is fixes that never land — but it is a change to a property the workflow comments call out, so push back if you'd rather I narrow it to `transform_error*` only (36 ontologies, 11 MB). A run with no failures *and* no changes is still a no-op, and a test holds that.

12 new tests: what's carried forward, each failure class being retried, the `NA` entries unchanged, a realistic mixed run, and the no-op case. Full suite: 341 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JM47TqJy5r9R2T2FgcWJhM)_