### PR TITLE
Fall back to Turtle when ROBOT will not read back its own RDF/XML

### DIFF
--- a/.claude/skills/kg-bioportal-data/references/data-model.md
+++ b/.claude/skills/kg-bioportal-data/references/data-model.md
@@ -59,7 +59,11 @@ ontologies:
                           #   was recorded carry a bare `transform_error`.
   detail: ''              # non-OK entries only, and only when there is something to
                           #   say: the message from the stage that failed, on one
-                          #   line, truncated to 500 characters
+                          #   line, truncated to 500 characters. When the message
+                          #   names no cause of its own -- "could not load a valid
+                          #   ontology from file: X" is true of every unreadable
+                          #   file -- the reason that points at a position in the
+                          #   file follows it after a ' | '.
   malformed_literals: 0   # present only when non-zero: literals whose lexical
                           #   form does not match their declared datatype (e.g.
                           #   xsd:dateTime '06/09/2012'). A fact about the source,

--- a/src/kg_bioportal/robot_utils.py
+++ b/src/kg_bioportal/robot_utils.py
@@ -53,6 +53,21 @@ _JVM_NOISE = (
 # or "java.io.IOException: errors#INVALID ONTOLOGY FILE ERROR ...".
 _THROWABLE = re.compile(r"\b[\w.$]*(?:Exception|Error|ERROR)\b")
 
+# A cause that points into the file: an OWL API parser position ("[line=26:
+# column=46]"), a SAX one ("lineNumber: 27"), or the "at line 4 of" a Turtle or
+# functional-syntax parser writes. A stack frame never carries one of these,
+# which is what makes it a usable filter for the reason among the noise.
+_POSITIONED_REASON = re.compile(
+    r"\[line=\d+|lineNumber:\s*\d+|\bat line \d+|\bat index \d+", re.I
+)
+
+# ROBOT's logging appends the first stack element to the message line itself,
+# after a run of spaces: "...Malformed escape pair at index 15        org.
+# semanticweb.owlapi.rdf.rdfxml.parser.RDFXMLParser.parse(RDFXMLParser.java:74)".
+# It identifies nothing about the ontology and it is the longest part of the
+# line, so it is cut before the 500-character budget is spent on it.
+_STACK_TAIL = re.compile(r"\s{2,}\S*\(\w+\.\w+:\d+\).*$")
+
 # Enough of stderr to find the error in; a stack trace that deep is not hiding
 # a better line further down.
 _MAX_ERROR_LINES = 200
@@ -77,32 +92,54 @@ def _output_written(output_path: str) -> str:
 
 
 def _error_text(e: Exception) -> str:
-    """The line of a ROBOT failure worth keeping.
+    """The part of a ROBOT failure worth keeping.
 
     ROBOT writes its verbose (-vvv) log to stdout and the failure to stderr,
-    where one line carries the exception and its whole cause chain --
+    where one line carries the exception and its cause chain --
     "java.lang.IllegalArgumentException: ...UnloadableImportException: Could not
     load imported ontology: <url>". Everything under it is a stack trace through
     OWL API internals, which identifies nothing about the ontology, and anything
     above it is the JVM clearing its throat.
 
-    So: skip the noise and the stack frames, prefer the first line that names a
-    throwable, and fall back to the first line left. Falls back to the exception
-    itself when there is no stderr to read at all.
+    That top line is enough when it names the cause, and useless when it does
+    not. A file ROBOT cannot read reports only "INVALID ONTOLOGY FILE ERROR
+    Could not load a valid ontology from file: X" -- true of every unreadable
+    file there has ever been. The reason is further down, because the OWL API
+    tries each parser in turn and collects their complaints under
+    UnparsableOntologyException:
+
+        [line=26:column=46] IRI 'http://ex.org/a%b' cannot be resolved against
+        current base IRI http://ex.org/o reason is: Malformed escape pair
+
+    That is the line that says which ontology, and where in it. So keep the top
+    line, and append the first line below it that points at a position in the
+    file -- the one thing a stack frame never does.
     """
     stderr = getattr(e, "stderr", b"") or b""
     if isinstance(stderr, (bytes, bytearray)):
         stderr = stderr.decode("utf-8", "replace")
 
+    head = ""
     fallback = ""
     for line in stderr.splitlines()[:_MAX_ERROR_LINES]:
         line = line.strip()
         if not line or line.startswith(("at ", "... ")) or line.startswith(_JVM_NOISE):
             continue
-        if _THROWABLE.search(line):
-            return line[:_MAX_ERROR_CHARS]
-        fallback = fallback or line
-    return (fallback or str(e).strip())[:_MAX_ERROR_CHARS]
+        line = _STACK_TAIL.sub("", line).strip()
+        if not line:
+            continue
+        if not head:
+            if _THROWABLE.search(line):
+                head = line
+                continue
+            fallback = fallback or line
+            continue
+        # Past the headline: the only thing left worth adding is a reason that
+        # names a place. Take the first, then stop -- the parsers after it are
+        # complaining about the same file in their own syntax.
+        if _POSITIONED_REASON.search(line) and line not in head:
+            return f"{head} | {line}"[:_MAX_ERROR_CHARS]
+    return (head or fallback or str(e).strip())[:_MAX_ERROR_CHARS]
 
 
 def initialize_robot(robot_path: str) -> list:

--- a/src/kg_bioportal/transformer.py
+++ b/src/kg_bioportal/transformer.py
@@ -1376,6 +1376,17 @@ class Transformer:
         # simply become dangling edges, resolved later at merge time.
         ontology_path = strip_imports(ontology_path)
 
+        # Drop invalid xml:lang here, on the way in, and not only from ROBOT's
+        # output further down. An XML attribute takes any string, but a Turtle
+        # language tag is part of the grammar, so when ROBOT writes one of these
+        # out as Turtle -- which it does on either fallback below -- it emits
+        # `"x"@editor@example.com`, which is not Turtle at all and takes the
+        # ontology out at the KGX step instead. Cleaning the source means no
+        # serialization ROBOT picks can carry the problem forward. XML-only, and
+        # a no-op for a file with no xml:lang in it, so a Turtle source (where
+        # such a tag could never have parsed) is untouched.
+        ontology_path = strip_invalid_lang_tags(ontology_path, ontology_name)
+
         # Convert
         def convert_to(output_path):
             return robot_convert(
@@ -1432,10 +1443,10 @@ class Transformer:
 
         # Relax. Its output is what KGX parses, so it keeps the serialization the
         # ontology could actually be written in.
-        def relax_to(output_path):
+        def relax_to(output_path, input_path):
             return robot_relax(
                 robot_path=self.robot_path,
-                input_path=relax_input_path,
+                input_path=input_path,
                 output_path=output_path,
                 robot_env=self.robot_env,
                 timeout=self.timeout_sec,
@@ -1444,7 +1455,7 @@ class Transformer:
         relaxed_outpath = os.path.join(
             workdir, f"{ontology_name}_relaxed{intermediate_ext}"
         )
-        relaxed = relax_to(relaxed_outpath)
+        relaxed = relax_to(relaxed_outpath, relax_input_path)
         if (
             not relaxed
             and is_serialization_failure(relaxed.error)
@@ -1459,7 +1470,37 @@ class Transformer:
             relaxed_outpath = os.path.join(
                 workdir, f"{ontology_name}_relaxed{FALLBACK_SERIALIZATION}"
             )
-            relaxed = relax_to(relaxed_outpath)
+            relaxed = relax_to(relaxed_outpath, relax_input_path)
+        elif (
+            not relaxed
+            and is_load_failure(relaxed.error)
+            and intermediate_ext != FALLBACK_SERIALIZATION
+        ):
+            # ROBOT will not read back the RDF/XML ROBOT just wrote. Its RDF/XML
+            # parser resolves every IRI against the base with java.net.URI and
+            # rejects what its Turtle parser accepted a step earlier, so an IRI
+            # holding a stray '%', a quote, a '<' or a second '#' loads from the
+            # source and then fails on the way in. Nothing is wrong with the
+            # ontology and nothing downstream needs this intermediate to be
+            # RDF/XML, so convert the source again to the serialization that can
+            # hold those IRIs, and relax that.
+            #
+            # It has to start from the source: ROBOT cannot read the RDF/XML it
+            # produced, so there is nothing to convert it *from*.
+            logging.warning(
+                f"{ontology_name}: ROBOT cannot read back its own RDF/XML "
+                f"({relaxed.error}); converting to {FALLBACK_SERIALIZATION} instead."
+            )
+            fallback_path = os.path.join(
+                workdir, f"{ontology_name}{FALLBACK_SERIALIZATION}"
+            )
+            reconverted = convert_to(fallback_path)
+            if reconverted:
+                intermediate_ext = FALLBACK_SERIALIZATION
+                relaxed_outpath = os.path.join(
+                    workdir, f"{ontology_name}_relaxed{FALLBACK_SERIALIZATION}"
+                )
+                relaxed = relax_to(relaxed_outpath, fallback_path)
         if not relaxed:
             return TransformOutcome.failed("relax", relaxed.error)
 
@@ -1472,9 +1513,11 @@ class Transformer:
         # ROBOT always writes RDF/XML for a .owl output, so the stripper applies.
         stripped_path = strip_imports(relaxed_outpath)
 
-        # Same pass, same reason: rdflib raises on an invalid xml:lang instead of
-        # warning, so one typo'd attribute in the source takes the whole ontology
-        # down at parse time. By here the file is always RDF/XML from ROBOT.
+        # Same pass, same reason: rdflib raises on an invalid xml:lang instead
+        # of warning, so one typo'd attribute takes the whole ontology down at
+        # parse time. The source was cleaned on the way in; this catches an
+        # RDF/XML output that reintroduces one, and no-ops on a Turtle output,
+        # where such a tag could not have been written in the first place.
         kgx_input_path = strip_invalid_lang_tags(stripped_path, ontology_name)
 
         # Transform to KGX nodes + edges

--- a/tests/test_relax_reread.py
+++ b/tests/test_relax_reread.py
@@ -1,0 +1,342 @@
+"""ROBOT would not read back the RDF/XML ROBOT had just written.
+
+Five ontologies in the 2026-08-25 run failed at relax with
+
+    INVALID ONTOLOGY FILE ERROR Could not load a valid ontology from file:
+    ELD.owl
+
+and ELD.owl is convert's own output. The cause, from ROBOT 1.9.6:
+
+    [line=26:column=46] IRI 'http://ex.org/a%b' cannot be resolved against
+    current base IRI http://ex.org/o reason is: Malformed escape pair at index 15
+
+The RDF/XML parser resolves every IRI against the base with java.net.URI, which
+is stricter than the Turtle parser that read the source a step earlier. An IRI
+carrying a stray '%', a quote, a '<' or a second '#' therefore loads from the
+source and fails on the way back in. Nothing is wrong with the ontology.
+
+Turtle round-trips all four with the IRIs intact, so the intermediate falls back
+to it -- converting again from the source, since ROBOT cannot read the RDF/XML
+it produced and so has nothing to convert it *from*.
+
+The error strings here are ROBOT 1.9.6's own, from convert/relax over an
+ontology whose only oddity is the IRI in the message.
+"""
+
+import os
+import tempfile
+from unittest import TestCase, mock
+
+from kg_bioportal.robot_utils import RobotResult, _error_text
+from kg_bioportal.transformer import FALLBACK_SERIALIZATION, Transformer
+
+# What relax says about an RDF/XML file its own convert wrote, before and after
+# the cause line is kept alongside the headline.
+BARE_LOAD_ERROR = (
+    "java.lang.IllegalArgumentException: java.io.IOException: errors#INVALID "
+    "ONTOLOGY FILE ERROR Could not load a valid ontology from file: ELD.owl"
+)
+IRI_CAUSE = (
+    "org.semanticweb.owlapi.rdf.rdfxml.parser.RDFParserException: "
+    "[line=26:column=46] IRI 'http://ex.org/a%b' cannot be resolved against "
+    "current base IRI http://ex.org/o reason is: Malformed escape pair at index 15"
+)
+LOAD_ERROR = f"{BARE_LOAD_ERROR} | {IRI_CAUSE}"
+STORAGE_ERROR = (
+    "java.io.IOException: errors#ONTOLOGY STORAGE ERROR Could not save ontology to IRI"
+)
+IMPORT_ERROR = (
+    "java.lang.IllegalArgumentException: org.semanticweb.owlapi.model."
+    "UnloadableImportException: Could not load imported ontology: <http://dead/>"
+)
+
+RDFXML = """<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#">
+  <owl:Ontology rdf:about="http://example.org/onto"/>
+</rdf:RDF>
+"""
+
+
+class RereadTestCase(TestCase):
+    """Drives transform() with a ROBOT that fails on what it is *given*.
+
+    The distinguishing fact here is the input's serialization, not the output's:
+    relax refuses the .owl and accepts the .ttl.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.input_dir = os.path.join(self._tmp.name, "raw")
+        self.output_dir = os.path.join(self._tmp.name, "transformed")
+
+        self.txr = Transformer.__new__(Transformer)
+        self.txr.input_dir = self.input_dir
+        self.txr.output_dir = self.output_dir
+        self.txr.timeout_sec = 60
+        self.txr.timeout_min = 1
+        self.txr.max_source_bytes = 0
+        self.txr.robot_path = "/nonexistent/robot"
+        self.txr.robot_env = {}
+
+        self.source = os.path.join(self.input_dir, "ONTO", "1", "onto.owl")
+        os.makedirs(os.path.dirname(self.source), exist_ok=True)
+        with open(self.source, "w") as f:
+            f.write(RDFXML)
+
+        self.converted = []   # output extensions convert was asked for
+        self.convert_inputs = []  # the files convert was actually handed
+        self.relaxed = []     # (input ext, output ext) pairs relax was asked for
+        self.kgx_input = None
+
+    def run_transform(
+        self,
+        relax_rejects=(".owl",),
+        error=LOAD_ERROR,
+        convert_fails_on=(),
+        convert_error=STORAGE_ERROR,
+    ):
+        def fake_convert(**kw):
+            out = kw["output_path"]
+            self.converted.append(os.path.splitext(out)[1])
+            self.convert_inputs.append(kw["input_path"])
+            if os.path.splitext(out)[1] in convert_fails_on:
+                return RobotResult(False, convert_error)
+            os.makedirs(os.path.dirname(out), exist_ok=True)
+            with open(out, "w") as f:
+                f.write(RDFXML)
+            return RobotResult(True)
+
+        def fake_relax(**kw):
+            in_ext = os.path.splitext(kw["input_path"])[1]
+            out = kw["output_path"]
+            self.relaxed.append((in_ext, os.path.splitext(out)[1]))
+            if in_ext in relax_rejects:
+                return RobotResult(False, error)
+            os.makedirs(os.path.dirname(out), exist_ok=True)
+            with open(out, "w") as f:
+                f.write(RDFXML)
+            return RobotResult(True)
+
+        test = self
+
+        class FakeKGX:
+            def __init__(self, *a, **k):
+                pass
+
+            def transform(self, input_args, output_args):
+                test.kgx_input = input_args["filename"][0]
+                for suffix in ("_nodes.tsv", "_edges.tsv"):
+                    with open(output_args["filename"] + suffix, "w") as fh:
+                        fh.write("id\n")
+
+        with mock.patch("kg_bioportal.transformer.robot_convert", fake_convert), \
+             mock.patch("kg_bioportal.transformer.robot_relax", fake_relax), \
+             mock.patch("kg_bioportal.transformer.KGXTransformer", FakeKGX):
+            return self.txr.transform(self.source, compress=False)
+
+
+class TestTheOntologyGetsThrough(RereadTestCase):
+    def test_it_succeeds(self):
+        self.assertTrue(self.run_transform().success)
+
+    def test_the_source_is_converted_again_to_turtle(self):
+        self.run_transform()
+        self.assertEqual(self.converted, [".owl", FALLBACK_SERIALIZATION])
+
+    def test_relax_is_retried_on_the_turtle(self):
+        self.run_transform()
+        self.assertEqual(
+            self.relaxed,
+            [(".owl", ".owl"), (FALLBACK_SERIALIZATION, FALLBACK_SERIALIZATION)],
+        )
+
+    def test_the_relaxed_output_keeps_the_fallback_format(self):
+        # Writing it back to RDF/XML would walk into the same wall.
+        self.run_transform()
+        _, out_ext = self.relaxed[-1]
+        self.assertEqual(out_ext, FALLBACK_SERIALIZATION)
+
+    def test_kgx_reads_the_turtle(self):
+        self.run_transform()
+        self.assertTrue(self.kgx_input.endswith(FALLBACK_SERIALIZATION))
+
+
+class TestNothingElseTakesThisPath(RereadTestCase):
+    """The retry costs a whole second conversion; only this failure earns it."""
+
+    def test_an_ontology_that_works_converts_once(self):
+        self.run_transform(relax_rejects=())
+        self.assertEqual(self.converted, [".owl"])
+        self.assertEqual(self.relaxed, [(".owl", ".owl")])
+
+    def test_a_write_failure_keeps_its_own_fallback(self):
+        # #139's path: relax loaded the file and could not save it. Retrying the
+        # conversion would not help, and it already has a retry of its own.
+        self.run_transform(relax_rejects=(".owl",), error=STORAGE_ERROR)
+        self.assertEqual(self.converted, [".owl"])
+
+    def test_an_unresolvable_import_is_not_retried(self):
+        outcome = self.run_transform(relax_rejects=(".owl",), error=IMPORT_ERROR)
+        self.assertFalse(outcome.success)
+        self.assertEqual(self.converted, [".owl"])
+
+    def test_a_turtle_intermediate_is_not_converted_a_third_time(self):
+        # Already Turtle and still unreadable: there is nowhere left to fall back
+        # to, and retrying forever is worse than failing.
+        outcome = self.run_transform(relax_rejects=(".owl", FALLBACK_SERIALIZATION))
+        self.assertFalse(outcome.success)
+        self.assertEqual(self.converted, [".owl", FALLBACK_SERIALIZATION])
+        self.assertEqual(len(self.relaxed), 2)
+
+
+class TestWhenTheFallbackAlsoFails(RereadTestCase):
+    def test_a_failed_reconversion_still_reports_the_relax_failure(self):
+        outcome = self.run_transform(convert_fails_on=(FALLBACK_SERIALIZATION,))
+        self.assertFalse(outcome.success)
+        self.assertEqual(outcome.stage, "relax")
+
+    def test_the_original_error_survives(self):
+        # The reconversion failing is not the story; what relax said is.
+        outcome = self.run_transform(convert_fails_on=(FALLBACK_SERIALIZATION,))
+        self.assertIn("Could not load a valid ontology", outcome.detail)
+
+    def test_the_reason_is_still_a_relax_error(self):
+        outcome = self.run_transform(relax_rejects=(".owl", FALLBACK_SERIALIZATION))
+        self.assertEqual(outcome.stage, "relax")
+
+
+class FakeFailure(Exception):
+    def __init__(self, stderr):
+        super().__init__("robot failed")
+        self.stderr = stderr.encode()
+
+
+class TestTheReasonIsKept(TestCase):
+    """"Could not load a valid ontology" is true of every unreadable file.
+
+    It named the problem for none of the five, which is why they sat unexplained
+    for a run. The line that identifies them is further down, under
+    UnparsableOntologyException, where each parser reports where it gave up.
+    """
+
+    STDERR = "\n".join([
+        "Picked up JAVA_TOOL_OPTIONS: -Dfoo",
+        BARE_LOAD_ERROR,
+        "\tat org.obolibrary.robot.IOHelper.loadOntology(IOHelper.java:596)",
+        "Caused by: java.io.IOException: errors#INVALID ONTOLOGY FILE ERROR "
+        "Could not load a valid ontology from file: ELD.owl",
+        "Caused by: org.semanticweb.owlapi.io.UnparsableOntologyException: "
+        "Problem parsing file:/data/ELD.owl",
+        # ROBOT glues the first stack element onto the message line itself,
+        # after a run of spaces -- so it is not filtered out by the "at " rule.
+        IRI_CAUSE + "        org.semanticweb.owlapi.rdf.rdfxml.parser."
+        "RDFXMLParser.parse(RDFXMLParser.java:74)",
+        "\tat org.semanticweb.owlapi.rdf.rdfxml.parser.RDFParser.resolveIRI(RDFParser.java:355)",
+    ])
+
+    def error(self, stderr=None):
+        return _error_text(FakeFailure(self.STDERR if stderr is None else stderr))
+
+    def test_the_headline_is_still_there(self):
+        self.assertIn("Could not load a valid ontology", self.error())
+
+    def test_the_reason_is_appended(self):
+        self.assertIn("Malformed escape pair", self.error())
+
+    def test_the_offending_iri_is_named(self):
+        self.assertIn("http://ex.org/a%b", self.error())
+
+    def test_the_position_is_kept(self):
+        self.assertIn("[line=26:column=46]", self.error())
+
+    def test_stack_frames_are_not(self):
+        # Including the one ROBOT glues onto the end of the message line, which
+        # is longer than the message and would eat the detail budget.
+        self.assertNotIn("RDFXMLParser.java:74", self.error())
+        self.assertNotIn("IOHelper.java:596", self.error())
+
+    def test_the_reason_ends_at_the_reason(self):
+        self.assertTrue(self.error().rstrip().endswith("Malformed escape pair at index 15"))
+
+    def test_jvm_noise_is_not(self):
+        self.assertNotIn("JAVA_TOOL_OPTIONS", self.error())
+
+    def test_an_error_that_explains_itself_is_left_alone(self):
+        # UnloadableImportException names the dead URL on the headline; there is
+        # no position below it and nothing to append.
+        stderr = "\n".join([IMPORT_ERROR, "\tat org.obolibrary.robot.Foo.bar(Foo.java:1)"])
+        self.assertEqual(self.error(stderr), IMPORT_ERROR)
+
+    def test_only_the_first_reason_is_taken(self):
+        # The OWL API tries every parser and each complains in its own syntax;
+        # the rest say nothing new about the ontology.
+        second = ("org.semanticweb.owlapi.rdf.turtle.parser.ParseException: "
+                  "Encountered \"\" at line 1, column 1.")
+        text = self.error(self.STDERR + "\n" + second)
+        self.assertNotIn("turtle.parser.ParseException", text)
+
+    def test_a_stderr_with_no_position_still_reports_something(self):
+        self.assertEqual(self.error(BARE_LOAD_ERROR), BARE_LOAD_ERROR)
+
+
+# An xml:lang an XML attribute takes and a Turtle language tag cannot express.
+# Real: DRMO ships an email address in one (#140).
+BAD_TAG = "editor@example.com"
+RDFXML_WITH_BAD_TAG = """<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#">
+  <owl:Ontology rdf:about="http://example.org/onto"/>
+  <owl:Class rdf:about="http://example.org/ns#A">
+    <rdfs:label xml:lang="%s">A</rdfs:label>
+  </owl:Class>
+</rdf:RDF>
+""" % BAD_TAG
+
+
+class TestTheFallbackCannotCarryABadLanguageTag(RereadTestCase):
+    """Falling back to Turtle must not trade one failure for another.
+
+    An XML attribute takes any string, but a Turtle language tag is part of the
+    grammar. Handed an ontology with xml:lang="editor@example.com", ROBOT writes
+    `"A"@editor@example.com` into Turtle -- checked against ROBOT 1.9.6 -- which
+    is not Turtle at all, and rdflib rejects the file at the KGX step. Cleaning
+    the source on the way in means no serialization ROBOT picks can carry it.
+    """
+
+    def setUp(self):
+        super().setUp()
+        with open(self.source, "w") as f:
+            f.write(RDFXML_WITH_BAD_TAG)
+
+    def read(self, path):
+        with open(path, encoding="utf-8") as f:
+            return f.read()
+
+    def test_convert_never_sees_the_bad_tag(self):
+        self.run_transform(relax_rejects=())
+        for path in self.convert_inputs:
+            self.assertNotIn(BAD_TAG, self.read(path), path)
+
+    def test_it_is_gone_on_the_fallback_conversion_too(self):
+        # The path that would have written it into Turtle.
+        self.run_transform()
+        self.assertEqual(len(self.convert_inputs), 2)
+        self.assertNotIn(BAD_TAG, self.read(self.convert_inputs[-1]))
+
+    def test_the_literal_itself_is_kept(self):
+        # The tag is dropped, not the label: there is nothing wrong with "A".
+        self.run_transform(relax_rejects=())
+        self.assertIn(">A<", self.read(self.convert_inputs[0]))
+
+    def test_the_ontology_still_transforms(self):
+        self.assertTrue(self.run_transform().success)
+
+    def test_a_source_with_no_language_tags_is_not_rewritten(self):
+        # The ontologies that build today must be handed the file they are now.
+        with open(self.source, "w") as f:
+            f.write(RDFXML)
+        self.run_transform(relax_rejects=())
+        self.assertEqual(self.convert_inputs[0], self.source)


### PR DESCRIPTION
Fixes the five `transform_error_relax` failures in the 2026-08-25 run — ELD, G-PROV, INFRARISK, MOMCARE, OPD-NAMBOBI.

## What was happening

All five failed at relax with

```
INVALID ONTOLOGY FILE ERROR Could not load a valid ontology from file: ELD.owl
```

and `ELD.owl` is convert's own output — ROBOT declining to read what ROBOT had just written. The recorded detail said no more than that, which is true of every unreadable file there has ever been, so they sat unexplained.

Reproduced against ROBOT 1.9.6:

```
[line=26:column=46] IRI 'http://ex.org/a%b' cannot be resolved against
current base IRI http://ex.org/o reason is: Malformed escape pair at index 15
```

**The RDF/XML parser resolves every IRI against the base with `java.net.URI`, which is stricter than the Turtle parser that read the source a step earlier.** An IRI carrying a stray `%`, a quote, a `<` or a second `#` loads from the source and then fails on the way back in. The written XML is well-formed — the writer escapes `&quot;` and `&lt;` correctly — so this is *not* #141's illegal-character case, and `strip_xml_illegal_chars` finds nothing to do. Nothing is wrong with the ontology.

Found by fuzzing convert→relax round-trips over 39 awkward inputs; four shapes reproduce, and Turtle round-trips all four with the IRIs intact.

## The fix

The intermediate falls back to Turtle, the way #139 already does for ontologies RDF/XML cannot *write*. It converts again from the source, because ROBOT cannot read the RDF/XML it produced and so there is nothing to convert it *from*. An intermediate that is already Turtle is not retried, so there is no loop.

**Falling back more often exposed something the #139 path had quietly been exposed to as well.** An XML attribute takes any string, but a Turtle language tag is part of the grammar — so handed `xml:lang="editor@example.com"` (DRMO ships an email address in one, #140), ROBOT writes `"A"@editor@example.com` into Turtle, which is not Turtle at all and loses the ontology at the KGX step instead. Trading a relax failure for a KGX failure is not a fix, so invalid `xml:lang` is now dropped from the source on the way in, not only from ROBOT's output further down. XML-only and a no-op for a file with no `xml:lang`, so Turtle sources and the ontologies that build today are untouched.

## Keeping the cause

`_error_text` kept only ROBOT's headline. That names the cause for an `UnloadableImportException` and names nothing for a file it cannot read, because the OWL API tries each parser in turn and collects their complaints underneath. It now appends the first line below the headline that points at a position in the file, and drops the stack element ROBOT glues onto the end of a message line — which is longer than the message and would otherwise spend the 500-character budget naming a line of OWL API source. Before and after, on real stderr:

```
- ...Could not load a valid ontology from file: m.owl
+ ...Could not load a valid ontology from file: m.owl | RDFParserException:
+ [line=26:column=47] IRI 'http://ex.org/a%b' cannot be resolved against current
+ base IRI http://ex.org/o reason is: Malformed escape pair at index 15
```

That single line is what turned this from "ROBOT says no" into a diagnosis, and it is what the next unknown failure of this shape will need.

## Verification

End to end against ROBOT 1.9.6, driving `transform_all` over sources whose only oddity is the IRI:

| source | before | after |
|---|---|---|
| IRI with `%` | `transform_error_relax` | OK |
| IRI with `"` | `transform_error_relax` | OK |
| IRI with `<` | `transform_error_relax` | OK |
| IRI with a second `#` | `transform_error_relax` | OK |
| RDF/XML with an unusable `xml:lang` | OK | OK |
| plain ontology | OK | OK |

`transform_error_relax` is the same reason the five real ontologies carry.

405 tests pass (26 new). Each of the three parts was mutation-checked: removing the Turtle re-convert fails 8 tests, removing the source lang pass fails 2, dropping the reason-append fails 3.

**Not confirmed:** there is no BioPortal key in my environment, so the mechanism is verified and the five ontologies are not. The next run settles them — and if one still fails, its detail will now say why.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JM47TqJy5r9R2T2FgcWJhM)_