### PR TITLE
Report the Biolink categories in every ontology (#98)

### DIFF
--- a/.claude/skills/kg-bioportal-data/references/data-model.md
+++ b/.claude/skills/kg-bioportal-data/references/data-model.md
@@ -71,6 +71,16 @@ ontologies:
                           #   written and the graph is unaffected.
   nodecount: 5102         # 0 unless status OK
   edgecount: 8691
+  # node_categories / edge_categories: OK entries only, and only where the run
+  # that built the entry recorded a tally -- which Biolink categories are present
+  # and how many rows carry each. A row with more than one category is counted
+  # under each, so a tally can sum to more than nodecount/edgecount; `(none)` is
+  # the key for rows with no category at all. Entries carried forward from a
+  # release built before this was recorded have neither field.
+  node_categories:
+    biolink:NamedThing: 5102
+  edge_categories:
+    biolink:Association: 8691
   submission_id: '6'      # BioPortal submission id
   source_bytes: 7501012   # size of the source ontology file
   download_url: https://github.com/ncbo/kg-bioportal/releases/download/data-2026.08.01-42/AGRO.tar.gz
@@ -108,7 +118,7 @@ transform_date: 2026-07-31
 | `subject` | source node CURIE | `OBO:AGRO_00000002` |
 | `predicate` | Biolink predicate | `biolink:subclass_of` |
 | `object` | target node CURIE | `OBO:AGRO_00000108` |
-| `category` | Biolink edge category | *(often empty)* |
+| `category` | Biolink edge category | `biolink:Association` |
 | `relation` | original relation CURIE | `rdfs:subClassOf` |
 | `aggregator_knowledge_source` | where we got it | `infores:bioportal` |
 | `primary_knowledge_source` | source ontology, as an infores | `infores:bioportal.agro` |
@@ -123,6 +133,18 @@ per-ontology infores. The acronym is the part after `infores:bioportal.`, lowerc
 column on edges, and a `provided_by` on nodes, both holding the **relaxed OWL file name**
 (`<ID>_relaxed.owl`) — an artifact of the ROBOT→KGX step that exists only inside a runner's temp
 directory. If you are reading one of those releases, strip `_relaxed.owl` to recover the acronym.
+
+### Category note
+Every node carries `biolink:NamedThing` and every edge `biolink:Association`. These are the roots
+of the Biolink class hierarchies, and they are what KGX writes when nothing more specific has been
+established: a plain OWL ontology carries no Biolink typing, and this pipeline does not currently
+infer any. So the `category` columns say *that* a row is a node or an edge, not what kind — treat
+a category tally as a completeness check rather than as a description of the ontology's contents.
+
+**Releases up to and including `data-2026.08.25-12`** carry the same `biolink:NamedThing` on nodes
+but leave `category` **empty** on every edge except those dereified from an `owl:Axiom`, which
+carry `biolink:Association`. The proportion is an artifact of how the ontology was written, not a
+distinction worth reading.
 
 ### Other characteristics
 - Node ids are CURIEs; prefixes vary by ontology (`OBO:`, ontology-specific prefixes, etc.).

--- a/docs/kg_site/build_site.py
+++ b/docs/kg_site/build_site.py
@@ -169,6 +169,11 @@ def onto_to_item(o, transform_date):
         "submission_id": o.get("submission_id", "NA"),
         "reason": o.get("reason", ""), "detail": o.get("detail", ""),
         "malformed_literals": o.get("malformed_literals", 0),
+        # Biolink categories present on this ontology's nodes and edges (#98).
+        # Absent from entries seeded from a release built before the transform
+        # recorded them; the page then says so rather than showing an empty chart.
+        "node_categories": o.get("node_categories") or {},
+        "edge_categories": o.get("edge_categories") or {},
         "transform_date": transform_date or "",
     }
 
@@ -492,6 +497,44 @@ def bar_chart(rows, kind, unit):
         )
     return f'<div class="barchart">{"".join(bars)}</div>'
 
+def category_chart(counts, kind, unit):
+    """Ranked bars for a Biolink category tally: {category: count}.
+
+    Unlinked, unlike bar_chart -- a category is not a page on this site. The
+    label is the class name without its ``biolink:`` prefix, which is the same
+    for every row and so carries no information at this width; the full CURIE
+    is in the row's tooltip.
+    """
+    if not counts:
+        return ""
+    ranked = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
+    top = ranked[0][1] or 1
+    rows = []
+    for label, v in ranked:
+        pct = max(v / top * 100, 0.8)
+        rows.append(
+            f'<div class="bar-row wide" title="{esc(label)}: {commafy(v)} {unit}">'
+            f'<span class="bar-lab">{esc(short_cat(label))}</span>'
+            f'<span class="bar-track"><span class="bar-fill {kind}" style="width:{pct:.2f}%"></span></span>'
+            f'<span class="bar-val num">{commafy(v)}</span></div>'
+        )
+    return f'<div class="barchart">{"".join(rows)}</div>'
+
+# A tally counts a node once per category it carries, so it can exceed the node
+# count. Said once here rather than in every panel that shows one.
+MULTI_CAT_NOTE = ("An item carrying more than one category is counted under each, so these "
+                  "counts can add up to more than the total.")
+
+def category_panel(counts, total, kind, unit, absent_html):
+    """The Nodes/Edges tab body for one ontology: its category tally, or why there isn't one."""
+    if not counts:
+        return absent_html
+    n = len(counts)
+    head = (f'<p class="eyebrow">Biolink categories <span class="eb-count">'
+            f'{commafy(n)} {"category" if n == 1 else "categories"} across '
+            f'{commafy(total)} {unit}</span></p>')
+    return head + category_chart(counts, kind, unit) + f'<p class="muted mt">{MULTI_CAT_NOTE}</p>'
+
 def render_summary(totals, kg_count, onto_items):
     """Site-wide summary: headline counts, transform status, and top-10 charts."""
     ok_ontos = [it for it in onto_items if it.get("ok")]
@@ -545,6 +588,34 @@ def render_summary(totals, kg_count, onto_items):
                         key=lambda it: it[field], reverse=True)[:10]
         return [(it["acr"], it[field], f'../resource/{it["id"]}/') for it in ranked]
 
