### PR TITLE
Raise the size gate to 250 MB (+20 ontologies), and quote the right parser

### DIFF
--- a/.github/workflows/transform.yml
+++ b/.github/workflows/transform.yml
@@ -24,7 +24,7 @@ on:
       max_source_mb:
         description: "Skip ontologies whose source exceeds this many MB"
         required: false
-        default: "100"
+        default: "250"
       timeout_min:
         description: "Per-ontology wall-clock cap (minutes)"
         required: false
@@ -44,7 +44,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MAX_SOURCE_MB: ${{ github.event.inputs.max_source_mb || '100' }}
+  MAX_SOURCE_MB: ${{ github.event.inputs.max_source_mb || '250' }}
   TIMEOUT_MIN: ${{ github.event.inputs.timeout_min || '30' }}
   NUM_SHARDS: ${{ github.event.inputs.num_shards || '20' }}
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,11 @@ the stats with a reason, rather than failing the build:
 
 - **`skiplist`** — a known giant, skipped up front with no download attempt
   (e.g. NCBITAXON, SNOMEDCT, RXNORM, GAZ, PR, NCIT, …). See `KNOWN_GIANTS` in
-  [`src/kg_bioportal/config.py`](src/kg_bioportal/config.py).
+  [`src/kg_bioportal/config.py`](src/kg_bioportal/config.py). Size is not the
+  only way to be a giant: CCO is 244 MB, inside the gate, but ships as OBO and
+  expands to 15.7M triples, which is what takes the runner down.
 - **`too_large`** — the source exceeded the size gate (`--max_source_mb`,
-  default 100 MB). Checked twice: on the file as downloaded, and again after
+  default 250 MB). Checked twice: on the file as downloaded, and again after
   decompression, since a gzipped source understates its real size by an order
   of magnitude (ROR is 14 MB gzipped and 135 MB unpacked).
 - **`too_slow`** — the transform exceeded the per-ontology wall-clock cap
@@ -63,6 +65,12 @@ the stats with a reason, rather than failing the build:
 
 These thresholds are tunable via config, CLI flags, or the environment
 (`KGBP_MAX_SOURCE_MB`, `KGBP_TIMEOUT_MIN`).
+
+The 250 MB gate is measured rather than assumed. Every ontology the index held
+between 100 and 250 MB was transformed on a standard runner on 2026-08-25 — 20
+of them, from HRA at 100 MB to GO-PLUS at 227 MB, each taking 2m32s to 7m49s —
+adding roughly 3.1M nodes and 6.6M edges. Raising it further has not been
+tested; the next band up starts at FMA (254 MB) and reaches BERO (878 MB).
 
 ## What BioPortal won't give us, and why
 
@@ -114,7 +122,7 @@ pip install .
 export NCBO_API_KEY=...   # from https://bioportal.bioontology.org/account
 
 # Download a few ontologies (honors the size gate + skiplist)
-kgbioportal download -d "AGRO SEPIO" -o data/raw -k "$NCBO_API_KEY" --max_source_mb 50
+kgbioportal download -d "AGRO SEPIO" -o data/raw -k "$NCBO_API_KEY" --max_source_mb 250
 
 # Transform them to KGX (honors the per-ontology time cap)
 kgbioportal transform -i data/raw -o data/transformed --timeout_min 30

