### PR TITLE
Two fixes the 2026-08-25 run exposed: source attribution, and shard cost

### DIFF
--- a/.claude/skills/kg-bioportal-data/references/data-model.md
+++ b/.claude/skills/kg-bioportal-data/references/data-model.md
@@ -50,7 +50,10 @@ ontologies:
                           #   invalid_source: the file BioPortal serves cannot be read
                           #   as an ontology at all; `detail` says whether it is broken
                           #   RDF (with the parse error) or valid RDF that ROBOT will
-                          #   not load. Not fixable on this side.
+                          #   not load. Not fixable on this side — and the check is
+                          #   made against BioPortal's own file, so a source we
+                          #   ourselves corrupted while stripping imports is recorded
+                          #   as transform_error_convert instead, saying so.
                           #   <stage> is decompress | convert | relax | kgx — which
                           #   step lost the ontology. Entries from runs before this
                           #   was recorded carry a bare `transform_error`.

--- a/.github/workflows/transform.yml
+++ b/.github/workflows/transform.yml
@@ -82,11 +82,16 @@ jobs:
         # Both pass --index: it carries the source sizes the shards are balanced
         # by, and version-skip applies only to the full list, so an explicit list
         # is still transformed exactly as given.
+        #
+        # --max_source_mb must match the one `transform` runs under: an ontology
+        # the index already shows above the gate is skipped at download, so it
+        # weighs nothing here. Without it the 2026-08-25 run gave four such
+        # giants a shard each and eight of twenty shards did no work at all.
         run: |
           if [ -n "${{ github.event.inputs.ontologies }}" ]; then
-            SHARDS=$(kgbioportal shard-list -d "${{ github.event.inputs.ontologies }}" -n "$NUM_SHARDS" --index prev/onto_stats.yaml)
+            SHARDS=$(kgbioportal shard-list -d "${{ github.event.inputs.ontologies }}" -n "$NUM_SHARDS" --index prev/onto_stats.yaml --max_source_mb "$MAX_SOURCE_MB")
           else
-            SHARDS=$(kgbioportal shard-list -f data/raw/ontologylist.tsv -n "$NUM_SHARDS" --index prev/onto_stats.yaml)
+            SHARDS=$(kgbioportal shard-list -f data/raw/ontologylist.tsv -n "$NUM_SHARDS" --index prev/onto_stats.yaml --max_source_mb "$MAX_SOURCE_MB")
           fi
           echo "shards=$SHARDS" >> "$GITHUB_OUTPUT"
       - name: Create release

--- a/src/kg_bioportal/cli.py
+++ b/src/kg_bioportal/cli.py
@@ -21,6 +21,13 @@ __all__ = [
 ]
 
 
+# What one ontology costs before any of its content is read: a download, two
+# ROBOT JVM starts and a KGX pass. Measured at roughly two megabytes' worth of
+# transform time in the 2026-08-25 run (see transform_weights), and expressed in
+# bytes so it can be added to a source size and compared with one.
+PER_ONTOLOGY_BYTES: int = 2 * 1024 * 1024
+
+
 def _read_acronyms(ontology_file: str) -> list:
     """Read ontology acronyms (first column) from a TSV list, skipping the header."""
     acronyms = []
@@ -106,7 +113,57 @@ def load_index_sizes(index_path: str) -> dict:
     return sizes
 
 