+    # Site-wide composition, summed over the ontologies whose index entries
+    # record a tally (#98). Entries seeded from a release built before the
+    # transform recorded them have none, so the header says how many ontologies
+    # are actually behind these numbers rather than implying it is all of them.
+    def sum_cats(field):
+        total, seen = {}, 0
+        for it in ok_ontos:
+            counts = it.get(field) or {}
+            if not counts:
+                continue
+            seen += 1
+            for name, v in counts.items():
+                total[name] = total.get(name, 0) + v
+        return total, seen
+
+    def cat_block(field, kind, unit, label):
+        counts, seen = sum_cats(field)
+        if not counts:
+            return ""
+        return f"""
+      <section class="block">
+        <p class="eyebrow">{label} <span class="eb-count">{commafy(seen)} of
+          {commafy(onto_ok)} ontologies</span></p>
+        {category_chart(counts, kind, unit)}
+        <p class="muted mt">{MULTI_CAT_NOTE} Ontologies last transformed before these counts
+          were recorded contribute nothing to them.</p>
+      </section>"""
+
     return head("Summary · KG-BioPortal") + nav("../", active="summary") + f"""
 <div class="wrap">
   <div class="crumbs"><a href="../index.html">Home</a><span>/</span>Summary</div>
@@ -576,6 +647,8 @@ def render_summary(totals, kg_count, onto_items):
         <p class="eyebrow">Largest ontologies by edge count</p>
         {bar_chart(top_rows('edges'), 'edge', 'edges')}
       </section>
+{cat_block('node_categories', 'node', 'nodes', 'Node categories across the collection')}
+{cat_block('edge_categories', 'edge', 'edges', 'Edge categories across the collection')}
     </main>
 
     <aside class="side">
@@ -992,21 +1065,25 @@ def render_ontology_resource(it):
     ]
     details = "".join(detail_rows)
 
-    # Transformed ontologies have only totals in the index — the per-node/edge
-    # types live in the KGX download, not here. Say so plainly.
-    ont_nodes_panel = (
-        "<p class=\"muted\">Per-node-type (Biolink category) lists aren't recorded in the index for "
-        "transformed ontologies"
+    # The Biolink category tally recorded at transform time (#98). Entries
+    # seeded from a release built before it was recorded have none, so each
+    # panel keeps the old "look in the download" text as its fallback.
+    ont_nodes_panel = category_panel(
+        it.get("node_categories"), nodes, "node", "nodes",
+        "<p class=\"muted\">Per-node-type (Biolink category) counts aren't recorded in the index for "
+        "this ontology"
         + (f' — each node carries a <span class="mono">category</span> column in the KGX download. '
            f'Total nodes: <span class="num">{commafy(nodes)}</span>.' if ok and nodes else ".")
-        + "</p>"
+        + "</p>",
     )
-    ont_edges_panel = (
-        "<p class=\"muted\">Per-edge-type (predicate) lists aren't recorded in the index for "
-        "transformed ontologies"
-        + (f' — each edge carries <span class="mono">predicate</span> and <span class="mono">relation</span> '
-           f'columns in the KGX download. Total edges: <span class="num">{commafy(edges)}</span>.' if ok and edges else ".")
-        + "</p>"
+    ont_edges_panel = category_panel(
+        it.get("edge_categories"), edges, "edge", "edges",
+        "<p class=\"muted\">Per-edge-type (Biolink category) counts aren't recorded in the index for "
+        "this ontology"
+        + (f' — each edge carries <span class="mono">category</span>, <span class="mono">predicate</span> '
+           f'and <span class="mono">relation</span> columns in the KGX download. '
+           f'Total edges: <span class="num">{commafy(edges)}</span>.' if ok and edges else ".")
+        + "</p>",
     )
 
     return head(f"{acr} · KG-BioPortal") + nav("../../") + f"""
@@ -1327,7 +1404,10 @@ padding:3px 5px;border-radius:7px;color:var(--ink)}
 .bar-fill{display:block;height:100%;border-radius:0 4px 4px 0;min-width:2px}
 .bar-fill.node{background:var(--node)}.bar-fill.edge{background:var(--edge)}
 .bar-val{font-size:12px;color:var(--ink-soft);text-align:right}
-@media(max-width:520px){.bar-row{grid-template-columns:88px minmax(0,1fr) 46px;gap:8px}}
+/* category tallies: longer labels, exact counts */
+.bar-row.wide{grid-template-columns:190px minmax(0,1fr) 76px}
+@media(max-width:520px){.bar-row{grid-template-columns:88px minmax(0,1fr) 46px;gap:8px}
+.bar-row.wide{grid-template-columns:120px minmax(0,1fr) 66px}}
 .stack{display:flex;gap:2px;height:16px;border-radius:4px;overflow:hidden;background:var(--panel-2)}
 .stack .seg{display:block;height:100%}
 .seg.ok{background:var(--prod)}.seg.fail{background:var(--warn)}.seg.skip{background:var(--ink-faint)}

--- a/src/kg_bioportal/kgx_patches.py
+++ b/src/kg_bioportal/kgx_patches.py
@@ -18,6 +18,7 @@ _mixed_type_sorts = 0
 _patched = False
 _owl_format_patched = False
 _edge_id_patched = False
+_edge_category_patched = False
 
 
 def mixed_type_sort_count() -> int:
@@ -222,4 +223,62 @@ def patch_missing_edge_ids() -> bool:
     OwlSource.parse = parse
     _edge_id_patched = True
     logging.debug("Patched kgx.source.OwlSource.parse to give every edge an id.")
