### PR TITLE
Give every edge an id, and name the ontology instead of a temp file

### DIFF
--- a/.claude/skills/kg-bioportal-data/references/data-model.md
+++ b/.claude/skills/kg-bioportal-data/references/data-model.md
@@ -97,34 +97,42 @@ transform_date: 2026-07-31
 | `category` | Biolink category | `biolink:NamedThing` |
 | `name` | label | `tillage process` |
 | `description` | definition | `A planned process in which soil is …` |
-| `provided_by` | source (see note) | `AGRO_relaxed.owl` |
+| `provided_by` | source ontology, as an infores | `infores:bioportal.agro` |
 | `synonym`, `exact_synonym`, `broad_synonym`, `narrow_synonym`, `related_synonym` | synonyms | (often blank) |
 
 **Edges** — `<ID>_edges.tsv`:
 
 | column | meaning | example |
 |--------|---------|---------|
-| `id` | edge id | *(usually empty)* |
+| `id` | edge id, `subject-predicate-object` | `OBO:AGRO_00000002-biolink:subclass_of-OBO:AGRO_00000108` |
 | `subject` | source node CURIE | `OBO:AGRO_00000002` |
 | `predicate` | Biolink predicate | `biolink:subclass_of` |
 | `object` | target node CURIE | `OBO:AGRO_00000108` |
 | `category` | Biolink edge category | *(often empty)* |
 | `relation` | original relation CURIE | `rdfs:subClassOf` |
-| `knowledge_source` | source (see note) | `AGRO_relaxed.owl` |
+| `aggregator_knowledge_source` | where we got it | `infores:bioportal` |
+| `primary_knowledge_source` | source ontology, as an infores | `infores:bioportal.agro` |
 
-### Provenance note (important)
-Both `provided_by` (nodes) and `knowledge_source` (edges) currently contain the **relaxed OWL file
-name** (`<ID>_relaxed.owl`), an artifact of the ROBOT→KGX step, rather than the acronym or an
-`infores:` CURIE. It still uniquely identifies the source ontology (strip `_relaxed.owl`). If you
-need clean per-source provenance in a merged graph, rewrite this column to the acronym or
-`infores:bioportal` before/after merging.
+### Provenance note
+The ontology is the primary source of its own assertions and BioPortal is the aggregator we got
+them from, so edges carry both `primary_knowledge_source` (`infores:bioportal.<acronym>`) and
+`aggregator_knowledge_source` (`infores:bioportal`), and nodes carry `provided_by` with the same
+per-ontology infores. The acronym is the part after `infores:bioportal.`, lowercased.
+
+**Releases up to and including `data-2026.08.25-12`** instead carry a single `knowledge_source`
+column on edges, and a `provided_by` on nodes, both holding the **relaxed OWL file name**
+(`<ID>_relaxed.owl`) — an artifact of the ROBOT→KGX step that exists only inside a runner's temp
+directory. If you are reading one of those releases, strip `_relaxed.owl` to recover the acronym.
 
 ### Other characteristics
 - Node ids are CURIEs; prefixes vary by ontology (`OBO:`, ontology-specific prefixes, etc.).
 - `predicate` is Biolink-normalized (e.g. `biolink:subclass_of`); `relation` keeps the original
   (e.g. `rdfs:subClassOf`).
-- Edge `id` is frequently empty — cat-merge and KGX handle this, but if you need stable edge ids,
-  synthesize them (e.g. `subject|predicate|object`).
+- Edge `id` is `subject-predicate-object`, and is present on every edge. In releases up to
+  `data-2026.08.25-12` it was empty on most of them: KGX assigned ids only to whole batches of
+  10,000 edges and left the remainder blank, so an ontology with fewer than 10,000 edges had none
+  at all. The ids are derived, not opaque, so they are stable across runs but not unique across
+  ontologies until you namespace them.
 - These are single-ontology graphs; cross-ontology references appear as edges whose `object` (or
   `subject`) is a CURIE not present as a node in this graph — i.e. **dangling** until you merge in
   the referenced ontology. This is the main signal the merge QC report surfaces.