-def assign_shards(acronyms: list, num_shards: int, sizes: dict) -> list:
+def transform_weights(acronyms: list, sizes: dict, gate_bytes: int = 0) -> dict:
+    """Expected transform cost per ontology, expressed in source bytes.
+
+    Source size alone was the model, and the 2026-08-25 run showed both of its
+    holes. Eight of that run's twenty shards -- 40% of the matrix -- did no
+    transform work at all, and the slowest shard took 12m03s against a 56s
+    fastest, a 12.9x spread, worse than the 10x that motivated balancing (#153).
+
+    Size is wrong for an ontology the run will not transform. One already known
+    to exceed this run's gate never reaches ROBOT: the downloader checks
+    Content-Length and skips without fetching, or streams with a hard abort at
+    the cap. Weighed at its size it buys a shard that does nothing, and that is
+    exactly what happened -- BERO (878 MB), UPHENO (397 MB), EFO (332 MB) and
+    PMAPP-PMO (290 MB) each got a shard to themselves and each finished in about
+    a minute. So an ontology over the gate contributes no size at all.
+
+    Size is also not the whole cost of one that is transformed. Every ontology
+    costs a download, two JVM starts and a KGX pass whatever its size: in that
+    run a shard of eight small ontologies spent ~31s on them and one of eleven
+    ~120s, against ~3.4 s/MB measured on the shard where MHCRO's 78.6 MB took
+    ~270s. That is a floor of roughly two megabytes' worth of time per ontology,
+    which is more than the 0.46 MB median source in the run -- so ignoring it
+    lets a shard of twenty "free" ontologies look empty. Every ontology carries
+    it, including the ones the gate rejects, which still cost a header check.
+
+    Both numbers are proxies fitted to one run, and they are only ever compared
+    against each other. If the stats ever carry per-ontology durations, schedule
+    on those and delete this.
+    """
+    transformable = [
+        sizes[a] for a in acronyms
+        if sizes.get(a) and not (gate_bytes and sizes[a] > gate_bytes)
+    ]
+    # An ontology the index has never seen is a new submission; the median of
+    # the ones we do know is a better guess than nothing, and does not let a
+    # single unknown dominate the packing the way the maximum would. Ontologies
+    # the gate will reject are left out of it -- they are not transform costs.
+    default = statistics.median(transformable) if transformable else 0
+    weights = {}
+    for a in acronyms:
+        size = sizes.get(a)
+        if size and gate_bytes and size > gate_bytes:
+            weights[a] = float(PER_ONTOLOGY_BYTES)  # skipped at download
+        else:
+            weights[a] = float(PER_ONTOLOGY_BYTES + (size or default))
+    return weights
+
+
+def assign_shards(
+    acronyms: list, num_shards: int, sizes: dict, gate_bytes: int = 0
+) -> list:
     """Split acronyms into shards of roughly equal expected cost.
 
     Round-robin only spreads the heavy ontologies out when size is uncorrelated
@@ -127,6 +184,9 @@ def assign_shards(acronyms: list, num_shards: int, sizes: dict) -> list:
         acronyms: The ontologies to shard, in input order.
         num_shards: How many shards to fill.
         sizes: {acronym: source_bytes}; entries may be missing.
+        gate_bytes: This run's source-size cap. An ontology already known to
+            exceed it is skipped at download, so it weighs nothing here; 0
+            means no cap is known and every size counts. See transform_weights.
 
     Returns:
         A list of shards, each a list of acronyms. Empty shards are dropped.
@@ -134,17 +194,12 @@ def assign_shards(acronyms: list, num_shards: int, sizes: dict) -> list:
     n = max(1, min(num_shards, len(acronyms)))
     buckets = [[] for _ in range(n)]
 
-    known = [sizes[a] for a in acronyms if sizes.get(a)]
-    if not known:
+    if not any(sizes.get(a) for a in acronyms):
         for i, acr in enumerate(acronyms):
             buckets[i % n].append(acr)
         return [b for b in buckets if b]
 
-    # An ontology the index has never seen is a new submission; the median of
-    # the ones we do know is a better guess than nothing, and does not let a
-    # single unknown dominate the packing the way the maximum would.
-    default = statistics.median(known)
-    weights = {a: sizes.get(a) or default for a in acronyms}
+    weights = transform_weights(acronyms, sizes, gate_bytes)
 
     loads = [0.0] * n
     for acr in sorted(acronyms, key=lambda a: (-weights[a], a)):
@@ -427,7 +482,18 @@ def transform(input_dir, output_dir, compress, timeout_min, max_source_mb) -> No
     "at the submission BioPortal is serving now. Those carry forward via the "
     "finalize seed; everything else, including previous failures, is retried.",
 )
-def shard_list(ontology_file, ontologies, num_shards, use_skiplist, index_path) -> None:
+@click.option(
+    "--max_source_mb",
+    default=MAX_SOURCE_MB,
+    show_default=True,
+    type=float,
+    help="The source-size cap this run will transform under. Ontologies the "
+    "index already shows above it are skipped at download, so they are weighed "
+    "at nothing when balancing the shards. Pass the same value as `transform`.",
+)
+def shard_list(
+    ontology_file, ontologies, num_shards, use_skiplist, index_path, max_source_mb
+) -> None:
     """Splits the ontology list into N shards and prints them as JSON.
 
     Emits a JSON array of strings, each a space-separated group of acronyms,
@@ -467,16 +533,22 @@ def shard_list(ontology_file, ontologies, num_shards, use_skiplist, index_path) 
     # Balance the shards by expected cost, so no runner sits idle while another
     # works through every heavyweight in the run.
     sizes = load_index_sizes(index_path)
-    buckets = assign_shards(acronyms, num_shards, sizes)
+    gate_bytes = int(max_source_mb * 1024 * 1024) if max_source_mb else 0
+    buckets = assign_shards(acronyms, num_shards, sizes, gate_bytes)
 
     if buckets and sizes:
-        loads = [
-            sum(sizes.get(a, 0) for a in b) / 1024 / 1024 for b in buckets
-        ]
+        # Report the weights actually used, not the raw sizes: a shard holding
+        # nothing but ontologies the gate will reject is not a 878 MB shard.
+        weights = transform_weights(acronyms, sizes, gate_bytes)
+        loads = [sum(weights.get(a, 0) for a in b) / 1024 / 1024 for b in buckets]
+        gated = sum(
+            1 for a in acronyms if gate_bytes and sizes.get(a, 0) > gate_bytes
+        )
         click.echo(
             f"sharding: {len(buckets)} shards of {min(loads):.0f}-{max(loads):.0f} MB "
             f"(by source size; {sum(1 for a in acronyms if a not in sizes)} "
-            "unknown weighted at the median).",
+            f"unknown weighted at the median, {gated} over the "
+            f"{max_source_mb:.0f} MB gate weighed at a skip).",
             err=True,
         )
 

--- a/src/kg_bioportal/transformer.py
+++ b/src/kg_bioportal/transformer.py
@@ -749,8 +749,26 @@ def is_load_failure(error: str) -> bool:
     return any(marker in error for marker in _LOAD_FAILURE_MARKERS)
 
 
-def diagnose_source(path: str, max_mb: float = MAX_SYNTAX_CHECK_MB) -> str:
-    """Say why a source ROBOT refused is unusable, in terms someone can act on.
+class SourceDiagnosis(NamedTuple):
+    """What a syntax check could establish about a file ROBOT would not read."""
+
+    # True when the file parses as RDF, False when it does not, and None when
+    # nothing could be checked -- too large, not an RDF serialization, or
+    # unreadable. None is not "fine": it is "unknown", and callers must not
+    # read it as either answer.
+    parsed: Optional[bool]
+    # A phrase to append to the recorded detail, or "" when there is nothing
+    # to say at all.
+    detail: str
+
+
+UNCHECKED = SourceDiagnosis(None, "")
+
+
+def diagnose_source(
+    path: str, max_mb: float = MAX_SYNTAX_CHECK_MB, subject: str = "source"
+) -> SourceDiagnosis:
+    """Say why a file ROBOT refused is unusable, in terms someone can act on.
 
     ROBOT reports the same thing for a file that is not valid RDF and for one
     that is valid RDF it will not accept as an ontology, and #142 wants those