--- a/docs/kg_site/build_site.py
+++ b/docs/kg_site/build_site.py
@@ -174,7 +174,7 @@ def onto_to_item(o, transform_date):
 
 # Human-readable explanation for why a non-OK ontology has no KGX artifact.
 REASON_MSG = {
-    "too_large": "The source ontology exceeds the transform size limit (100 MB), so it is not "
+    "too_large": "The source ontology exceeds the transform size limit (250 MB), so it is not "
                  "transformed on the automated (GitHub Actions) pipeline.",
     "too_slow": "The transform exceeded the per-ontology time limit and was stopped.",
     "skiplist": "This ontology is known to be too large or slow for the automated pipeline and is "

--- a/src/kg_bioportal/config.py
+++ b/src/kg_bioportal/config.py
@@ -11,7 +11,13 @@ import os
 
 # Skip an ontology whose downloaded source file exceeds this many megabytes.
 # Big source files mean big memory use in ROBOT and big output artifacts.
-MAX_SOURCE_MB: float = float(os.environ.get("KGBP_MAX_SOURCE_MB", 100))
+#
+# Measured, not guessed: on 2026-08-25 all 21 ontologies the index held between
+# 100 and 250 MB were transformed on a standard runner, from HRA at 100 MB to
+# GO-PLUS at 227 MB, in 2m32s to 7m49s each. The one that did not survive was
+# CCO at 244 MB, and it is on the skiplist below rather than being a reason to
+# hold the gate down -- see KNOWN_GIANTS for why size is not what stopped it.
+MAX_SOURCE_MB: float = float(os.environ.get("KGBP_MAX_SOURCE_MB", 250))
 
 # Hard wall-clock cap for transforming a single ontology, in minutes. If a
 # transform runs longer it is killed and recorded as skipped (too_slow), so one
@@ -54,6 +60,16 @@ KNOWN_GIANTS: frozenset = frozenset(
         "MESH",        # Medical Subject Headings
         "UMLS",        # UMLS-derived
         "RH-MESH",     # MeSH (Robert Hoehndorf variant)
+        # Not a giant by file size -- 244 MB, inside the gate -- but by what
+        # that file expands to. CCO ships as OBO, which is far denser per byte
+        # than the RDF/XML most sources use, and it parsed to 15,693,276
+        # triples: an order of magnitude more than anything else in its size
+        # band (GNO, 206 MB, is the next densest at ~2.2M nodes+edges). ROBOT
+        # convert and relax both finished; rdflib held the graph, went quiet
+        # for five minutes, and the runner was reclaimed under it, so the
+        # ontology was never recorded as anything and the whole run went red.
+        # Measured 2026-08-25 (run 12).
+        "CCO",         # Cell Cycle Ontology — 15.7M triples from 244 MB of OBO
     }
 )
 

--- a/src/kg_bioportal/robot_utils.py
+++ b/src/kg_bioportal/robot_utils.py
@@ -3,6 +3,8 @@
 import os
 import logging
 import re
+from typing import Optional
+
 import requests
 import sh  # type: ignore
 from sh import chmod  # type: ignore
@@ -58,8 +60,16 @@ _THROWABLE = re.compile(r"\b[\w.$]*(?:Exception|Error|ERROR)\b")
 # functional-syntax parser writes. A stack frame never carries one of these,
 # which is what makes it a usable filter for the reason among the noise.
 _POSITIONED_REASON = re.compile(
-    r"\[line=\d+|lineNumber:\s*\d+|\bat line \d+|\bat index \d+", re.I
+    r"\[line=(\d+)|lineNumber:\s*(\d+)|\bat line (\d+)|\bat index (\d+)", re.I
 )
+
+
+def _reason_position(line: str) -> Optional[int]:
+    """Where in the file a cause line points, or None if it points nowhere."""
+    match = _POSITIONED_REASON.search(line)
+    if not match:
+        return None
+    return int(next(g for g in match.groups() if g is not None))
 
 # ROBOT's logging appends the first stack element to the message line itself,
 # after a run of spaces: "...Malformed escape pair at index 15        org.
@@ -121,6 +131,7 @@ def _error_text(e: Exception) -> str:
 
     head = ""
     fallback = ""
+    first_line_reason = ""
     for line in stderr.splitlines()[:_MAX_ERROR_LINES]:
         line = line.strip()
         if not line or line.startswith(("at ", "... ")) or line.startswith(_JVM_NOISE):
@@ -135,10 +146,21 @@ def _error_text(e: Exception) -> str:
             fallback = fallback or line
             continue
         # Past the headline: the only thing left worth adding is a reason that
-        # names a place. Take the first, then stop -- the parsers after it are
-        # complaining about the same file in their own syntax.
-        if _POSITIONED_REASON.search(line) and line not in head:
+        # names a place. The OWL API tries every parser it has and reports each
+        # one's complaint, so most of what follows is a parser saying the file
+        # is not in its format -- and the RDF/XML parser, which goes first, says
+        # so at line 1 ("Content is not allowed in prolog") for every Turtle
+        # file there has ever been. A parser that got somewhere into the file is
+        # the one that recognized it, so prefer a position past the first line,
+        # and settle for a line-1 reason only if nothing else is offered.
+        position = _reason_position(line)
+        if position is None or line in head:
+            continue
+        if position > 1:
             return f"{head} | {line}"[:_MAX_ERROR_CHARS]