+    return True
+
+
+# The root of Biolink's association hierarchy. Every edge is an association of
+# some kind, so this is the one category that is true of all of them.
+ROOT_ASSOCIATION = "biolink:Association"
+
+
+def patch_missing_edge_categories() -> bool:
+    """Give every edge the root association category, not just the reified ones.
+
+    KGX sets a category on an edge in exactly one place: ``OwlSource`` reifies
+    the edges that carry a logical interpretation and stamps
+    ``biolink:Association`` on those. Every other edge -- which is almost all of
+    them -- reaches the TSV with an empty ``category`` column. In the
+    ``data-2026.08.25-12`` release MONDO's and VTO's edges are blank to the last
+    one, while MCBCC, whose axioms are reified, is mostly ``biolink:Association``.
+
+    That is the same inconsistency as the missing edge ids (#71): the value KGX
+    would have written is not in doubt, it just does not write it on the path
+    most edges take. Filling it in makes the category counts this pipeline now
+    reports (#98) say something about every edge rather than about the handful
+    that happened to be reified.
+
+    ``biolink:Association`` is the root of the association hierarchy, so it is
+    correct-but-general for any edge: a more specific category would need
+    per-predicate evidence we do not have here. An edge that already carries a
+    category -- the reified ones, or anything a future KGX assigns -- is left
+    exactly as it is.
+
+    Returns:
+        True if the patch was applied, False if it was already in place.
+    """
+    global _edge_category_patched
+    if _edge_category_patched:
+        return False
+
+    try:
+        from kgx.source.owl_source import OwlSource
+    except ImportError as e:
+        logging.warning(f"Could not patch KGX's edge category assignment: {e}")
+        return False
+
+    original_parse = OwlSource.parse
+
+    def parse(self, *args: Any, **kwargs: Any):
+        for record in original_parse(self, *args, **kwargs):
+            # See patch_missing_edge_ids for the record shapes; the stream
+            # carries bare None values as well as tuples.
+            if isinstance(record, tuple) and len(record) == 4:
+                edge = record[3]
+                if isinstance(edge, dict) and not edge.get("category"):
+                    edge["category"] = [ROOT_ASSOCIATION]
+            yield record
+
+    OwlSource.parse = parse
+    _edge_category_patched = True
+    logging.debug("Patched kgx.source.OwlSource.parse to give every edge a category.")
     return True

--- a/src/kg_bioportal/transformer.py
+++ b/src/kg_bioportal/transformer.py
@@ -11,7 +11,7 @@ import sys
 import tarfile
 import zipfile
 from contextlib import contextmanager
-from typing import List, NamedTuple, Optional, Tuple
+from typing import Dict, List, NamedTuple, Optional, Tuple
 
 import yaml
 from kgx.transformer import Transformer as KGXTransformer
@@ -23,6 +23,7 @@ from kg_bioportal.config import (
 )
 from kg_bioportal.downloader import DOWNLOAD_REPORT_NAME, ONTOLOGY_LIST_NAME
 from kg_bioportal.kgx_patches import (
+    patch_missing_edge_categories,
     patch_missing_edge_ids,
     patch_mixed_type_sorting,
     patch_owl_source_format,
@@ -34,6 +35,7 @@ from kg_bioportal.robot_utils import initialize_robot, robot_convert, robot_rela
 patch_mixed_type_sorting()
 patch_owl_source_format()
 patch_missing_edge_ids()
+patch_missing_edge_categories()
 
 # TODO: Don't repeat steps if the products already exist
 # TODO: Fix KGX hijacking logging
@@ -956,6 +958,15 @@ class TransformOutcome(NamedTuple):
     # Literals whose lexical form does not match their declared datatype -- a
     # data-quality fact about the source, counted rather than logged (#152).
     malformed_literals: int = 0
+    # Biolink categories present on this ontology's nodes and edges, and how
+    # many of each (#98). Empty for a failure, and for an ontology whose files
+    # carry no category column at all. Appended after malformed_literals so
+    # ``failed()``'s positional construction is unaffected.
+    #
+    # The two empty dicts are shared defaults, as any NamedTuple default is:
+    # nothing here mutates a tally after it is built.
+    node_categories: Dict[str, int] = {}
+    edge_categories: Dict[str, int] = {}
 
     @classmethod
     def failed(
@@ -968,6 +979,67 @@ class TransformOutcome(NamedTuple):
         return cls(
             False, 0, 0, stage, summarize_detail(detail), reason, malformed_literals
         )
+
+
+# Recorded in place of an empty category cell, so "how many of these carry no
+# category at all" is a number in the report rather than a blank key.
+UNCATEGORIZED = "(none)"
+
+
+def tally_column(path: str, column: str = "category") -> Tuple[int, Dict[str, int]]:
+    """Count a KGX TSV's rows and tally the values of one column.
+
+    Read line by line rather than in one go: a large ontology's node file runs
+    to hundreds of megabytes, and this replaces a ``readlines()`` that held all
+    of it at once purely to take its length.
+
+    KGX writes a multi-valued column pipe-delimited, and a node may legitimately
+    carry more than one category. Each value is counted once per row it appears
+    in, so a tally sums to at least the row count and can exceed it: it answers
+    "how many nodes are a Disease", not "how do the nodes partition".
+
+    Args:
+        path: The TSV to read. Its first line is the header.
+        column: Header name to tally. A file without that column is still
+            counted; its tally is empty.
+
+    Returns:
+        (rows excluding the header, {value: rows carrying that value}).
+    """
+    counts: Dict[str, int] = {}
+    rows = 0
+    with open(path, "r") as f:
+        header = f.readline()
+        if not header:
+            return 0, counts
+        fields = header.rstrip("\n").split("\t")
+        index = fields.index(column) if column in fields else None
+        for line in f:
+            rows += 1
+            if index is None:
+                continue
+            cells = line.rstrip("\n").split("\t")
+            cell = cells[index].strip() if index < len(cells) else ""
+            values = [v.strip() for v in cell.split("|") if v.strip()]
+            for value in values or [UNCATEGORIZED]:
+                counts[value] = counts.get(value, 0) + 1
+    return rows, counts
+
+
+def format_tally(counts: Dict[str, int], limit: int = 10) -> str:
+    """A tally as one log line, biggest first.
+
+    Truncated rather than unbounded: the full tally goes to onto_stats.yaml, and
+    an ontology with a long tail of categories should not push everything else
+    in the shard log out of view.
+    """
+    if not counts:
+        return "none"
+    ranked = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
+    shown = ", ".join(f"{name} {count:,}" for name, count in ranked[:limit])
+    if len(ranked) > limit:
+        shown += f", and {len(ranked) - limit} more"
+    return shown
 
 
 def summarize_detail(text: str, limit: int = MAX_DETAIL_CHARS) -> str:
@@ -1335,6 +1407,12 @@ class Transformer:
             # Same reasoning: recorded only for the ontologies that have any.
             if outcome.malformed_literals:
                 entry["malformed_literals"] = outcome.malformed_literals
+            # What kinds of node and edge this ontology actually produced (#98).
+            # Only OK entries have any; a failure has no files to tally.
+            if outcome.node_categories:
+                entry["node_categories"] = dict(outcome.node_categories)
+            if outcome.edge_categories:
+                entry["edge_categories"] = dict(outcome.edge_categories)
             onto_log[ontology_name] = entry
 
         # Write total stats to a yaml
@@ -1621,13 +1699,18 @@ class Transformer:
             )
             if literals.count:
                 logging.warning(f"{ontology_name}: {literals.summary()}")
-            # Get length of nodefile
-            with open(nodefilename, "r") as f:
-                nodecount = len(f.readlines()) - 1
-
-            # Get length of edgefile
-            with open(edgefilename, "r") as f:
-                edgecount = len(f.readlines()) - 1
+            # Size and composition of what we just wrote, in one pass over each
+            # file. The categories are logged here as well as recorded, so a
+            # shard log says what came out of an ontology and not just how much
+            # (#98).
+            nodecount, node_categories = tally_column(nodefilename)
+            edgecount, edge_categories = tally_column(edgefilename)
+            logging.info(
+                f"{ontology_name}: node categories: {format_tally(node_categories)}"
+            )
+            logging.info(
+                f"{ontology_name}: edge categories: {format_tally(edge_categories)}"
+            )
 
             # Compress if requested. Product is written flat at the top of the
             # output dir as <ACRONYM>.tar.gz for direct release upload.
@@ -1670,7 +1753,12 @@ class Transformer:
             )
 
         return TransformOutcome(
-            True, nodecount, edgecount, malformed_literals=literals.count
+            True,
+            nodecount,
+            edgecount,
+            malformed_literals=literals.count,
+            node_categories=node_categories,
+            edge_categories=edge_categories,
         )
 
     def decompress(self, ontology_path: str, ontology_name: str) -> str:

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -173,6 +173,120 @@ class TestDownloadLinks(TestCase):
         self.assertNotIn("Artifact location not recorded", page)
 
 