--- a/src/kg_bioportal/kgx_patches.py
+++ b/src/kg_bioportal/kgx_patches.py
@@ -17,6 +17,7 @@ _mixed_type_sorts = 0
 
 _patched = False
 _owl_format_patched = False
+_edge_id_patched = False
 
 
 def mixed_type_sort_count() -> int:
@@ -146,4 +147,79 @@ def patch_owl_source_format() -> bool:
     OwlSource.parse = parse
     _owl_format_patched = True
     logging.debug("Patched kgx.source.OwlSource.parse to honour the file's format.")
+    return True
+
+
+def edge_key(edge: dict) -> str:
+    """The id KGX itself would give this edge, from its subject/predicate/object.
+
+    Matches ``kgx.utils.kgx_utils.generate_edge_key``, which is what KGX uses
+    for the edges it does assign ids to, so a filled-in id is indistinguishable
+    from one KGX wrote -- rather than a second scheme sitting alongside the
+    first.
+    """
+    return "{}-{}-{}".format(
+        edge.get("subject", ""), edge.get("predicate", ""), edge.get("object", "")
+    )
+
+
+def patch_missing_edge_ids() -> bool:
+    """Give every edge an id, not just the ones a cache flush happened to catch.
+
+    KGX's RdfSource holds parsed edges in ``edge_cache`` and drains it in two
+    places. The mid-stream drain, which fires when the cache reaches
+    ``CACHE_SIZE`` (10,000), assigns an id to every edge that does not already
+    have one::
+
+        if "id" not in self.edge_cache[k] and "association_id" not in ...:
+            self.edge_cache[k]["id"] = generate_edge_key(subject, predicate, object)
+
+    The final drain at end-of-parse -- the one that yields everything left over
+    -- has no such block. So an ontology's edges get ids only in whole batches
+    of 10,000, and the remainder never do.
+
+    That is exactly what the published graphs show (#71). NANDO has 14,133
+    edges: the first 10,000 carry ids and the last 4,133 are blank, with the
+    same mix of predicates on both sides of the boundary. FAST-EVENT-SKOS is
+    60,000 of 62,123, MONDO 260,000 of 268,909. An ontology with fewer than
+    10,000 edges never flushes at all, so BFO's 115 edges are blank to the last
+    one -- which is the case the issue was filed about.
+
+    (A handful of edges carry an id regardless: those dereified from an
+    owl:Axiom bring their own, which is why HPIO has 3 ids among 244 edges.)
+
+    So: fill in the id on the way past, using KGX's own scheme. This is a fix to
+    a KGX bug applied from outside, like the two patches above; it stops
+    mattering if upstream drains the final batch the way it drains the others.
+
+    Returns:
+        True if the patch was applied, False if it was already in place.
+    """
+    global _edge_id_patched
+    if _edge_id_patched:
+        return False
+
+    try:
+        from kgx.source.owl_source import OwlSource
+    except ImportError as e:
+        logging.warning(f"Could not patch KGX's edge id assignment: {e}")
+        return False
+
+    original_parse = OwlSource.parse
+
+    def parse(self, *args: Any, **kwargs: Any):
+        for record in original_parse(self, *args, **kwargs):
+            # Node records are 2-tuples, edge records 4-tuples of
+            # (subject, object, key, data) -- see RdfSource's drains. The
+            # stream also carries a bare None after every triple that did not
+            # complete a record, so this cannot assume it has a tuple at all.
+            if isinstance(record, tuple) and len(record) == 4:
+                edge = record[3]
+                if isinstance(edge, dict) and not edge.get("id"):
+                    edge["id"] = edge_key(edge)
+            yield record
+
+    OwlSource.parse = parse
+    _edge_id_patched = True
+    logging.debug("Patched kgx.source.OwlSource.parse to give every edge an id.")
     return True

--- a/src/kg_bioportal/transformer.py
+++ b/src/kg_bioportal/transformer.py
@@ -22,13 +22,18 @@ from kg_bioportal.config import (
     PER_ONTOLOGY_TIMEOUT_MIN,
 )
 from kg_bioportal.downloader import DOWNLOAD_REPORT_NAME, ONTOLOGY_LIST_NAME