+        first_line_reason = first_line_reason or line
+    if head and first_line_reason:
+        return f"{head} | {first_line_reason}"[:_MAX_ERROR_CHARS]
     return (head or fallback or str(e).strip())[:_MAX_ERROR_CHARS]
 
 

--- a/tests/test_relax_reread.py
+++ b/tests/test_relax_reread.py
@@ -340,3 +340,65 @@ class TestTheFallbackCannotCarryABadLanguageTag(RereadTestCase):
             f.write(RDFXML)
         self.run_transform(relax_rejects=())
         self.assertEqual(self.convert_inputs[0], self.source)
+
+
+# Verbatim from the 2026-08-25 run 11 logs. INFRARISK is the ontology the
+# Turtle fallback did not rescue, and the two lines are the two relax attempts.
+INFRARISK_XML_REASON = (
+    "org.xml.sax.SAXParseException; systemId: file:/data/INFRARISK.owl; "
+    "lineNumber: 712; columnNumber: 22; Element or attribute \"xmlns:5g_devices\" "
+    "do not match QName production: QName::=(NCName:)?NCName."
+)
+NOT_XML_AT_ALL = (
+    "org.xml.sax.SAXParseException; systemId: file:/data/INFRARISK.ttl; "
+    "lineNumber: 1; columnNumber: 1; Content is not allowed in prolog."
+)
+TURTLE_REASON = (
+    "org.semanticweb.owlapi.rdf.turtle.parser.ParseException: Encountered "
+    "\" <PNAME_NS> \"5g_devices: \"\" at line 412, column 9."
+)
+
+
+class TestTheRightParserIsQuoted(TestCase):
+    """The OWL API asks every parser it has, and most of them say "not mine".
+
+    The RDF/XML parser goes first and answers "Content is not allowed in prolog"
+    at line 1 for every Turtle file there has ever been. Quoting that as the
+    reason a Turtle file failed says nothing -- it was the recorded detail for
+    all four invalid_source entries and for INFRARISK in run 11, none of which
+    are XML. The parser that got somewhere into the file is the one that
+    recognized it.
+    """
+
+    def error(self, *lines):
+        return _error_text(FakeFailure("\n".join((BARE_LOAD_ERROR,) + lines)))
+
+    def test_a_line_one_not_my_format_reason_is_passed_over(self):
+        text = self.error(NOT_XML_AT_ALL, TURTLE_REASON)
+        self.assertIn("5g_devices", text)
+        self.assertNotIn("not allowed in prolog", text)
+
+    def test_the_parser_that_read_the_file_is_quoted(self):
+        self.assertIn("at line 412", self.error(NOT_XML_AT_ALL, TURTLE_REASON))
+
+    def test_order_does_not_matter(self):
+        # The RDF/XML parser happens to go first, but nothing guarantees it.
+        self.assertIn("at line 412", self.error(TURTLE_REASON, NOT_XML_AT_ALL))
+
+    def test_a_line_one_reason_is_still_better_than_nothing(self):
+        # When no parser got past line 1, say what little there is rather than
+        # dropping to the headline alone.
+        self.assertIn("not allowed in prolog", self.error(NOT_XML_AT_ALL))
+
+    def test_a_real_line_one_failure_still_reports(self):
+        self.assertIn(BARE_LOAD_ERROR, self.error(NOT_XML_AT_ALL))
+
+    def test_the_xml_reason_survives_when_the_file_is_xml(self):
+        # INFRARISK's first attempt: ROBOT wrote xmlns:5g_devices, which is not
+        # a legal XML name, so here the SAX parser is the one that read it.
+        text = self.error(INFRARISK_XML_REASON)
+        self.assertIn("xmlns:5g_devices", text)
+        self.assertIn("lineNumber: 712", text)
+
+    def test_the_iri_case_is_unaffected(self):
+        self.assertIn("Malformed escape pair", self.error(IRI_CAUSE))