@@ -758,35 +776,39 @@ def diagnose_source(path: str, max_mb: float = MAX_SYNTAX_CHECK_MB) -> str:
     line number; the second is a file that might yet be readable another way.
     rdflib answers the question directly, and it is already a dependency.
 
-    Returns:
-        A phrase to append to the recorded detail, or "" when nothing can be
-        said (an unrecognized serialization, a file too large to check, or
-        rdflib itself failing for an unrelated reason).
+    Args:
+        path: The file to check.
+        max_mb: Ceiling above which the file is reported unchecked.
+        subject: What to call the file in the phrase, since this is also used
+            on our own intermediates, where calling them "source" would pin our
+            bug on the ontology's maintainers.
     """
     try:
         size_mb = os.path.getsize(path) / 1024 / 1024
     except OSError:
-        return ""
+        return UNCHECKED
     if max_mb and size_mb > max_mb:
-        return f"source not syntax-checked ({size_mb:.1f} MB)"
+        return SourceDiagnosis(None, f"{subject} not syntax-checked ({size_mb:.1f} MB)")
 
     try:
         with open(path, encoding="utf-8", errors="replace") as f:
             text = f.read()
     except OSError:
-        return ""
+        return UNCHECKED
 
     if _HTML_DOCUMENT.match(text[:4096].lstrip("\ufeff")):
-        return "source is an HTML document, not an ontology"
+        return SourceDiagnosis(False, f"{subject} is an HTML document, not an ontology")
 
     rdflib_format = _RDFLIB_FORMATS.get(_sniff_serialization(text) or "")
     if not rdflib_format:
-        return "source is not an RDF serialization we can check"
+        return SourceDiagnosis(
+            None, f"{subject} is not an RDF serialization we can check"
+        )
 
     try:
         import rdflib
     except ImportError:  # pragma: no cover - rdflib ships with kgx
-        return ""
+        return UNCHECKED
 
     graph = rdflib.Graph()
     try:
@@ -794,11 +816,52 @@ def diagnose_source(path: str, max_mb: float = MAX_SYNTAX_CHECK_MB) -> str:
     except Exception as e:
         # The line and column live in the message; they are what an upstream
         # report needs, so keep the message rather than just the type.
-        return f"source is not valid {rdflib_format}: {type(e).__name__}: {e}"
-    return (
-        f"source is valid {rdflib_format} ({len(graph)} triples) that ROBOT "
-        "will not load as an ontology"
+        return SourceDiagnosis(
+            False, f"{subject} is not valid {rdflib_format}: {type(e).__name__}: {e}"
+        )
+    return SourceDiagnosis(
+        True,
+        f"{subject} is valid {rdflib_format} ({len(graph)} triples) that ROBOT "
+        "will not load as an ontology",
     )
+
+
+# What we call the file we hand ROBOT when it is not the file BioPortal served.
+STRIPPED_SUBJECT = "the import-stripped copy"
+
+
+def diagnose_load_failure(
+    source_path: str,
+    robot_input_path: str,
+    max_mb: float = MAX_SYNTAX_CHECK_MB,
+) -> Tuple[str, str]:
+    """Attribute a file ROBOT could not read to BioPortal or to ourselves.
+
+    strip_imports rewrites most sources before ROBOT sees them, so "ROBOT could
+    not load this file" is not on its own a statement about what BioPortal
+    served -- the file named in the error may be one we wrote. Recording that as
+    invalid_source blames the ontology's maintainers for our own bug, and hides
+    a stripper that corrupts files inside a bucket labelled "not our problem".
+
+    So check the source itself. If it does not parse, the source is the story.
+    If it parses and the copy we handed ROBOT does not, the corruption is ours
+    and belongs with the failures we can fix.
+
+    Returns:
+        (reason, detail): reason is INVALID_SOURCE_REASON when the source is
+        what is unusable, or "" -- meaning the transform's own stage reason --
+        when our preprocessing is what ROBOT choked on.
+    """
+    source = diagnose_source(source_path, max_mb=max_mb)
+    if robot_input_path == source_path or source.parsed is not True:
+        # Nothing of ours stands between BioPortal's file and ROBOT, or the
+        # source is itself unreadable (or unknowable). Either way, the source.
+        return INVALID_SOURCE_REASON, source.detail
+
+    ours = diagnose_source(robot_input_path, max_mb=max_mb, subject=STRIPPED_SUBJECT)
+    if ours.parsed is False:
+        return "", f"{ours.detail}, from a source that parses cleanly"
+    return INVALID_SOURCE_REASON, source.detail
 
 
 def is_serialization_failure(error: str) -> bool:
@@ -1303,6 +1366,10 @@ class Transformer:
                     f"(> {self.max_source_mb} MB limit)"
                 )
 
+        # Keep what BioPortal served. From here on ontology_path may be a file
+        # we wrote, and a failure over it is not upstream's to answer for.
+        source_path = ontology_path
+
         # Remove owl:imports so ROBOT doesn't try (and fail) to fetch external
         # ontologies over the network — the dominant cause of transform errors.
         # Each ontology is transformed standalone; references to imported terms
@@ -1335,16 +1402,23 @@ class Transformer:
             converted = convert_to(intermediate_path)
         if not converted:
             if is_load_failure(converted.error):
-                # convert's input is the source as BioPortal served it, so this
-                # is a file we were never going to transform. Say which kind of
-                # unusable it is, and record it apart from the failures that are
-                # ours to fix (#142).
-                diagnosis = diagnose_source(ontology_path)
-                logging.error(f"{ontology_name}: unusable source. {diagnosis}")
+                # ROBOT could not read the file at all. That is usually a source
+                # we were never going to transform, recorded apart from the
+                # failures that are ours to fix (#142) -- but convert's input is
+                # the stripped copy, not what BioPortal served, so which of the
+                # two is unusable has to be established rather than assumed.
+                reason, diagnosis = diagnose_load_failure(source_path, ontology_path)
+                if reason == INVALID_SOURCE_REASON:
+                    logging.error(f"{ontology_name}: unusable source. {diagnosis}")
+                else:
+                    logging.error(
+                        f"{ontology_name}: we broke this file, not BioPortal. "
+                        f"{diagnosis}"
+                    )
                 return TransformOutcome.failed(
                     "convert",
                     f"{converted.error} ({diagnosis})" if diagnosis else converted.error,
-                    reason=INVALID_SOURCE_REASON,
+                    reason=reason,
                 )
             return TransformOutcome.failed("convert", converted.error)
 

--- a/tests/test_invalid_source.py
+++ b/tests/test_invalid_source.py
@@ -26,9 +26,15 @@ from kg_bioportal.transformer import (
     INVALID_SOURCE_REASON,
     MAX_SYNTAX_CHECK_MB,
     Transformer,
+    diagnose_load_failure,
     diagnose_source,
     is_load_failure,
 )
+
+
+def detail_of(path, **kw):
+    """The phrase diagnose_source records, for tests that only care about that."""
+    return diagnose_source(path, **kw).detail
 
 LOAD_FAILURE = (
     "java.lang.IllegalArgumentException: java.io.IOException: errors#INVALID "
@@ -105,62 +111,62 @@ class TestDiagnosis(DiagnoseTestCase):
     """Which of the two kinds of unusable a file is."""
 
     def test_broken_turtle_is_reported_as_invalid(self):
-        detail = diagnose_source(self.write("onto.ttl", BAD_TURTLE))
+        detail = detail_of(self.write("onto.ttl", BAD_TURTLE))
         self.assertIn("not valid turtle", detail)
 
     def test_the_parse_error_is_kept(self):
         # A line number is the difference between a useful bug report and "it
         # doesn't work".
-        detail = diagnose_source(self.write("onto.ttl", BAD_TURTLE))
+        detail = detail_of(self.write("onto.ttl", BAD_TURTLE))
         self.assertIn("line", detail.lower())
 
     def test_html_served_as_an_ontology_is_named_outright(self):
         # rdflib's RDF/XML parser reads arbitrary XML, so an error page comes
         # back as "valid XML, 3 triples" unless it is caught first -- a
         # diagnosis that reassures exactly where it should not.
-        detail = diagnose_source(self.write("onto.ttl", HTML_PAGE))
+        detail = detail_of(self.write("onto.ttl", HTML_PAGE))
         self.assertIn("HTML document", detail)
         self.assertNotIn("triples", detail)
 
     def test_html_under_an_owl_name_is_caught_too(self):
-        detail = diagnose_source(self.write("onto.owl", HTML_PAGE))
+        detail = detail_of(self.write("onto.owl", HTML_PAGE))
         self.assertIn("HTML document", detail)
 
     def test_valid_rdf_is_reported_as_such(self):
         # This is the "might be recoverable another way" case, and it must not
         # be described as broken.
-        detail = diagnose_source(self.write("onto.ttl", GOOD_TURTLE))
+        detail = detail_of(self.write("onto.ttl", GOOD_TURTLE))
         self.assertIn("valid turtle", detail)
         self.assertNotIn("not valid", detail)
         self.assertIn("will not load as an ontology", detail)
 
     def test_the_triple_count_is_reported(self):
-        detail = diagnose_source(self.write("onto.ttl", GOOD_TURTLE))
+        detail = detail_of(self.write("onto.ttl", GOOD_TURTLE))
         self.assertIn("3 triples", detail)
 
     def test_broken_rdfxml_is_reported_as_invalid(self):
-        detail = diagnose_source(self.write("onto.owl", RDFXML.replace("</rdf:RDF>", "")))
+        detail = detail_of(self.write("onto.owl", RDFXML.replace("</rdf:RDF>", "")))
         self.assertIn("not valid xml", detail)
 
     def test_valid_rdfxml_is_reported_as_such(self):
-        self.assertIn("valid xml", diagnose_source(self.write("onto.owl", RDFXML)))
+        self.assertIn("valid xml", detail_of(self.write("onto.owl", RDFXML)))
 
     def test_a_non_rdf_serialization_says_so(self):
         # OBO is not RDF; rdflib has nothing to say about it either way.
-        detail = diagnose_source(
+        detail = detail_of(
             self.write("onto.obo", "format-version: 1.2\n\n[Term]\nid: X:1\n"))
         self.assertIn("not an RDF serialization", detail)
 
     def test_a_large_source_is_not_checked(self):
         path = self.write("onto.ttl", GOOD_TURTLE)
-        detail = diagnose_source(path, max_mb=0.000001)
+        detail = detail_of(path, max_mb=0.000001)
         self.assertIn("not syntax-checked", detail)
 
     def test_the_default_ceiling_is_finite(self):
         self.assertGreater(MAX_SYNTAX_CHECK_MB, 0)
 
     def test_a_missing_file_says_nothing(self):
-        self.assertEqual(diagnose_source(os.path.join(self._tmp.name, "nope.ttl")), "")
+        self.assertEqual(detail_of(os.path.join(self._tmp.name, "nope.ttl")), "")
 
 
 class TransformTestCase(TestCase):
@@ -280,3 +286,159 @@ class TestEverythingElseKeepsItsReason(TransformTestCase):
         entry = self.stats()
         self.assertEqual(entry["status"], "OK")
         self.assertEqual(entry["reason"], "")
+
+
+# A source with an import, of the shape strip_imports rewrites. What matters
+# for the tests below is only that the two files differ.
+TURTLE_WITH_IMPORT = """@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+<http://example.org/onto> a owl:Ontology ;
+    owl:imports <http://dead.example/gone.owl> ;
+    rdfs:label "Onto" .
+<http://example.org/ns#A> a owl:Class ; rdfs:label "A" .
+"""
+
+
+class TestWhoBrokeIt(DiagnoseTestCase):
+    """invalid_source is a claim about BioPortal's file, so check BioPortal's file.
+
+    strip_imports rewrites most sources before ROBOT sees them, so the file
+    named in "Could not load a valid ontology from file: X" is often one we
+    wrote. Recording that as invalid_source blames the ontology's maintainers
+    for our own bug, and buries a stripper that corrupts files inside a bucket
+    labelled "nothing we can do".
+
+    SHEDDING-HUB in the 2026-08-25 run is the case: it failed with
+    "shedding-hub_noimports.ttl", the _noimports copy, and the recorded
+    diagnosis described that copy while calling it the source -- so the run
+    could not say whether the syntax error was upstream's or ours.
+    """
+
+    def attribute(self, source_text, stripped_text=None, **kw):
+        source = self.write("onto.ttl", source_text)
+        robot_input = source
+        if stripped_text is not None:
+            robot_input = self.write("onto_noimports.ttl", stripped_text)
+        return diagnose_load_failure(source, robot_input, **kw)
+
+    def test_an_unstripped_source_is_judged_on_itself(self):
+        reason, detail = self.attribute(BAD_TURTLE)
+        self.assertEqual(reason, INVALID_SOURCE_REASON)
+        self.assertIn("not valid turtle", detail)
+
+    def test_a_broken_source_stays_the_source_even_when_stripped(self):
+        # The stripped copy of a broken file is broken too; the source is still
+        # the thing to report.
+        reason, detail = self.attribute(BAD_TURTLE, stripped_text=BAD_TURTLE)
+        self.assertEqual(reason, INVALID_SOURCE_REASON)
+        self.assertIn("source is not valid turtle", detail)
+
+    def test_a_good_source_and_a_broken_copy_is_ours(self):
+        # The case the run could not distinguish.
+        reason, detail = self.attribute(TURTLE_WITH_IMPORT, stripped_text=BAD_TURTLE)
+        self.assertNotEqual(reason, INVALID_SOURCE_REASON)
+        self.assertIn("not valid turtle", detail)
+
+    def test_our_own_file_is_not_called_the_source(self):
+        # The whole point: the phrase must not pin our corruption on upstream.
+        _, detail = self.attribute(TURTLE_WITH_IMPORT, stripped_text=BAD_TURTLE)
+        self.assertNotIn("source is not valid", detail)
+        self.assertIn("import-stripped copy", detail)
+
+    def test_the_detail_says_the_source_was_fine(self):
+        # Without this the reader cannot tell a stripper bug from a source that
+        # happened to fail after stripping.
+        _, detail = self.attribute(TURTLE_WITH_IMPORT, stripped_text=BAD_TURTLE)
+        self.assertIn("source that parses cleanly", detail)
+
+    def test_a_good_source_and_a_good_copy_is_still_the_source(self):
+        # Both parse, so ROBOT is refusing valid RDF as an ontology -- #142's
+        # second kind of unusable, and not ours.
+        reason, detail = self.attribute(TURTLE_WITH_IMPORT, stripped_text=GOOD_TURTLE)
+        self.assertEqual(reason, INVALID_SOURCE_REASON)
+        self.assertIn("will not load as an ontology", detail)
+
+    def test_an_unknowable_source_is_not_blamed_on_us(self):
+        # Too large to check: we have no evidence either way, and inventing a
+        # stripper bug is as wrong as inventing an upstream one.
+        reason, detail = self.attribute(
+            TURTLE_WITH_IMPORT, stripped_text=BAD_TURTLE, max_mb=0.000001)
+        self.assertEqual(reason, INVALID_SOURCE_REASON)
+        self.assertIn("not syntax-checked", detail)
+
+    def test_a_non_rdf_source_is_not_blamed_on_us_either(self):
+        reason, detail = self.attribute(
+            "format-version: 1.2\n\n[Term]\nid: X:1\n", stripped_text=BAD_TURTLE)
+        self.assertEqual(reason, INVALID_SOURCE_REASON)
+        self.assertIn("not an RDF serialization", detail)
+
+    def test_a_missing_source_says_nothing_and_blames_nobody(self):
+        reason, detail = diagnose_load_failure(
+            os.path.join(self._tmp.name, "nope.ttl"),
+            self.write("onto_noimports.ttl", BAD_TURTLE),
+        )
+        self.assertEqual(reason, INVALID_SOURCE_REASON)
+        self.assertEqual(detail, "")
+
+
+class TestTheDiagnosisReportsWhatItKnows(DiagnoseTestCase):
+    """parsed is three-valued, and None must not read as either answer."""
+
+    def test_a_parsable_file_is_true(self):
+        self.assertIs(diagnose_source(self.write("onto.ttl", GOOD_TURTLE)).parsed, True)
+
+    def test_an_unparsable_file_is_false(self):
+        self.assertIs(diagnose_source(self.write("onto.ttl", BAD_TURTLE)).parsed, False)
+
+    def test_html_is_false_not_unknown(self):
+        self.assertIs(diagnose_source(self.write("onto.ttl", HTML_PAGE)).parsed, False)
+
+    def test_an_unchecked_file_is_unknown(self):
+        self.assertIsNone(
+            diagnose_source(self.write("onto.ttl", GOOD_TURTLE), max_mb=1e-6).parsed)
+
+    def test_a_non_rdf_file_is_unknown(self):
+        self.assertIsNone(diagnose_source(self.write("onto.obo", "[Term]\n")).parsed)
+
+    def test_a_missing_file_is_unknown(self):
+        self.assertIsNone(
+            diagnose_source(os.path.join(self._tmp.name, "nope.ttl")).parsed)
+
+
+class TestAStripperBugReachesTheStats(TransformTestCase):
+    """End to end: a file we corrupted is recorded as ours, and says why."""
+
+    def run_with_stripper_output(self, source_text, stripped_text):
+        source = self.source("onto.ttl", source_text)
+        # Outside input_dir, so transform_all does not pick it up as an ontology.
+        stripped = os.path.join(self._tmp.name, "onto_noimports.ttl")
+        with open(stripped, "w", encoding="utf-8") as f:
+            f.write(stripped_text)
+        with mock.patch(
+            "kg_bioportal.transformer.strip_imports",
+            lambda p: stripped if p == source else p,
+        ):
+            self.run_transform(None, all_at_once=True)
+        return self.stats()
+
+    def test_a_corrupted_copy_is_recorded_as_a_transform_error(self):
+        entry = self.run_with_stripper_output(TURTLE_WITH_IMPORT, BAD_TURTLE)
+        self.assertEqual(entry["reason"], "transform_error_convert")
+
+    def test_it_is_not_recorded_as_an_unusable_source(self):
+        entry = self.run_with_stripper_output(TURTLE_WITH_IMPORT, BAD_TURTLE)
+        self.assertNotEqual(entry["reason"], INVALID_SOURCE_REASON)
+
+    def test_the_stats_say_which_file_was_broken(self):
+        entry = self.run_with_stripper_output(TURTLE_WITH_IMPORT, BAD_TURTLE)
+        self.assertIn("import-stripped copy", entry["detail"])
+        self.assertIn("source that parses cleanly", entry["detail"])
+
+    def test_robots_own_message_is_still_kept(self):
+        entry = self.run_with_stripper_output(TURTLE_WITH_IMPORT, BAD_TURTLE)
+        self.assertIn("INVALID ONTOLOGY FILE ERROR", entry["detail"])
+
+    def test_a_genuinely_broken_source_is_still_invalid_source(self):
+        # The stripper ran here too; what decides is that the source is broken.
+        entry = self.run_with_stripper_output(BAD_TURTLE, BAD_TURTLE)
+        self.assertEqual(entry["reason"], INVALID_SOURCE_REASON)

--- a/tests/test_shard_balance.py
+++ b/tests/test_shard_balance.py
@@ -23,7 +23,13 @@ from unittest import TestCase
 import yaml
 from click.testing import CliRunner
 
-from kg_bioportal.cli import assign_shards, load_index_sizes, main
+from kg_bioportal.cli import (
+    PER_ONTOLOGY_BYTES,
+    assign_shards,
+    load_index_sizes,
+    main,
+    transform_weights,
+)
 
 MB = 1024 * 1024
 
@@ -256,6 +262,168 @@ class TestShardListCommand(TestCase):
         scheduled = " ".join(json.loads(result.stdout.strip())).split()
         self.assertEqual(sorted(scheduled), ["BDPM", "FOODON"])
 
+    def test_the_gated_count_is_reported(self):
+        # The line is how a run explains its own shard sizes; a count derived
+        # from the weights read 0 once the gated entries stopped weighing 0.
+        index = self.index({"BERO": 878, "SMALL": 1})
+        result = self.run_shard(
+            "--ontologies", "BERO SMALL", "--num_shards", "2",
+            "--index", index, "--max_source_mb", "100")
+        self.assertIn("1 over the 100 MB gate", result.stderr)
+
+    def test_nothing_is_gated_when_the_gate_is_high(self):
+        index = self.index({"BERO": 878, "SMALL": 1})
+        result = self.run_shard(
+            "--ontologies", "BERO SMALL", "--num_shards", "2",
+            "--index", index, "--max_source_mb", "1000")
+        self.assertIn("0 over the 1000 MB gate", result.stderr)
+
     def test_it_works_without_an_index(self):
         result = self.run_shard("--ontologies", "A B C D E", "--num_shards", "2")
         self.assertEqual(json.loads(result.stdout.strip()), ["A C E", "B D"])
+
+
+# The 2026-08-25 run, as the index and the Actions job list recorded it. Eight
+# of its twenty shards did no transform work at all -- every one of them held
+# nothing but ontologies already over the run's 100 MB gate, so each spent
+# roughly a minute of job setup and stopped at a Content-Length check.
+GATE_MB = 100
+
+# The four the run gave a shard each, with their indexed source size.
+RUN_2026_08_25_GATED = {
+    "BERO": 878, "UPHENO": 397, "EFO": 332, "PMAPP-PMO": 290,
+    "CHEBI": 258, "FMA": 254, "CCO": 244, "GO-PLUS": 227,
+}
+# The ontologies that run actually transformed, largest first. Two of them are
+# most of the work; the rest are the long tail the packing has to spread.
+RUN_2026_08_25_REAL = {
+    "XREF-FUNDER-REG": 86, "MHCRO": 79, "GO": 35, "PHIPO": 30, "ECOCORE": 20,
+    "ARO": 17, "CTCAE": 14, "ROR": 13, "JFO": 10, "VFB_DRIVERS": 10, "OBI": 9,
+}
+# The measured shards whose full membership the job list records, with their
+# duration. UPHENO and BERO alone are the floor: a shard that does nothing
+# still costs about a minute.
+MEASURED = {"UPHENO": 57, "BERO": 63, "EFO": 69, "PMAPP-PMO": 56}
+
+
+def gate_bytes(mb=GATE_MB):
+    return mb * MB
+
+
+def work_in(bucket, sizes, gate=None):
+    """Source bytes a shard actually hands to ROBOT -- what sets its duration."""
+    gate = gate if gate is not None else gate_bytes()
+    return sum(s for a in bucket for s in [sizes.get(a, 0)] if 0 < s <= gate)
+
+
+class TestTheGateIsPartOfTheCost(TestCase):
+    """An ontology the run will not transform must not be weighed as if it will.
+
+    The downloader checks Content-Length and skips without fetching, so an
+    ontology over the gate costs a header check, not its size. Weighed at its
+    size it buys a shard that does nothing, and on 2026-08-25 it bought four.
+    """
+
+    def setUp(self):
+        self.sizes = sizes_in_bytes({**RUN_2026_08_25_GATED, **RUN_2026_08_25_REAL})
+        self.acronyms = sorted(self.sizes)
+
+    def test_the_run_that_happened_wasted_shards_on_them(self):
+        # Not a test of the fix: it holds the fixture to what was measured.
+        for acronym, seconds in MEASURED.items():
+            self.assertLess(seconds, 75, f"{acronym} was not an idle shard")
+            self.assertGreater(RUN_2026_08_25_GATED[acronym], GATE_MB)
+
+    def test_without_the_gate_the_giants_get_their_own_shards(self):
+        buckets = assign_shards(self.acronyms, 8, self.sizes)
+        idle = [b for b in buckets if work_in(b, self.sizes) == 0]
+        self.assertTrue(idle, "the fixture no longer reproduces the problem")
+
+    def test_with_the_gate_no_shard_is_left_with_nothing_to_do(self):
+        buckets = assign_shards(self.acronyms, 8, self.sizes, gate_bytes())
+        for bucket in buckets:
+            self.assertGreater(
+                work_in(bucket, self.sizes), 0, f"{bucket} has no work in it")
+
+    def test_the_gated_giants_are_spread_rather_than_isolated(self):
+        buckets = assign_shards(self.acronyms, 8, self.sizes, gate_bytes())
+        alone = [b for b in buckets if len(b) == 1 and b[0] in RUN_2026_08_25_GATED]
+        self.assertEqual(alone, [], "a gated ontology still has a shard to itself")
+
+    def test_the_real_work_is_spread_more_evenly(self):
+        loads = lambda bs: [work_in(b, self.sizes) for b in bs]
+        before = loads(assign_shards(self.acronyms, 8, self.sizes))
+        after = loads(assign_shards(self.acronyms, 8, self.sizes, gate_bytes()))
+        self.assertLess(max(after), max(before))
+
+    def test_raising_the_gate_gives_them_their_weight_back(self):
+        # The gate is a per-run input, not a property of the ontology: at 1000 MB
+        # BERO is transformed, so it is the heaviest thing in the run again.
+        buckets = assign_shards(self.acronyms, 8, self.sizes, gate_bytes(1000))
+        with_bero = next(b for b in buckets if "BERO" in b)
+        self.assertEqual(with_bero, ["BERO"], "BERO is 878 MB and should stand alone")
+
+    def test_no_gate_keeps_the_previous_behaviour(self):
+        self.assertEqual(
+            assign_shards(self.acronyms, 8, self.sizes, 0),
+            assign_shards(self.acronyms, 8, self.sizes),
+        )
+
+    def test_nothing_is_lost_to_the_gate(self):
+        buckets = assign_shards(self.acronyms, 8, self.sizes, gate_bytes())
+        self.assertEqual(sorted(a for b in buckets for a in b), self.acronyms)
+
+
+class TestEveryOntologyCostsSomething(TestCase):
+    """Size is not the whole cost: a download and two JVM starts are not free.
+
+    In the 2026-08-25 run a shard of eight small ontologies spent ~31s on them
+    and one of eleven ~120s, against ~3.4 s/MB measured elsewhere in the run --
+    a floor of roughly 2 MB's worth of time each, well above the 0.46 MB median
+    source. Ignoring it lets a shard of twenty tiny ontologies look empty.
+    """
+
+    def test_a_tiny_ontology_weighs_more_than_its_bytes(self):
+        weights = transform_weights(["TINY"], {"TINY": 1024})
+        self.assertGreater(weights["TINY"], 1024)
+        self.assertGreaterEqual(weights["TINY"], PER_ONTOLOGY_BYTES)
+
+    def test_a_gated_ontology_still_costs_its_header_check(self):
+        weights = transform_weights(["BIG"], {"BIG": 878 * MB}, gate_bytes())
+        self.assertEqual(weights["BIG"], float(PER_ONTOLOGY_BYTES))
+
+    def test_a_gated_ontology_weighs_less_than_a_transformed_one(self):
+        sizes = {"BIG": 878 * MB, "SMALL": MB}
+        weights = transform_weights(["BIG", "SMALL"], sizes, gate_bytes())
+        self.assertLess(weights["BIG"], weights["SMALL"])
+
+    def test_many_tiny_ontologies_outweigh_one_middling_one(self):
+        # The case the old model got wrong: twenty 0.1 MB ontologies are more
+        # work than a single 2 MB one, because each pays the floor.
+        sizes = {f"T{i}": MB // 10 for i in range(20)}
+        sizes["MID"] = 2 * MB
+        weights = transform_weights(list(sizes), sizes)
+        self.assertGreater(sum(weights[f"T{i}"] for i in range(20)), weights["MID"])
+
+    def test_a_pile_of_small_ontologies_outweighs_a_single_large_one(self):
+        # A shard of forty 0.1 MB ontologies is not idle, and must not be given
+        # a 30 MB ontology on top on the grounds that it holds "4 MB".
+        sizes = {f"T{i}": MB // 10 for i in range(40)}
+        sizes["BIG"] = 30 * MB
+        weights = transform_weights(list(sizes), sizes)
+        self.assertGreater(sum(weights[f"T{i}"] for i in range(40)), weights["BIG"])
+
+    def test_the_gated_ones_do_not_all_land_on_one_shard(self):
+        # They weigh the same as each other, so without a per-ontology cost they
+        # would all follow the same lightest-shard choice.
+        sizes = {f"G{i}": 500 * MB for i in range(12)}
+        sizes.update({f"R{i}": (i + 1) * MB for i in range(4)})
+        buckets = assign_shards(sorted(sizes), 4, sizes, gate_bytes())
+        per_shard = [sum(1 for a in b if a.startswith("G")) for b in buckets]
+        self.assertLess(max(per_shard), 12, "every gated ontology went to one shard")
+
+    def test_the_weights_still_sum_over_every_ontology(self):
+        sizes = {"A": MB, "B": 500 * MB}
+        weights = transform_weights(["A", "B", "UNKNOWN"], sizes, gate_bytes())
+        self.assertEqual(sorted(weights), ["A", "B", "UNKNOWN"])
+        self.assertTrue(all(w > 0 for w in weights.values()))


### PR DESCRIPTION
Two independent findings from the full run (release `data-2026.08.25-10`), one commit each. Happy to split into two PRs — they touch different files and neither depends on the other.

---

## 1. Check BioPortal's file before calling a source unusable (`1294548`)

`invalid_source` is a claim about the file BioPortal served: nothing on our side will change it, so #142 records it apart from the failures that are ours to fix. But convert's input is not that file. `strip_imports` rewrites most sources first, so "ROBOT could not load this file" is often about a copy we wrote — and `diagnose_source` was pointed at that copy while describing it as "source", pinning our own bug on the ontology's maintainers and hiding a stripper that corrupts files inside a bucket labelled "not our problem".

The run has the case. SHEDDING-HUB failed with

```
Could not load a valid ontology from file: shedding-hub_noimports.ttl
(source is not valid turtle: BadSyntax: at line 25 ...)
```

The `_noimports` copy is only written when something was actually removed, so that line 25 might have been ours, and the run could not say which. The other three `invalid_source` entries (CATALOG-THEMES, NCOD, GENE-CDS) name their original filenames, so nothing was stripped and their diagnoses were sound.

Establish it rather than assume it:

| source | copy handed to ROBOT | recorded as |
|---|---|---|
| does not parse | — | `invalid_source`, describing the source |
| parses | does not parse | `transform_error_convert`, naming *the import-stripped copy* |
| parses | parses | `invalid_source` — valid RDF ROBOT will not load as an ontology |
| cannot be checked | — | `invalid_source`, unchanged prior behaviour |

Nothing is inferred from a source that cannot be checked (too large, not an RDF serialization, missing): inventing a stripper bug is as wrong as inventing an upstream one. `diagnose_source` now returns a three-valued `SourceDiagnosis` so `None` cannot be misread as either answer, and takes the subject it should call the file.

**Verified against ROBOT 1.9.6 end to end**, three real transforms: a valid source with a dead import transforms; a source broken at line 4 is `invalid_source` naming the source; the same source with a corrupted stripper output is `transform_error_convert`, *"the import-stripped copy is not valid turtle: … , from a source that parses cleanly"*. Before this change the third case was indistinguishable from the second.

Separately probed the Turtle stripper against ten realistic shapes — comments after the import line, imports last or alone in a predicate list, object lists, consecutive import statements, prefixed import IRIs, an import-looking IRI inside a literal, no trailing newline, and SHEDDING-HUB's own `> . # Biology` context. All ten still parse and lose their imports, so the evidence points upstream; the next run will say so outright instead of leaving it to inference.

---

## 2. Weigh a shard by the work in it, not by bytes it will never read (`631cfd0`)

Balancing shards by source size (#153, #161) did not deliver. The run's slowest shard took 12m03s against a 56s fastest — a **12.9× spread, worse than the 10× that motivated balancing** — and **eight of twenty shards did no transform work at all**. The packing is fine; the cost model had two holes.

**Size is wrong for an ontology the run will not transform.** One already over the gate never reaches ROBOT — the downloader checks `Content-Length` and skips without fetching. Weighed at its size it buys a shard that does nothing, and it bought four: BERO (878 MB), UPHENO (397 MB), EFO (332 MB) and PMAPP-PMO (290 MB) each got a shard to itself and each finished in about a minute. `shard-list` now takes `--max_source_mb` and the workflow passes the same value `transform` runs under, so raising the gate (#118) gives those entries their weight back on its own.

**Size is also not the whole cost of one that is transformed.** Every ontology costs a download, two JVM starts and a KGX pass whatever its size: a shard of eight small ontologies spent ~31s on them and one of eleven ~120s, against ~3.4 s/MB measured where MHCRO's 78.6 MB took ~270s. That is a floor of roughly 2 MB's worth of time each — well above the run's 0.46 MB median source. Without it a shard of twenty "free" ontologies looks empty, which is how one shard ended up with 21 members while another had one.

Measured by repacking that run's own 198 scheduled ontologies against the index it used, with a cost model fitted to the twelve shards whose full membership the job list records (mean absolute error 11s over durations of 56–330s):

|  | before | after |
|---|---|---|
| slowest shard | 8.7 min | **6.0 min** |
| spread | 8.1× | **2.0×** |
| shards with no work | 7/20 | **0/20** |
| largest shard | 21 members | 14 members |

The remaining 6.0 min is XREF-FUNDER-REG at 85.9 MB, which no packing can split; it now has a shard to itself instead of twenty other ontologies queued behind it.

Both numbers are proxies fitted to one run and only ever compared with each other — if the stats ever carry per-ontology durations, schedule on those and delete this.

Also fixes the `sharding:` log line, which counted gated entries by looking for a zero weight and so reported 0 once they stopped weighing zero.

---

Tests: **378 pass** (37 new). Each new test was mutation-checked — reverting either half of the cost model fails the tests that cover it.