+class TestCategoryCounts(TestCase):
+    """The dashboard half of #98: what kinds of node and edge an ontology has.
+
+    Before this, both tabs said the same thing for every ontology -- "look in
+    the download". The counts are now in the index, so they can be read here.
+    """
+
+    NODE_CATS = {"biolink:NamedThing": 300000, "biolink:Disease": 22000}
+    EDGE_CATS = {"biolink:Association": 268909}
+
+    def mondo(self, **kw):
+        return item("MONDO", "OK", nodecount=300000, edgecount=268909,
+                    node_categories=self.NODE_CATS,
+                    edge_categories=self.EDGE_CATS, **kw)
+
+    def panel(self, html, which):
+        """The Nodes or Edges tab body.
+
+        Sliced between the panel markers rather than matched to a closing tag:
+        the panels nest divs, so a non-greedy match stops inside the chart.
+        """
+        start = html.index(f'data-panel="{which}"')
+        rest = html.index('data-panel="edges"', start + 1) if which == "nodes" else len(html)
+        return html[start:rest]
+
+    def test_the_tallies_are_carried_onto_the_item(self):
+        it = self.mondo()
+        self.assertEqual(it["node_categories"], self.NODE_CATS)
+        self.assertEqual(it["edge_categories"], self.EDGE_CATS)
+
+    def test_an_entry_without_them_gets_empty_dicts_not_none(self):
+        # Entries seeded from a release built before the counts existed.
+        it = item("BFO", "OK", nodecount=36, edgecount=115)
+        self.assertEqual(it["node_categories"], {})
+        self.assertEqual(it["edge_categories"], {})
+
+    def test_node_categories_are_named_on_the_page(self):
+        html = bs.render_ontology_resource(self.mondo())
+        self.assertIn("Disease", self.panel(html, "nodes"))
+
+    def test_node_category_counts_are_shown(self):
+        html = bs.render_ontology_resource(self.mondo())
+        self.assertIn("22,000", self.panel(html, "nodes"))
+
+    def test_edge_categories_are_named_on_the_page(self):
+        html = bs.render_ontology_resource(self.mondo())
+        edges = self.panel(html, "edges")
+        self.assertIn("Association", edges)
+        self.assertIn("268,909", edges)
+
+    def test_the_biggest_category_leads(self):
+        html = self.panel(bs.render_ontology_resource(self.mondo()), "nodes")
+        self.assertLess(html.index("NamedThing"), html.index("Disease"))
+
+    def test_bar_widths_are_relative_to_the_biggest(self):
+        html = bs.render_ontology_resource(self.mondo())
+        widths = [float(w) for w in
+                  re.findall(r'bar-fill node" style="width:([\d.]+)%', html)]
+        self.assertEqual(widths[0], 100.0)
+        self.assertTrue(all(w <= 100.0 for w in widths))
+
+    def test_the_multi_category_caveat_is_stated(self):
+        # A node counted under two categories makes the tally exceed the node
+        # count; a reader who does not know that reads it as an error.
+        html = bs.render_ontology_resource(self.mondo())
+        self.assertIn("counted under each", self.panel(html, "nodes"))
+
+    def test_an_ontology_without_a_tally_keeps_the_old_explanation(self):
+        html = bs.render_ontology_resource(item("BFO", "OK", nodecount=36, edgecount=115))
+        self.assertIn("aren't recorded in the index", self.panel(html, "nodes"))
+
+    def test_a_failed_ontology_renders_without_one(self):
+        html = bs.render_ontology_resource(item("FYPO", "Failed", "transform_error_kgx"))
+        self.assertIn("aren't recorded in the index", self.panel(html, "edges"))
+
+    def test_category_names_are_escaped(self):
+        # The tally's keys come from the transform, not from a fixed list.
+        # Checked on the panel, not the page: the page carries its own <script>.
+        panel = self.panel(bs.render_ontology_resource(item(
+            "X", "OK", nodecount=1, edgecount=1,
+            node_categories={"<script>alert(1)</script>": 1})), "nodes")
+        self.assertNotIn("<script>", panel)
+        self.assertIn("&lt;script&gt;", panel)
+
+    def test_the_collection_wide_tally_is_summed_over_ontologies(self):
+        html = bs.render_summary(
+            {"totalcount": 2, "transform_date": DATE},
+            0,
+            [self.mondo(), item("DOID", "OK", nodecount=10, edgecount=10,
+                                node_categories={"biolink:Disease": 8000})],
+        )
+        self.assertIn("Node categories across the collection", html)
+        self.assertIn("30,000", html)  # 22,000 + 8,000
+
+    def test_the_collection_wide_tally_says_how_many_ontologies_it_covers(self):
+        # Not every entry has one, so "2 of 3" is the difference between a
+        # partial picture and a wrong one.
+        html = bs.render_summary(
+            {"totalcount": 3, "transform_date": DATE},
+            0,
+            [self.mondo(), item("DOID", "OK", nodecount=10, edgecount=10,
+                                node_categories={"biolink:Disease": 8000}),
+             item("BFO", "OK", nodecount=36, edgecount=115)],
+        )
+        head = re.search(r"Node categories across the collection.*?</p>", html, re.S).group(0)
+        self.assertIn("2 of", head)
+        self.assertIn("3 ontologies", head)
+
+    def test_the_collection_wide_tally_is_omitted_when_nothing_records_one(self):
+        html = bs.render_summary({"totalcount": 1}, 0,
+                                 [item("BFO", "OK", nodecount=36, edgecount=115)])
+        self.assertNotIn("Node categories across the collection", html)
+
+
 class TestSummaryCounts(TestCase):
     TOTALS = {
         "totalcount": 1108, "skippedcount": 43, "failedcount": 133,

--- a/tests/test_category_stats.py
+++ b/tests/test_category_stats.py
@@ -1,0 +1,361 @@
+"""Biolink category counts for every ontology, in the logs and in the index (#98).
+
+The issue asks for the set of node and edge categories per ontology, propagated
+to the stats and shown on the dashboard. Measuring what the pipeline actually
+produces first, across 12 graphs sampled from release ``data-2026.08.25-12``:
+
+    nodes   100% biolink:NamedThing, in every one of them -- MONDO's diseases,
+            VTO's taxa, GO-PLUS's processes alike
+    edges   blank, except where an ontology's axioms are reified
+
+Neither is a tally of anything. ``NamedThing`` is what KGX's RdfSource writes
+when nothing has set a category (rdf_source.py:176), which for a plain OWL file
+is always; ``biolink:Association`` is set only on the reified path
+(owl_source.py:144), so MONDO and VTO are 100% blank while MCBCC, whose axioms
+are reified, is mostly ``Association``.
+
+So this change is in two parts:
+
+* the edges get the root ``biolink:Association``, the way the reified ones
+  already do -- correct-but-general for any edge, and the same "KGX assigns it
+  inconsistently" shape as the missing edge ids in #71;
+* the tally is counted, logged, recorded in onto_stats.yaml and rendered.
+
+Making the categories *specific* is a separate problem and not this one: node
+prefixes cap out at about 11.5% of nodes (57,096 of 497,959 sampled), because
+the big prefixes are genuinely ambiguous in Biolink -- GO spans
+``biological process or activity`` and ``anatomical entity``, CHEBI spans the
+``named thing`` and ``attribute`` branches.
+"""
+
+import os
+import tempfile
+from unittest import TestCase, mock
+
+import yaml
+
+from kg_bioportal import kgx_patches
+from kg_bioportal.kgx_patches import ROOT_ASSOCIATION
+from kg_bioportal.robot_utils import RobotResult
+from kg_bioportal.transformer import (
+    UNCATEGORIZED,
+    Transformer,
+    format_tally,
+    tally_column,
+)
+
+# Captured before any test touches the flag. Importing kg_bioportal.transformer
+# -- which the imports above just did -- is what puts the patch in place for the
+# pipeline; nothing else in this file applies it at module scope. Read here
+# rather than asserted in a test body, because the helpers below toggle it.
+PATCHED_AT_IMPORT = kgx_patches._edge_category_patched
+
+RDFXML = (
+    '<?xml version="1.0"?>\n<rdf:RDF '
+    'xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" '
+    'xmlns:owl="http://www.w3.org/2002/07/owl#">\n'
+    '<owl:Ontology rdf:about="http://example.org/onto"/>\n'
+    '</rdf:RDF>\n'
+)
+
+
+def tsv(tmpdir, name, *rows):
+    """Write a TSV whose first row is the header. Returns its path."""
+    path = os.path.join(tmpdir, name)
+    with open(path, "w") as f:
+        for row in rows:
+            f.write("\t".join(row) + "\n")
+    return path
+
+
+class TestTheTally(TestCase):
+    """What comes out of a KGX TSV, counted in one pass over it."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.dir = self._tmp.name
+
+    def test_rows_are_counted_without_the_header(self):
+        path = tsv(self.dir, "n.tsv",
+                   ["id", "category"], ["A", "biolink:NamedThing"],
+                   ["B", "biolink:NamedThing"])
+        self.assertEqual(tally_column(path)[0], 2)
+
+    def test_each_category_is_counted(self):
+        path = tsv(self.dir, "n.tsv",
+                   ["id", "category"], ["A", "biolink:Disease"],
+                   ["B", "biolink:Disease"], ["C", "biolink:NamedThing"])
+        self.assertEqual(tally_column(path)[1],
+                         {"biolink:Disease": 2, "biolink:NamedThing": 1})
+
+    def test_a_multi_valued_cell_counts_under_each_category(self):
+        # KGX writes a multi-valued column pipe-delimited, and a node may
+        # legitimately be both. "How many nodes are a Disease" is the question
+        # being answered, so both get the row.
+        path = tsv(self.dir, "n.tsv",
+                   ["id", "category"],
+                   ["A", "biolink:Disease|biolink:NamedThing"])
+        rows, counts = tally_column(path)
+        self.assertEqual(rows, 1)
+        self.assertEqual(counts,
+                         {"biolink:Disease": 1, "biolink:NamedThing": 1})
+
+    def test_an_empty_cell_is_counted_as_uncategorized(self):
+        # Not dropped: "how many carry nothing" is the finding this whole
+        # change came out of, and a blank key in YAML says it badly.
+        path = tsv(self.dir, "e.tsv", ["id", "category"], ["A", ""])
+        self.assertEqual(tally_column(path)[1], {UNCATEGORIZED: 1})
+
+    def test_whitespace_only_cells_are_uncategorized_too(self):
+        path = tsv(self.dir, "e.tsv", ["id", "category"], ["A", "   "])
+        self.assertEqual(tally_column(path)[1], {UNCATEGORIZED: 1})
+
+    def test_the_column_is_found_by_name_not_position(self):
+        # Column order is set by NODE_COLUMNS/EDGE_COLUMNS and has changed
+        # before; an index baked in here would silently tally the wrong field.
+        path = tsv(self.dir, "e.tsv",
+                   ["id", "subject", "predicate", "object", "category"],
+                   ["e1", "A", "biolink:subclass_of", "B", ROOT_ASSOCIATION])
+        self.assertEqual(tally_column(path)[1], {ROOT_ASSOCIATION: 1})
+
+    def test_a_file_without_the_column_still_counts_its_rows(self):
+        path = tsv(self.dir, "n.tsv", ["id", "name"], ["A", "a"], ["B", "b"])
+        self.assertEqual(tally_column(path), (2, {}))
+
+    def test_a_short_row_does_not_raise(self):
+        # A row with fewer cells than the header would be an IndexError.
+        path = tsv(self.dir, "n.tsv",
+                   ["id", "name", "category"], ["A", "a", "biolink:NamedThing"],
+                   ["B"])
+        rows, counts = tally_column(path)
+        self.assertEqual(rows, 2)
+        self.assertEqual(counts, {"biolink:NamedThing": 1, UNCATEGORIZED: 1})
+
+    def test_a_header_only_file_has_no_rows(self):
+        self.assertEqual(tally_column(tsv(self.dir, "n.tsv", ["id", "category"])),
+                         (0, {}))
+
+    def test_an_empty_file_has_no_rows(self):
+        # The old count was len(readlines()) - 1, which made this -1.
+        path = os.path.join(self.dir, "empty.tsv")
+        open(path, "w").close()
+        self.assertEqual(tally_column(path), (0, {}))
+
+    def test_another_column_can_be_tallied(self):
+        path = tsv(self.dir, "e.tsv",
+                   ["id", "predicate", "category"],
+                   ["e1", "biolink:subclass_of", ROOT_ASSOCIATION],
+                   ["e2", "biolink:part_of", ROOT_ASSOCIATION])
+        self.assertEqual(tally_column(path, "predicate")[1],
+                         {"biolink:subclass_of": 1, "biolink:part_of": 1})
+
+    def test_the_file_is_not_read_into_memory(self):
+        # The reason this replaced readlines(): a large ontology's node file
+        # runs to hundreds of megabytes and was being held whole to take its
+        # length. Reading lazily is the property under test.
+        path = tsv(self.dir, "n.tsv", ["id", "category"], ["A", "x"])
+        with mock.patch("builtins.open", mock.mock_open(
+                read_data="id\tcategory\nA\tx\n")) as opened:
+            tally_column(path)
+        handle = opened.return_value
+        self.assertFalse(handle.readlines.called)
+        self.assertFalse(handle.read.called)
+
+
+class TestTheLogLine(TestCase):
+    """The tally as one line, since it is logged per ontology across ~1200 of them."""
+
+    def test_the_biggest_category_comes_first(self):
+        self.assertEqual(
+            format_tally({"biolink:Disease": 3, "biolink:NamedThing": 90}),
+            "biolink:NamedThing 90, biolink:Disease 3")
+
+    def test_ties_are_ordered_by_name_so_a_log_is_reproducible(self):
+        self.assertEqual(format_tally({"b": 1, "a": 1}), "a 1, b 1")
+
+    def test_large_counts_are_grouped(self):
+        self.assertEqual(format_tally({"biolink:NamedThing": 268909}),
+                         "biolink:NamedThing 268,909")
+
+    def test_a_long_tail_is_truncated_rather_than_dumped(self):
+        line = format_tally({f"c{i}": i for i in range(25)}, limit=3)
+        self.assertEqual(line, "c24 24, c23 23, c22 22, and 22 more")
+
+    def test_nothing_to_report_says_so(self):
+        self.assertEqual(format_tally({}), "none")
+
+    def test_it_stays_on_one_line(self):
+        self.assertNotIn("\n", format_tally({f"c{i}": i for i in range(50)}))
+
+
+class TestEveryEdgeGetsACategory(TestCase):
+    """Blank on almost every published edge; biolink:Association on all of them now."""
+
+    def test_an_edge_without_one_gets_the_root_association(self):
+        edge = {"subject": "A", "predicate": "biolink:subclass_of", "object": "B"}
+        self.apply(edge)
+        self.assertEqual(edge["category"], [ROOT_ASSOCIATION])
+
+    def test_an_edge_that_already_has_one_keeps_it(self):
+        # The reified path sets biolink:Association itself, and a future KGX
+        # may set something specific. This fills gaps, it does not overwrite.
+        edge = {"subject": "A", "object": "B", "category": ["biolink:GeneToGeneAssociation"]}
+        self.apply(edge)
+        self.assertEqual(edge["category"], ["biolink:GeneToGeneAssociation"])
+
+    def test_nodes_are_left_alone(self):
+        # Node records are 2-tuples; only the 4-tuples are edges.
+        node = {"id": "A", "category": ["biolink:NamedThing"]}
+        records = list(self.patched([("A", node)]))
+        self.assertEqual(records[0][1]["category"], ["biolink:NamedThing"])
+
+    def test_the_bare_none_between_records_survives(self):
+        # RdfSource yields None for every triple that did not complete a
+        # record. Calling len() on it took down the whole parse.
+        self.assertEqual(list(self.patched([None, None])), [None, None])
+
+    def test_the_root_is_the_biolink_association_class(self):
+        self.assertEqual(ROOT_ASSOCIATION, "biolink:Association")
+
+    def test_the_transform_pipeline_applies_it(self):
+        # A patch nothing installs fixes nothing. Every test above drives the
+        # patch directly, so they all pass whether or not transformer.py ever
+        # calls it -- this is the one that notices.
+        self.assertTrue(PATCHED_AT_IMPORT)
+
+    def test_patching_twice_is_a_no_op(self):
+        # A second call must not stack another generator on top of the first.
+        self.assertFalse(kgx_patches.patch_missing_edge_categories())
+
+    # -- helpers ----------------------------------------------------------- #
+    def patched(self, records):
+        """Run `records` through the patch as KGX's parse would yield them."""
+        from kgx.source.owl_source import OwlSource
+
+        with mock.patch.object(OwlSource, "parse", lambda self, *a, **k: iter(records)):
+            was = kgx_patches._edge_category_patched
+            kgx_patches._edge_category_patched = False
+            try:
+                kgx_patches.patch_missing_edge_categories()
+                return list(OwlSource.parse(None))
+            finally:
+                # Restore what it was, not an assumed True: forcing it True here
+                # is what let a build that never applies the patch pass.
+                kgx_patches._edge_category_patched = was
+
+    def apply(self, edge):
+        list(self.patched([("A", "B", "key", edge)]))
+
+
+class TestItReachesTheStats(TestCase):
+    """A count nobody can read is not a report. It has to land in the index."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.input_dir = os.path.join(self._tmp.name, "raw")
+        self.output_dir = os.path.join(self._tmp.name, "transformed")
+        os.makedirs(self.output_dir, exist_ok=True)
+
+        self.txr = Transformer.__new__(Transformer)
+        self.txr.input_dir = self.input_dir
+        self.txr.output_dir = self.output_dir
+        self.txr.timeout_sec, self.txr.timeout_min = 60, 1
+        self.txr.max_source_bytes = 0
+        self.txr.robot_path, self.txr.robot_env = "/nonexistent/robot", {}
+
+        self.source = os.path.join(self.input_dir, "ONTO", "1", "onto.owl")
+        os.makedirs(os.path.dirname(self.source), exist_ok=True)
+        with open(self.source, "w") as f:
+            f.write(RDFXML)
+
+    def run_transform(self, nodes, edges, all_at_once=False):
+        """Run one ontology through, with KGX writing exactly these TSV rows."""
+        def robot(**kwargs):
+            os.makedirs(os.path.dirname(kwargs["output_path"]), exist_ok=True)
+            with open(kwargs["output_path"], "w") as f:
+                f.write(RDFXML)
+            return RobotResult(True)
+
+        class FakeKGX:
+            def __init__(self, *a, **k):
+                pass
+
+            def transform(self, input_args, output_args):
+                for suffix, rows in (("_nodes.tsv", nodes), ("_edges.tsv", edges)):
+                    with open(output_args["filename"] + suffix, "w") as fh:
+                        for row in rows:
+                            fh.write("\t".join(row) + "\n")
+
+        with mock.patch("kg_bioportal.transformer.robot_convert", robot), \
+             mock.patch("kg_bioportal.transformer.robot_relax", robot), \
+             mock.patch("kg_bioportal.transformer.KGXTransformer", FakeKGX):
+            if all_at_once:
+                self.txr.transform_all(compress=False)
+                return None
+            return self.txr.transform(self.source, compress=False)
+
+    NODES = (["id", "category"], ["A", "biolink:Disease"], ["B", "biolink:NamedThing"])
+    EDGES = (["id", "category"], ["e1", ROOT_ASSOCIATION], ["e2", ROOT_ASSOCIATION])
+
+    def stats(self):
+        with open(os.path.join(self.output_dir, "onto_stats.yaml")) as f:
+            return {o["id"]: o for o in yaml.safe_load(f)["ontologies"]}["ONTO"]
+
+    def test_the_node_tally_reaches_the_outcome(self):
+        outcome = self.run_transform(self.NODES, self.EDGES)
+        self.assertEqual(outcome.node_categories,
+                         {"biolink:Disease": 1, "biolink:NamedThing": 1})
+
+    def test_the_edge_tally_reaches_the_outcome(self):
+        outcome = self.run_transform(self.NODES, self.EDGES)
+        self.assertEqual(outcome.edge_categories, {ROOT_ASSOCIATION: 2})
+
+    def test_the_counts_still_come_out_right(self):
+        # tally_column replaced the readlines() that produced these; they are
+        # published numbers and must not shift.
+        outcome = self.run_transform(self.NODES, self.EDGES)
+        self.assertEqual((outcome.nodecount, outcome.edgecount), (2, 2))
+
+    def test_the_node_tally_reaches_onto_stats(self):
+        self.run_transform(self.NODES, self.EDGES, all_at_once=True)
+        self.assertEqual(self.stats()["node_categories"],
+                         {"biolink:Disease": 1, "biolink:NamedThing": 1})
+
+    def test_the_edge_tally_reaches_onto_stats(self):
+        self.run_transform(self.NODES, self.EDGES, all_at_once=True)
+        self.assertEqual(self.stats()["edge_categories"], {ROOT_ASSOCIATION: 2})
+
+    def test_it_survives_a_yaml_round_trip_as_plain_data(self):
+        # onto_stats.yaml is read by merge_stats.py and the site builder with
+        # safe_load; a tagged Python object would fail to load there.
+        self.run_transform(self.NODES, self.EDGES, all_at_once=True)
+        text = open(os.path.join(self.output_dir, "onto_stats.yaml")).read()
+        self.assertNotIn("!!python", text)
+        self.assertIsInstance(self.stats()["node_categories"], dict)
+
+    def test_an_ontology_with_no_edges_carries_no_edge_field(self):
+        # An empty mapping on every such entry would be noise in the index.
+        self.run_transform(self.NODES, (["id", "category"],), all_at_once=True)
+        self.assertNotIn("edge_categories", self.stats())
+
+    def test_a_failure_records_no_tally(self):
+        # There are no files to tally, and a stale count would be worse than none.
+        def robot_fails(**kwargs):
+            return RobotResult(False, error="ROBOT could not load it")
+
+        with mock.patch("kg_bioportal.transformer.robot_convert", robot_fails):
+            outcome = self.txr.transform(self.source, compress=False)
+        self.assertFalse(outcome.success)
+        self.assertEqual(outcome.node_categories, {})
+        self.assertEqual(outcome.edge_categories, {})
+
+    def test_the_tally_is_logged_per_ontology(self):
+        # The other half of the issue: a shard log should say what came out of
+        # an ontology, not only how much.
+        with self.assertLogs(level="INFO") as logs:
+            self.run_transform(self.NODES, self.EDGES)
+        output = "\n".join(logs.output)
+        self.assertIn("ONTO: node categories: biolink:Disease 1", output)
+        self.assertIn(f"ONTO: edge categories: {ROOT_ASSOCIATION} 2", output)

--- a/tests/test_merge_stats.py
+++ b/tests/test_merge_stats.py
@@ -77,6 +77,57 @@ class MergeStatsTestCase(TestCase):
         return dict(line.split("\t") for line in lines[1:])
 
 
+class TestCategoryTalliesSurviveTheMerge(MergeStatsTestCase):
+    """The per-ontology Biolink category counts (#98) are shard-local data.
+
+    Every shard writes its own onto_stats fragment and this script is the only
+    thing that joins them, so a tally that does not survive the merge never
+    reaches the site -- which is the half of the issue a reader actually sees.
+    """
+
+    NODE_CATS = {"biolink:NamedThing": 10}
+    EDGE_CATS = {"biolink:Association": 20}
+
+    def test_a_fresh_tally_reaches_the_merged_index(self):
+        self.write_fragment([entry("FRESH", node_categories=self.NODE_CATS,
+                                   edge_categories=self.EDGE_CATS)])
+        index, _ = self.run_merge()
+        self.assertEqual(index["FRESH"]["node_categories"], self.NODE_CATS)
+        self.assertEqual(index["FRESH"]["edge_categories"], self.EDGE_CATS)
+
+    def test_tallies_from_separate_shards_both_survive(self):
+        self.write_fragment([entry("A", node_categories={"biolink:Disease": 3})],
+                            shard="shard-1")
+        self.write_fragment([entry("B", node_categories={"biolink:NamedThing": 4})],
+                            shard="shard-2")
+        index, _ = self.run_merge()
+        self.assertEqual(index["A"]["node_categories"], {"biolink:Disease": 3})
+        self.assertEqual(index["B"]["node_categories"], {"biolink:NamedThing": 4})
+
+    def test_a_carried_forward_tally_is_kept(self):
+        # A run that does not rebuild an ontology must not strip what the run
+        # that did rebuild it recorded.
+        base = self.write_base([entry("OLD", download_url=asset(PREV_TAG, "OLD"),
+                                      node_categories=self.NODE_CATS)])
+        self.write_fragment([entry("FRESH")])
+        index, _ = self.run_merge(base)
+        self.assertEqual(index["OLD"]["node_categories"], self.NODE_CATS)
+
+    def test_a_rerun_that_fails_drops_the_stale_tally(self):
+        # The entry no longer describes any artifact; carrying its old
+        # composition forward would describe a graph that is not published.
+        base = self.write_base([entry("X", download_url=asset(PREV_TAG, "X"),
+                                      node_categories=self.NODE_CATS)])
+        self.write_fragment([entry("X", status="Failed", reason="transform_error_kgx")])
+        index, _ = self.run_merge(base)
+        self.assertNotIn("node_categories", index["X"])
+
+    def test_an_entry_without_a_tally_gains_no_empty_one(self):
+        self.write_fragment([entry("PLAIN")])
+        index, _ = self.run_merge()
+        self.assertNotIn("node_categories", index["PLAIN"])
+
+
 class TestDownloadUrlInvariants(MergeStatsTestCase):
     """Where each artifact lives must survive a run that didn't rebuild it.
 


### PR DESCRIPTION
Closes #98.

## What the categories look like today

The issue asks for the set of node and edge categories per ontology, propagated to the stats and shown on the dashboard. Before building the reporting I measured what there is to report, across 12 graphs sampled from release `data-2026.08.25-12` (AGRO, BFO, BMONT, CPRO, ERO, GO-PLUS, GS1GDSN, MCBCC, MONDO, OBA, RADXTT-MVREASONS, VTO):

| | what's there |
|---|---|
| nodes | **100% `biolink:NamedThing`**, in every one of them — MONDO's diseases, VTO's taxa and GO-PLUS's processes alike |
| edges | **blank**, except where an ontology's axioms happen to be reified |

Neither is a tally of anything. `NamedThing` is what KGX's `RdfSource` writes when nothing has set a category (`rdf_source.py:176`), which for a plain OWL file is always. `biolink:Association` is set only on the reified path (`owl_source.py:144`), so MONDO and VTO are 100% blank while MCBCC, whose axioms are reified, is mostly `Association`.

## What this PR does

**Every edge gets the root `biolink:Association`**, the way the reified ones already do. It's correct-but-general for any edge — a more specific category needs per-predicate evidence we don't have here — and it's the same "KGX assigns it inconsistently" shape as the missing edge ids in #71. An edge that already carries a category keeps it.

**The tally is counted, logged, recorded and rendered.** `tally_column` reads each output file once, replacing the `readlines()` that was holding a whole node file in memory purely to take its length. From there:

- the shard log gets a line per ontology — `TINY: node categories: biolink:NamedThing 4`;
- `onto_stats.yaml` gets `node_categories` / `edge_categories` on OK entries;
- `merge_stats.py` carries them across shards and releases unchanged (no code change needed, but now covered by tests so a refactor can't silently drop them);
- each ontology page's **Nodes** and **Edges** tabs show a ranked bar chart instead of the "look in the download" placeholder, and the summary page gains a collection-wide roll-up.

A row carrying two categories is counted under each, so a tally can exceed the row count — the pages say so rather than leaving a reader to notice the arithmetic doesn't work.

Entries seeded from a release built before this existed have no tally; those pages keep the old placeholder text, and the collection-wide block says how many ontologies are actually behind its numbers.

## What this PR deliberately doesn't do

Making the categories *specific* is a separate problem, and worth its own issue. Node id prefixes cap out at about **11.5%** of nodes (57,096 of 497,959 sampled) because the big prefixes are genuinely ambiguous in Biolink — confirmed against `bmt` 4.4.4:

- `GO:` → 8 candidate classes spanning *biological process or activity* **and** *anatomical entity*
- `CHEBI:` → spans the *named thing* and *attribute* branches
- `UBERON:` → life stage / anatomical entity / cellular component / cell
- `HP:` → disease / phenotypic feature / genetic inheritance

The unambiguous wins are small (MONDO/DOID→disease, NCBITaxon→organism taxon, FOODON→food). Doing better needs per-term evidence such as `oboInOwl:hasOBONamespace` or the `rdfs:subClassOf` roots.

## Verification

- 519 tests pass, including 34 new ones in `tests/test_category_stats.py`, 13 in `tests/test_build_site.py` and 5 in `tests/test_merge_stats.py`.
- Mutation-tested: 18 deliberate breakages of the new code (patch never applied at import, tally indexed by position instead of name, chart unsorted, category names unescaped, roll-up sums overwritten, …) — all caught. The first pass found one that *wasn't*: a test helper was forcing the patch's applied-flag back to `True`, so a build that never installed the patch still passed. Fixed, and the flag is now read once at import instead.
- Run end to end against **real ROBOT and real KGX**, not stubs: the log lines appear, `onto_stats.yaml` carries both tallies, and every edge in the output TSV has `biolink:Association`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JM47TqJy5r9R2T2FgcWJhM)_