--- a/tests/test_size_gate.py
+++ b/tests/test_size_gate.py
@@ -1,0 +1,71 @@
+"""The size gate is a measurement, and CCO is why it is not the whole story.
+
+Run 12 on 2026-08-25 attempted every ontology the index held between 100 and
+250 MB, with only the gate raised. Twenty of the twenty-one transformed on a
+standard runner, taking 2m32s to 7m49s each and adding 3,128,595 nodes and
+6,637,965 edges -- roughly two thirds again on top of the whole rest of the
+index.
+
+The twenty-first was CCO, and it did not fail: it took the runner down. ROBOT
+convert and relax both finished; rdflib then parsed 15,693,276 triples, went
+quiet for five minutes, and the runner was reclaimed under it. Nothing was
+recorded, and the run went red. CCO is 244 MB -- inside the gate -- so the gate
+cannot be what stops it. What makes it expensive is that it ships as OBO, which
+is far denser per byte than the RDF/XML most sources use; the next densest
+ontology in the band, GNO at 206 MB, yielded about 2.2M nodes and edges to
+CCO's 15.7M triples.
+
+So the gate rises to what was measured, and CCO joins the static skiplist,
+which is exactly the list for an ontology that cannot be transformed here.
+"""
+
+from unittest import TestCase
+
+from kg_bioportal.config import KNOWN_GIANTS, MAX_SOURCE_MB, is_skiplisted
+
+# The band run 12 attempted, with each source size as the index recorded it.
+# The largest that transformed, and the one that did not.
+LARGEST_THAT_WORKED = ("GO-PLUS", 227)
+THE_ONE_THAT_DID_NOT = ("CCO", 244)
+# Still out of reach, and untested at any gate: the next band up.
+STILL_TOO_LARGE = {"FMA": 254, "CHEBI": 258, "PMAPP-PMO": 290,
+                   "EFO": 333, "UPHENO": 397, "BERO": 878}
+
+
+class TestTheGateMatchesWhatWasMeasured(TestCase):
+    def test_the_largest_ontology_that_transformed_is_inside_the_gate(self):
+        self.assertGreaterEqual(MAX_SOURCE_MB, LARGEST_THAT_WORKED[1])
+
+    def test_nothing_untested_is_inside_the_gate(self):
+        # Raising the gate past what has been run is a guess, and the failure
+        # mode is a dead runner rather than a recorded skip.
+        for acronym, size_mb in STILL_TOO_LARGE.items():
+            self.assertLess(MAX_SOURCE_MB, size_mb, acronym)
+
+    def test_the_gate_is_not_lowered_below_the_previous_one(self):
+        # 100 MB was the previous setting; every ontology that built under it
+        # must still build.
+        self.assertGreaterEqual(MAX_SOURCE_MB, 100)
+
+
+class TestSizeIsNotTheOnlyWayToBeAGiant(TestCase):
+    def test_cco_is_skiplisted(self):
+        self.assertTrue(is_skiplisted("CCO"))
+
+    def test_it_is_skiplisted_despite_fitting_the_gate(self):
+        # The point of the entry: the gate would let it through.
+        acronym, size_mb = THE_ONE_THAT_DID_NOT
+        self.assertLess(size_mb, MAX_SOURCE_MB)
+        self.assertTrue(is_skiplisted(acronym))
+
+    def test_the_ontologies_that_worked_are_not_skiplisted(self):
+        for acronym in ("HRA", "DINTO", "RETO", "REXO", "OGG", "OGG-MM",
+                        "REGN_GO", "GEXO", "LCGFT", "VTO", "PCL", "OBA", "ZP",
+                        "IOBC", "HOOM", "GNO", "RDL", "MONDO", "HGNC", "GO-PLUS"):
+            self.assertFalse(is_skiplisted(acronym), acronym)
+
+    def test_the_skiplist_still_holds_the_giants_it_held_before(self):
+        for acronym in ("NCBITAXON", "SNOMEDCT", "RXNORM", "MEDDRA", "NCIT",
+                        "LOINC", "GAZ", "PR", "DRON", "CPT", "ICD10", "ICD10CM",
+                        "OMIM", "MESH", "UMLS", "RH-MESH"):
+            self.assertIn(acronym, KNOWN_GIANTS)