-from kg_bioportal.kgx_patches import patch_mixed_type_sorting, patch_owl_source_format
+from kg_bioportal.kgx_patches import (
+    patch_missing_edge_ids,
+    patch_mixed_type_sorting,
+    patch_owl_source_format,
+)
 from kg_bioportal.robot_utils import initialize_robot, robot_convert, robot_relax
 
 # Applied at import so it is in place for any use of the KGX transform, not just
 # the ones that go through Transformer. See kgx_patches for what and why.
 patch_mixed_type_sorting()
 patch_owl_source_format()
+patch_missing_edge_ids()
 
 # TODO: Don't repeat steps if the products already exist
 # TODO: Fix KGX hijacking logging
@@ -726,6 +731,49 @@ _LOAD_FAILURE_MARKERS = (
 # The onto_stats reason for those, so they stop sitting in the same bucket as
 # failures we can do something about.
 INVALID_SOURCE_REASON = "invalid_source"
+
+
+# Who we got the ontology from. BioPortal aggregates ontologies it does not
+# author, which is what an aggregator_knowledge_source is for; the ontology
+# itself is the primary source of its own assertions.
+AGGREGATOR_INFORES = "infores:bioportal"
+
+# The columns the TSVs carry. Streaming is the only way a 250 MB ontology fits
+# on a runner, and a streaming sink cannot discover its columns from records it
+# has already written past -- KGX says as much, and falls back to a fixed
+# DEFAULT_EDGE_COLUMNS that has "knowledge_source" in it and neither of the two
+# slots we actually populate. So the provenance would sit on every record and
+# reach no column. Declared here instead.
+#
+# These are KGX's own defaults with the edge provenance corrected: the generic
+# "knowledge_source" is dropped because nothing fills it once the specific slots
+# are set, and an always-empty column is worse than no column.
+NODE_COLUMNS = [
+    "id", "category", "name", "description", "provided_by",
+    "synonym", "exact_synonym", "broad_synonym", "narrow_synonym",
+    "related_synonym",
+]
+EDGE_COLUMNS = [
+    "id", "subject", "predicate", "object", "category", "relation",
+    "primary_knowledge_source", "aggregator_knowledge_source",
+]
+
+# An acronym is not an infores identifier, and inventing a registry entry for
+# 1190 ontologies is not this function's job -- but a bare "AGRO" in a
+# knowledge_source column is not one either. Namespacing it says plainly where
+# the value came from and keeps it distinguishable from a registered infores,
+# which is the honest state of things until BioPortal ontologies have real ones.
+INFORES_PREFIX = "infores:bioportal."
+
+
+def ontology_infores(acronym: str) -> str:
+    """The knowledge-source identifier for one BioPortal ontology.
+
+    Lowercased and namespaced under the aggregator: infores identifiers are
+    conventionally lowercase, and an acronym on its own would read as a claim to
+    a registered infores that does not exist.
+    """
+    return f"{INFORES_PREFIX}{acronym.strip().lower()}"
 
 # Ceiling on the syntax check below. It runs only for an ontology that has
 # already failed, but rdflib holds the whole graph in memory and the per-
@@ -1524,15 +1572,37 @@ class Transformer:
         outfilename = os.path.join(workdir, f"{ontology_name}")
         nodefilename = outfilename + "_nodes.tsv"
         edgefilename = outfilename + "_edges.tsv"
+        # Provenance goes in input_args, not output_args. KGX reads it in
+        # Transformer.transform as `source.parse(f, default_provenance=..., 
+        # **input_args)`, and the sink never looks at it -- so the same keys set
+        # on output_args, as they were, are silently dropped (#72). What KGX
+        # falls back to when nothing is set is
+        #
+        #     default_provenance = os.path.basename(f)
+        #
+        # which is our own intermediate: every node and edge of all 1190
+        # published graphs says it was provided by "<ACRONYM>_relaxed.owl", a
+        # build artifact that does not exist anywhere outside a runner's temp
+        # directory and identifies nothing about where the knowledge came from.
+        #
+        # So say it properly. The ontology is the primary source of its own
+        # assertions; BioPortal is the aggregator we got them from. Both slots
+        # take the same infores rather than the bare acronym on one and a
+        # namespaced id on the other: these are knowledge-source slots in
+        # Biolink, and the acronym is still recoverable from the value, from the
+        # file name, and from the index.
         input_args = {
             "format": "owl",
             "filename": [kgx_input_path],
+            "provided_by": ontology_infores(ontology_name),
+            "primary_knowledge_source": ontology_infores(ontology_name),
+            "aggregator_knowledge_source": AGGREGATOR_INFORES,
         }
         output_args = {
             "format": "tsv",
             "filename": outfilename,
-            "provided_by": ontology_name,
-            "aggregator_knowledge_source": "infores:bioportal",
+            "node_properties": NODE_COLUMNS,
+            "edge_properties": EDGE_COLUMNS,
         }
         logging.info("Doing KGX transform.")
         # Constructing the transformer is inside the try as well: it is part of

--- a/tests/test_edge_ids_and_provenance.py
+++ b/tests/test_edge_ids_and_provenance.py
@@ -1,0 +1,342 @@
+"""Every edge gets an id, and provenance names the ontology rather than a temp file.
+
+Two faults visible in the same rows of every published graph.
+
+**#71.** KGX's RdfSource drains its edge cache in two places. The mid-stream
+drain, which fires at CACHE_SIZE (10,000), assigns an id to every edge that has
+none. The final drain at end-of-parse does not. So ids arrive only in whole
+batches of 10,000 and the remainder never get one -- measured on release
+data-2026.08.25-12:
+
+    BFO         115 edges        115 blank (100.0%)   never flushes
+    AGRO      8,691 edges      6,466 blank ( 74.4%)
+    NANDO    14,133 edges      4,133 blank ( 29.2%)   10,000 with ids
+    MONDO   268,909 edges      8,909 blank (  3.3%)  260,000 with ids
+
+In NANDO the boundary is positional, not semantic: rows 2-10001 carry ids and
+everything after does not, with the same mix of predicates on both sides.
+
+**#72.** KGX reads provenance out of ``input_args``, in Transformer.transform::
+
+    default_provenance = os.path.basename(f)
+    g = source.parse(f, default_provenance=default_provenance, **input_args)
+
+The pipeline set ``provided_by`` and ``aggregator_knowledge_source`` on
+``output_args`` instead, where nothing reads them, so every node and edge of all
+1190 graphs fell back to the basename of our own intermediate --
+``<ACRONYM>_relaxed.owl``, a file that exists only inside a runner's temp
+directory.
+
+These tests run against the real KGX, not a stub: the patch threads a generator
+that also yields bare ``None`` between records, which a stub would not have
+reproduced.
+"""
+
+import os
+import tempfile
+from unittest import TestCase
+
+from kgx.source.owl_source import OwlSource
+
+from kg_bioportal import kgx_patches
+from kg_bioportal.transformer import (
+    AGGREGATOR_INFORES,
+    EDGE_COLUMNS,
+    NODE_COLUMNS,
+    ontology_infores,
+)
+
+kgx_patches.patch_owl_source_format()
+
+# CACHE_SIZE in kgx.source.rdf_source. The tests below straddle it deliberately.
+FLUSH_AT = 10000
+
+
+class Owner:
+    """The little of a KGX Transformer that OwlSource actually touches."""
+
+    def log_error(self, **kwargs):
+        pass
+
+
+def ontology_with(edge_count):
+    """An RDF/XML ontology with exactly `edge_count` subclass edges."""
+    tmp = tempfile.mkdtemp()
+    path = os.path.join(tmp, "onto.owl")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write('<?xml version="1.0"?>\n<rdf:RDF '
+                'xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" '
+                'xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" '
+                'xmlns:owl="http://www.w3.org/2002/07/owl#">\n'
+                '<owl:Ontology rdf:about="http://ex.org/o"/>\n'
+                '<owl:Class rdf:about="http://ex.org/Root"/>\n')
+        for i in range(edge_count):
+            f.write(f'<owl:Class rdf:about="http://ex.org/C{i}">'
+                    f'<rdfs:subClassOf rdf:resource="http://ex.org/Root"/>'
+                    f'<rdfs:label>C{i}</rdfs:label></owl:Class>\n')
+        f.write('</rdf:RDF>\n')
+    return path
+
+
+def parse(path, **provenance):
+    """Nodes and edges as KGX yields them, with our patches in place."""
+    records = list(OwlSource(owner=Owner()).parse(path, format="owl", **provenance))
+    edges = [r[3] for r in records if isinstance(r, tuple) and len(r) == 4]
+    nodes = [r[1] for r in records if isinstance(r, tuple) and len(r) == 2]
+    return nodes, edges
+
+
+class TestEveryEdgeHasAnId(TestCase):
+    """The counts above go to zero."""
+
+    def test_a_small_ontology_that_never_flushes(self):
+        # BFO's case: 115 edges, no flush, and before the fix not one id.
+        _, edges = parse(ontology_with(115))
+        self.assertEqual(len(edges), 115)
+        self.assertEqual([e for e in edges if not e.get("id")], [])
+
+    def test_an_ontology_that_straddles_the_flush(self):
+        # NANDO's case: the remainder after the last whole batch.
+        _, edges = parse(ontology_with(FLUSH_AT + 200))
+        self.assertEqual(len(edges), FLUSH_AT + 200)
+        self.assertEqual(len([e for e in edges if not e.get("id")]), 0)
+
+    def test_the_id_is_the_one_kgx_would_have_written(self):
+        # Not a second scheme alongside KGX's: the same subject-predicate-object.
+        _, edges = parse(ontology_with(3))
+        for edge in edges:
+            self.assertEqual(
+                edge["id"],
+                f"{edge['subject']}-{edge['predicate']}-{edge['object']}",
+            )
+
+    def test_ids_are_stable_across_parses(self):
+        # Derived, not generated: the same ontology yields the same ids, so a
+        # rebuilt graph does not look like a graph of entirely new edges.
+        path = ontology_with(50)
+        first = sorted(e["id"] for e in parse(path)[1])
+        self.assertEqual(sorted(e["id"] for e in parse(path)[1]), first)
+
+    def test_an_edge_that_already_has_an_id_keeps_it(self):
+        # Edges dereified from an owl:Axiom bring their own; the patch fills
+        # gaps rather than overwriting.
+        edge = {"subject": "A", "predicate": "p", "object": "B", "id": "kept"}
+        self.assertEqual(kgx_patches.edge_key(edge), "A-p-B")
+        self.assertEqual(edge["id"], "kept")
+
+    def test_patching_twice_is_a_no_op(self):
+        self.assertFalse(kgx_patches.patch_missing_edge_ids())
+
+
+class TestProvenanceNamesTheOntology(TestCase):
+    """Not <ACRONYM>_relaxed.owl, which is a file on a runner that no longer exists."""
+
+    def setUp(self):
+        self.path = ontology_with(5)
+        self.nodes, self.edges = parse(
+            self.path,
+            provided_by=ontology_infores("AGRO"),
+            primary_knowledge_source=ontology_infores("AGRO"),
+            aggregator_knowledge_source=AGGREGATOR_INFORES,
+        )
+
+    def flat(self, value):
+        return value[0] if isinstance(value, list) else value
+
+    def test_nodes_say_which_ontology_provided_them(self):
+        self.assertEqual(self.flat(self.nodes[-1]["provided_by"]),
+                         "infores:bioportal.agro")
+
+    def test_edges_name_the_ontology_as_the_primary_source(self):
+        self.assertEqual(self.flat(self.edges[-1]["primary_knowledge_source"]),
+                         "infores:bioportal.agro")
+
+    def test_edges_name_bioportal_as_the_aggregator(self):
+        self.assertEqual(self.flat(self.edges[-1]["aggregator_knowledge_source"]),
+                         "infores:bioportal")
+
+    def test_nothing_carries_the_intermediate_filename(self):
+        # The whole point. Before the fix every one of these held "onto.owl".
+        for record in self.nodes + self.edges:
+            for key, value in record.items():
+                self.assertNotIn(
+                    "onto.owl", str(value), f"{key} still names the intermediate")
+
+    def test_without_provenance_kgx_falls_back_to_the_filename(self):
+        # Holds the diagnosis in place: this is what the published graphs show,
+        # and what the pipeline gets if the keys go anywhere but input_args.
+        # Transformer.transform is what supplies the basename, so pass it the
+        # way it does rather than asserting parse() invents it.
+        nodes, _ = parse(self.path, default_provenance=os.path.basename(self.path))
+        self.assertEqual(self.flat(nodes[-1]["provided_by"]), "onto.owl")
+
+    def test_our_provenance_wins_over_that_fallback(self):
+        # The pipeline passes both: KGX supplies default_provenance from the
+        # filename and we supply the real thing alongside it.
+        nodes, edges = parse(
+            self.path,
+            default_provenance=os.path.basename(self.path),
+            provided_by=ontology_infores("AGRO"),
+            primary_knowledge_source=ontology_infores("AGRO"),
+            aggregator_knowledge_source=AGGREGATOR_INFORES,
+        )
+        self.assertEqual(self.flat(nodes[-1]["provided_by"]),
+                         "infores:bioportal.agro")
+        self.assertEqual(self.flat(edges[-1]["primary_knowledge_source"]),
+                         "infores:bioportal.agro")
+
+
+class TestTheInforesIdentifiers(TestCase):
+    def test_the_acronym_is_lowercased_and_namespaced(self):
+        self.assertEqual(ontology_infores("AGRO"), "infores:bioportal.agro")
+
+    def test_a_hyphenated_acronym_survives(self):
+        self.assertEqual(ontology_infores("FAST-EVENT-SKOS"),
+                         "infores:bioportal.fast-event-skos")
+
+    def test_surrounding_whitespace_is_dropped(self):
+        self.assertEqual(ontology_infores("  ZP "), "infores:bioportal.zp")
+
+    def test_the_aggregator_is_bioportal_itself(self):
+        self.assertEqual(AGGREGATOR_INFORES, "infores:bioportal")
+
+    def test_an_ontology_is_distinguishable_from_the_aggregator(self):
+        # A merged graph has to be able to tell "BioPortal gave us this" from
+        # "this ontology asserts it".
+        self.assertNotEqual(ontology_infores("BIOPORTAL"), AGGREGATOR_INFORES)
+
+
+class TestTheProvenanceIsWiredWhereKgxReadsIt(TestCase):
+    """The bug was never the values -- it was which dict they were in.
+
+    KGX reads provenance from ``input_args`` and the sink ignores it, so the
+    same keys on ``output_args`` are silently dropped. Asserting the values
+    round-trip through ``parse()`` does not catch that; this drives
+    ``transform()`` and looks at what it actually hands KGX.
+    """
+
+    def setUp(self):
+        import tempfile as _tempfile
+        from unittest import mock
+
+        from kg_bioportal.robot_utils import RobotResult
+        from kg_bioportal.transformer import Transformer
+
+        self._tmp = _tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        input_dir = os.path.join(self._tmp.name, "raw")
+        source = os.path.join(input_dir, "AGRO", "1", "agro.owl")
+        os.makedirs(os.path.dirname(source), exist_ok=True)
+        with open(source, "w") as f:
+            f.write('<?xml version="1.0"?>\n<rdf:RDF '
+                    'xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" '
+                    'xmlns:owl="http://www.w3.org/2002/07/owl#">\n'
+                    '<owl:Ontology rdf:about="http://example.org/onto"/>\n'
+                    '</rdf:RDF>\n')
+
+        txr = Transformer.__new__(Transformer)
+        txr.input_dir = input_dir
+        txr.output_dir = os.path.join(self._tmp.name, "transformed")
+        txr.timeout_sec, txr.timeout_min = 60, 1
+        txr.max_source_bytes = 0
+        txr.robot_path, txr.robot_env = "/nonexistent/robot", {}
+
+        captured = {}
+
+        def robot_ok(**kwargs):
+            os.makedirs(os.path.dirname(kwargs["output_path"]), exist_ok=True)
+            with open(kwargs["output_path"], "w") as f:
+                f.write('<?xml version="1.0"?>\n<rdf:RDF '
+                        'xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" '
+                        'xmlns:owl="http://www.w3.org/2002/07/owl#">\n'
+                        '<owl:Ontology rdf:about="http://example.org/onto"/>\n'
+                        '</rdf:RDF>\n')
+            return RobotResult(True)
+
+        class FakeKGX:
+            def __init__(self, *a, **k):
+                pass
+
+            def transform(self, input_args, output_args):
+                captured["input"] = dict(input_args)
+                captured["output"] = dict(output_args)
+                for suffix in ("_nodes.tsv", "_edges.tsv"):
+                    with open(output_args["filename"] + suffix, "w") as fh:
+                        fh.write("id\n")
+
+        with mock.patch("kg_bioportal.transformer.robot_convert", robot_ok), \
+             mock.patch("kg_bioportal.transformer.robot_relax", robot_ok), \
+             mock.patch("kg_bioportal.transformer.KGXTransformer", FakeKGX):
+            txr.transform(source, compress=False)
+        self.captured = captured
+
+    def test_provided_by_reaches_input_args(self):
+        self.assertEqual(self.captured["input"]["provided_by"],
+                         "infores:bioportal.agro")
+
+    def test_primary_knowledge_source_reaches_input_args(self):
+        self.assertEqual(self.captured["input"]["primary_knowledge_source"],
+                         "infores:bioportal.agro")
+
+    def test_aggregator_reaches_input_args(self):
+        self.assertEqual(self.captured["input"]["aggregator_knowledge_source"],
+                         AGGREGATOR_INFORES)
+
+    def test_none_of_it_is_left_on_output_args(self):
+        # Where it was, and where KGX never looks.
+        for key in ("provided_by", "primary_knowledge_source",
+                    "aggregator_knowledge_source", "knowledge_source"):
+            self.assertNotIn(key, self.captured["output"])
+
+    def test_the_acronym_is_what_names_the_ontology(self):
+        # Not the intermediate file the transform happens to have written.
+        self.assertNotIn(
+            "relaxed", str(self.captured["input"]["primary_knowledge_source"]))
+
+    def test_the_columns_are_declared_on_output_args(self):
+        # Streaming sinks fix their columns before the first record, so without
+        # this the provenance is on every record and in no file.
+        self.assertEqual(self.captured["output"]["edge_properties"], EDGE_COLUMNS)
+        self.assertEqual(self.captured["output"]["node_properties"], NODE_COLUMNS)
+
+
+class TestTheColumnsExistToWriteItInto(TestCase):
+    """Values on a record reach no file if the sink has no column for them.
+
+    KGX streams -- the only way a 250 MB ontology fits on a runner -- and a
+    streaming TSV sink fixes its columns before the first record, so it cannot
+    discover them. Given no `edge_properties` it falls back to a default set
+    that carries `knowledge_source` and neither of the slots we populate. The
+    provenance was correct on every record and absent from every file; only
+    running the real pipeline showed it.
+    """
+
+    def test_the_edge_provenance_columns_are_declared(self):
+        self.assertIn("primary_knowledge_source", EDGE_COLUMNS)
+        self.assertIn("aggregator_knowledge_source", EDGE_COLUMNS)
+
+    def test_the_node_provenance_column_is_declared(self):
+        self.assertIn("provided_by", NODE_COLUMNS)
+
+    def test_the_empty_generic_column_is_gone(self):
+        # Nothing fills knowledge_source once the specific slots are set, and an
+        # always-empty column is worse than no column.
+        self.assertNotIn("knowledge_source", EDGE_COLUMNS)
+
+    def test_edges_keep_every_other_column_they_had(self):
+        # 1190 published graphs have these; a consumer reading them must not
+        # find one missing.
+        for column in ("id", "subject", "predicate", "object", "category", "relation"):
+            self.assertIn(column, EDGE_COLUMNS)
+
+    def test_nodes_keep_every_column_they_had(self):
+        for column in ("id", "category", "name", "description", "provided_by",
+                       "synonym", "exact_synonym", "broad_synonym",
+                       "narrow_synonym", "related_synonym"):
+            self.assertIn(column, NODE_COLUMNS)
+
+    def test_the_columns_are_ordered_not_a_set(self):
+        # The header has to be stable across runs, so a diff of two releases
+        # shows changed data rather than reshuffled columns.
+        self.assertIsInstance(EDGE_COLUMNS, list)
+        self.assertIsInstance(NODE_COLUMNS, list)


### PR DESCRIPTION
Closes #71. Closes #72. Two faults visible in the same rows of all 1190 published graphs.

## #71 — most edges have no id

KGX's `RdfSource` drains its edge cache in two places. The mid-stream drain, at `CACHE_SIZE` (10,000), assigns an id to every edge that lacks one. The final drain at end-of-parse **does not**. So ids arrive only in whole batches of 10,000 and the remainder never get one.

Measured on release `data-2026.08.25-12`:

| | edges | blank id | |
|---|---|---|---|
| BFO | 115 | 115 (100.0%) | never flushes |
| AGRO | 8,691 | 6,466 (74.4%) | |
| ICD-O-3 | 4,480 | 4,468 (99.7%) | |
| NANDO | 14,133 | 4,133 (29.2%) | 10,000 with ids |
| MONDO | 268,909 | 8,909 (3.3%) | 260,000 with ids |

**The boundary is positional, not semantic.** In NANDO rows 2–10001 carry ids and everything after does not, with the same mix of predicates on both sides — which rules out the "certain edge types don't get ids" reading the issue's BFO snippet suggests. An ontology under 10,000 edges never flushes at all, which is BFO, the case the issue was filed about.

(A handful carry an id regardless: edges dereified from an `owl:Axiom` bring their own, which is why HPIO has 3 among 244.)

Fixed by filling the id in as records go past, using KGX's own `generate_edge_key` scheme, in `kgx_patches` beside the two patches already there. A filled id is indistinguishable from one KGX wrote.

## #72 — provenance names our temp file

KGX reads provenance from **`input_args`**, in `Transformer.transform`:

```python
default_provenance = os.path.basename(f)
g = source.parse(f, default_provenance=default_provenance, **input_args)
```

The pipeline set `provided_by` and `aggregator_knowledge_source` on **`output_args`**, where nothing reads them. So every node and edge fell back to the basename of our own intermediate — `<ACRONYM>_relaxed.owl`, a file that exists only inside a runner's temp directory and says nothing about where the knowledge came from.

Moved to `input_args`. The ontology now names itself as `primary_knowledge_source`, with BioPortal as `aggregator_knowledge_source`. Both take `infores:bioportal.<acronym>` rather than a bare acronym: these are knowledge-source slots in Biolink, and the acronym is still recoverable from the value, the file name and the index. It's namespaced under the aggregator because BioPortal ontologies have no registered infores identifiers — claiming otherwise would be worse than saying plainly where the id came from.

**That wasn't sufficient on its own.** Streaming is the only way a 250 MB ontology fits on a runner, and a streaming TSV sink fixes its columns before the first record, so it can't discover them. Given no `edge_properties`, KGX falls back to a default set carrying `knowledge_source` and neither slot we populate — so the provenance was correct on every record and absent from every file. The columns are now declared, with the always-empty generic `knowledge_source` dropped.

## Verification

End to end with **real ROBOT 1.9.6 and real KGX 2.6.0**, not the stub, over a 40-edge ontology:

```
before   id blank on 40 of 40;  provided_by = demo_relaxed.owl
after    id blank on  0 of 40;  provided_by = infores:bioportal.demo
         aggregator_knowledge_source = infores:bioportal
         primary_knowledge_source    = infores:bioportal.demo
```

Running against real KGX caught two things a stub would not have:

- the parse generator yields a bare `None` between records, which the first version of the patch called `len()` on;
- the column declaration above, which no amount of asserting on record *contents* would have revealed.

The whole suite now runs against real KGX locally, including `test_kgx_patches.py`, which was previously CI-only. **466 tests pass.** All three parts mutation-checked — and the first two mutation runs passed against my initial tests, which is how I found that I was asserting on values and constants rather than on the wiring that was actually broken.

## Note for consumers

Edge ids are derived (`subject-predicate-object`), so they're stable across runs but **not unique across ontologies** until namespaced. The edge `knowledge_source` column is replaced by `primary_knowledge_source` + `aggregator_knowledge_source`. Both documented in `data-model.md`, along with what releases up to `data-2026.08.25-12` carry instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JM47TqJy5r9R2T2FgcWJhM)_