### PR DESCRIPTION
Two independent commits. Only one branch is available to me, so the gate change landed on top of the #166 commit rather than in its own PR — happy to split if you'd rather review them separately.

---

## 1. Raise the source-size gate to 250 MB, and skiplist CCO (`d3e17c8`) — closes #118

Run 12 attempted every ontology the index held between 100 and 250 MB with **only the gate raised**, to find out whether the limit that keeps a runner alive is really 100 MB. It is not.

**Twenty of twenty-one transformed**, from HRA at 100 MB to GO-PLUS at 227 MB, taking 2m32s–7m49s each — nowhere near the 30-minute cap, and none ran out of memory:

| | source | nodes | edges |
|---|---|---|---|
| GNO | 206 MB | 580,716 | 1,621,987 |
| RDL | 208 MB | 617,934 | 648,010 |
| IOBC | 164 MB | 233,878 | 463,177 |
| HRA | 100 MB | 190,296 | 422,256 |
| …20 in all | | **3,128,595** | **6,637,965** |

That is roughly two thirds again on top of the entire rest of the index (4.7M nodes / 9.0M edges → **7.85M / 15.65M**). MONDO, HGNC, GO-PLUS, OBA, PCL, VTO and ZP are among them.

**The twenty-first was CCO, and it didn't fail — it took the runner down.** ROBOT convert (2m49s) and relax (3m08s) both finished; rdflib then parsed **15,693,276 triples** over 17 minutes, went quiet for five, and the runner was reclaimed under it. Nothing was recorded for CCO — its index entry still reads `Skipped/too_large` from the previous run, because the job died before writing anything — and the run went red.

CCO is 244 MB, *inside* the gate, so the gate is not what stops it. It ships as **OBO**, far denser per byte than the RDF/XML most sources use: the next densest in the band, GNO at 206 MB, yields ~2.2M nodes+edges to CCO's 15.7M triples. Bytes are the wrong unit for it, and holding the gate at 227 MB to exclude one outlier would cost the ontologies between there and 250 for nothing. So it goes on the static skiplist — exactly the list for an ontology that cannot be transformed on this hardware.

> The log says the runner was *reclaimed*, not literally that it ran out of memory. Five minutes of silence while rdflib holds 15.7M triples, the runner VM going rather than our process erroring, and no `too_slow` record from the per-ontology timeout all point one way. Worth noting the shutdown landed 12 seconds after the 30-minute cap would have fired, which the evidence does not distinguish from coincidence.

Everything above 250 MB stays out and stays **untested**: FMA (254), CHEBI (258), PMAPP-PMO (290), EFO (333), UPHENO (397), BERO (878). A test holds the gate below those, so raising it further has to be a deliberate act with a run behind it, as this one was.

Docs updated to match: README's skip reasons, the thresholds section, the local-run example, and the graph browser's explanation of `too_large`.

---

## 2. Quote the parser that read the file, not the one that refused it (`b8c848f`)

Follow-up to #165, from what run 11 recorded. #165 kept the first cause line pointing at a position in the file — but the OWL API asks every parser it has, the RDF/XML one goes first, and for anything not XML it answers at **line 1** with `Content is not allowed in prolog`. That was the recorded detail for all four `invalid_source` entries and for INFRARISK, none of which are RDF/XML.

A parser that got somewhere into the file is the one that recognized it, so prefer a cause pointing past the first line; settle for line 1 only when nothing better is offered. Keeps every case #165 was verified against (`[line=26:column=46]`, `lineNumber: 712`).

Concretely, INFRARISK's two attempts in run 11: the first names the reason — `lineNumber: 712; Element or attribute "xmlns:5g_devices" do not match QName production` (ROBOT writing a namespace prefix starting with a digit, a second distinct way for it to write RDF/XML it can't read back). #165's fallback engaged, converted to Turtle, and relax refused that too — but recorded only `Content is not allowed in prolog`, so **why** is still unknown. With this change the next run says.

---

**419 tests pass** (7 new for the gate). Both parts mutation-checked: reverting the gate to 100 fails 2 tests, removing CCO from the skiplist fails 2, dropping the line>1 preference fails 2.