### PR TITLE
Give nodes a real Biolink category, decided here (#169)

### DIFF
--- a/.claude/skills/kg-bioportal-data/references/data-model.md
+++ b/.claude/skills/kg-bioportal-data/references/data-model.md
@@ -135,16 +135,27 @@ column on edges, and a `provided_by` on nodes, both holding the **relaxed OWL fi
 directory. If you are reading one of those releases, strip `_relaxed.owl` to recover the acronym.
 
 ### Category note
-Every node carries `biolink:NamedThing` and every edge `biolink:Association`. These are the roots
-of the Biolink class hierarchies, and they are what KGX writes when nothing more specific has been
-established: a plain OWL ontology carries no Biolink typing, and this pipeline does not currently
-infer any. So the `category` columns say *that* a row is a node or an edge, not what kind — treat
-a category tally as a completeness check rather than as a description of the ontology's contents.
+**Nodes.** KG-Bioportal assigns a real Biolink category where the ontology gives it grounds to.
+Terms whose meaning is not in doubt (`MONDO:0000001` disease, `GO:0008150` biological_process,
+`CL:0000000` cell, BFO's upper-level classes …) are seeded, the category rolls down
+`biolink:subclass_of` to every class beneath — nearest seed wins — and it then carries across
+`biolink:exact_match` edges to mapping targets, which is how a `UMLS:`/ICD/SNOMED node reached
+from a MONDO class gets one. A node with no such evidence keeps `biolink:NamedThing`, so that
+value means "we could not establish anything more specific", not "this is typed as the root".
 
-**Releases up to and including `data-2026.08.25-12`** carry the same `biolink:NamedThing` on nodes
-but leave `category` **empty** on every edge except those dereified from an `owl:Axiom`, which
-carry `biolink:Association`. The proportion is an artifact of how the ontology was written, not a
-distinction worth reading.
+How much of an ontology this reaches depends entirely on whether it is built on shared vocabulary.
+On a uniform random sample of 90 ontologies it is **16.9%** of nodes, with 71 of the 90 getting
+nothing — most of the collection is bespoke, rooted in one-off project IRIs. On the large OBO
+ontologies it is most of the graph: VTO 96.8%, MONDO 93.6%, ERO 89.8%, GO-PLUS and OBA ~80%.
+A node may carry more than one category, pipe-delimited, where two equally specific seeds apply.
+
+**Edges** all carry `biolink:Association`, the root of the association hierarchy. Biolink keys its
+association classes on the subject/object category pair, and those cannot be resolved from a pair
+alone (`organism taxon` → `organism taxon` alone admits four), so nothing more specific is claimed.
+
+**Releases up to and including `data-2026.08.25-12`** carry `biolink:NamedThing` on *every* node
+and leave `category` **empty** on every edge except those dereified from an `owl:Axiom`. In those
+releases the category columns say nothing about the contents at all.
 
 ### Other characteristics
 - Node ids are CURIEs; prefixes vary by ontology (`OBO:`, ontology-specific prefixes, etc.).

--- a/src/kg_bioportal/categories.py
+++ b/src/kg_bioportal/categories.py
@@ -1,0 +1,480 @@
+"""Assign Biolink categories to the nodes of a transformed ontology (#169).
+
+KGX writes ``biolink:NamedThing`` on every node, because a plain OWL file says
+nothing about Biolink and that is the honest default for a transcriber to pick.
+Deciding what these particular ontologies mean in Biolink terms is a
+KG-Bioportal judgement, not KGX's and not the model toolkit's -- giving the
+collection one consistent structure is much of what this pipeline is for -- so
+it happens here, over the node and edge files KGX has just written.
+
+Two sources of evidence, both already present in that output:
+
+**The subclass hierarchy.** Label a term whose meaning is not in doubt, and
+every class beneath it inherits. Measured over 12 graphs from release
+``data-2026.08.25-12``, the top subclass root alone reaches 96.8% of VTO,
+92.0% of ERO, 87.4% of MONDO's own classes and 81.6% of AGRO; three roots reach
+70.5% of GO-PLUS. The roots are largely shared, because these ontologies import
+the same upper ontologies, which is why one modest seed table goes a long way.
+
+**Mappings.** An ``exact_match`` edge asserts the same referent, so a category
+carries across it. This matters more than it sounds: 74.6% of MONDO's 148,965
+nodes are mapping *targets* -- UMLS CUIs, ICD IRIs, MedGen, SNOMED -- rather
+than MONDO classes, and having no subclass edges at all they are exactly the
+population the hierarchy cannot reach. Propagating outward from the ontology's
+own classes also means no external table is needed: the earlier idea of going
+the other way, from a CUI's UMLS semantic type, would have required MRSTY and
+its licence. That direction remains open as a fallback for the ontologies whose
+own classes never get a category.
+
+Edges are left at ``biolink:Association``. See ``ASSOCIATION_NOTE``.
+"""
+
+import collections
+import logging
+import os
+from typing import Dict, Iterable, List, NamedTuple, Optional, Set, Tuple
+
+# The root Biolink class, which is what KGX writes and what a node keeps when
+# nothing below establishes anything more specific.
+NAMED_THING = "biolink:NamedThing"
+
+# Why edges are not given a specific association class here. Biolink keys its
+# association classes on the subject/object category pair, so in principle they
+# follow from the node categories -- but the toolkit does not resolve one
+# answer. bmt 4.4.4's get_associations returns candidates that are ambiguous
+# (organism taxon -> organism taxon yields "taxon to taxon association",
+# "organism taxon to organism taxon association", "... specialization" and
+# "... interaction", which only the predicate's meaning separates) and
+# sometimes plainly wrong (chemical entity -> chemical entity yields "gene
+# regulates gene association"). subclass_of, which is most of our edges, maps
+# to the bare "association". Picking one anyway would put a claim in the data
+# that the data does not support, so the edge half of #169 stays open.
+ASSOCIATION_NOTE = (
+    "edge categories are unchanged: Biolink's association classes cannot be "
+    "resolved from a category pair alone"
+)
+
+SUBCLASS_PREDICATE = "biolink:subclass_of"
+
+# Predicates that assert the same referent, so a category is true of both ends.
+# close_match is deliberately absent: "close" is not "same", and treating it as
+# such would push categories across boundaries the source was careful about.
+MAPPING_PREDICATES = frozenset({"biolink:exact_match", "biolink:same_as"})
+
+# Terms whose Biolink category is not in doubt, and which sit high enough in
+# their ontology to carry a subtree. Seeded deliberately *below* the literal
+# top: owl:Thing and BFO:0000001 "entity" are the top roots of several
+# ontologies in the sample and are useless here -- rolling up from them only
+# re-derives NamedThing.
+#
+# Written in the canonical OBO CURIE form; see canonical_forms() for the other
+# shapes the same term arrives in.
+SEEDS: Dict[str, str] = {
+    # -- anatomy, cells, organisms
+    "UBERON:0001062": "biolink:AnatomicalEntity",    # anatomical entity
+    "CL:0000000": "biolink:Cell",                    # cell
+    "NCBITaxon:1": "biolink:OrganismTaxon",          # root
+    "VTO:0000001": "biolink:OrganismTaxon",          # Chordata (VTO's root)
+    "UBERON:0000105": "biolink:LifeStage",           # life cycle stage
+    # -- function, process, component
+    "GO:0008150": "biolink:BiologicalProcessOrActivity",   # biological_process
+    "GO:0003674": "biolink:BiologicalProcessOrActivity",   # molecular_function
+    "GO:0005575": "biolink:CellularComponent",             # cellular_component
+    # -- disease and phenotype
+    "MONDO:0000001": "biolink:Disease",
+    "MONDO:0042489": "biolink:Disease",              # disease susceptibility
+    "DOID:4": "biolink:Disease",
+    "HP:0000118": "biolink:PhenotypicFeature",       # phenotypic abnormality
+    "MP:0000001": "biolink:PhenotypicFeature",
+    "UPHENO:0001001": "biolink:PhenotypicFeature",
+    # -- chemistry and molecules
+    "CHEBI:24431": "biolink:ChemicalEntity",         # chemical entity
+    "PR:000018263": "biolink:Polypeptide",           # amino acid chain (PR's root)
+    "PR:000000001": "biolink:Protein",               # protein
+    "SO:0000110": "biolink:NucleicAcidEntity",       # sequence_feature
+    "GO:0032991": "biolink:MacromolecularComplex",   # protein-containing complex
+    # -- environment and food
+    "ENVO:00002297": "biolink:EnvironmentalFeature", # environmental feature
+    "ENVO:01000254": "biolink:EnvironmentalFeature", # environmental system
+    "FOODON:00001002": "biolink:Food",               # food material
+    # -- information, publications, samples
+    "IAO:0000013": "biolink:Publication",            # journal article
+    "OBI:0000011": "biolink:Procedure",              # planned process
+    "OBI:0100051": "biolink:MaterialSample",         # specimen
+}
+
+# Upper-ontology terms, kept apart because they are a *last resort*. Nearly
+# every OBO ontology imports BFO, so these reach a great deal -- but they reach
+# it from above, and where a domain seed also applies the domain seed is the
+# better answer. Distance alone does not express that: "material anatomical
+# entity" is one step below UBERON's "anatomical entity" and one step below
+# BFO's "material entity", so the tie has to be broken by which seed says more.
+# Hence the two tiers, and a general seed only wins where no specific one is
+# equally near.
+UPPER_SEEDS: Dict[str, str] = {
+    "BFO:0000040": "biolink:PhysicalEntity",         # material entity
+    "BFO:0000015": "biolink:Activity",               # process
+    "BFO:0000019": "biolink:Attribute",              # quality
+    "PATO:0000001": "biolink:Attribute",             # quality
+    "IAO:0000030": "biolink:InformationContentEntity",
+    # BFO 1.1, in the ifomis.org namespace it had before the OBO PURLs. Older
+    # submissions still import it, and its terms share no ids with BFO 2 -- so
+    # without these an ontology built on it looks, to the seeds above, like one
+    # built on nothing. Four of the 90 randomly sampled ontologies use it.
+    "http://www.ifomis.org/bfo/1.1/snap#IndependentContinuant": "biolink:PhysicalEntity",
+    "http://www.ifomis.org/bfo/1.1/snap#MaterialEntity": "biolink:PhysicalEntity",
+    "http://www.ifomis.org/bfo/1.1/snap#Object": "biolink:PhysicalEntity",
+    "http://www.ifomis.org/bfo/1.1/snap#ObjectAggregate": "biolink:PhysicalEntity",
+    "http://www.ifomis.org/bfo/1.1/snap#FiatObjectPart": "biolink:PhysicalEntity",
+    "http://www.ifomis.org/bfo/1.1/snap#Quality": "biolink:Attribute",
+    "http://www.ifomis.org/bfo/1.1/snap#RealizableEntity": "biolink:Attribute",
+    "http://www.ifomis.org/bfo/1.1/snap#Role": "biolink:Attribute",
+    "http://www.ifomis.org/bfo/1.1/snap#Disposition": "biolink:Attribute",
+    "http://www.ifomis.org/bfo/1.1/snap#Function": "biolink:Attribute",
+    "http://www.ifomis.org/bfo/1.1/snap#GenericallyDependentContinuant":
+        "biolink:InformationContentEntity",
+    "http://www.ifomis.org/bfo/1.1/span#Occurrent": "biolink:Activity",
+    "http://www.ifomis.org/bfo/1.1/span#ProcessualEntity": "biolink:Activity",
+    "http://www.ifomis.org/bfo/1.1/span#Process": "biolink:Activity",
+    "http://www.ifomis.org/bfo/1.1/span#ProcessAggregate": "biolink:Activity",
+    "http://www.ifomis.org/bfo/1.1/span#FiatProcessPart": "biolink:Activity",
+}
+
+SPECIFIC, GENERAL = 0, 1
+
+# Which of the categories above are ancestors of which others, in Biolink.
+# Written out rather than looked up so that assignment needs no model download
+# at transform time; tests/test_categories.py checks it still agrees with the
+# installed bmt, so it cannot drift silently.
+#
+# It is shorter than it looks because most of these sit directly under
+# NamedThing -- AnatomicalEntity is *not* under PhysicalEntity, which is why
+# that particular tie needs the tiers above rather than this table.
+CATEGORY_ANCESTORS: Dict[str, Tuple[str, ...]] = {
+    "biolink:Cell": ("biolink:AnatomicalEntity",),
+    "biolink:CellularComponent": ("biolink:AnatomicalEntity",),
+    "biolink:Protein": ("biolink:Polypeptide",),
+    "biolink:NucleicAcidEntity": ("biolink:ChemicalEntity",),
+    "biolink:Food": ("biolink:ChemicalEntity",),
+    "biolink:Publication": ("biolink:InformationContentEntity",),
+    "biolink:MaterialSample": ("biolink:PhysicalEntity",),
+}
+
+
+def most_specific(categories: Set[str]) -> Set[str]:
+    """Drop any category that another one in the set already implies.
+
+    A class reached from two equally near, equally specific seeds can come out
+    as e.g. {Cell, AnatomicalEntity}. Every Cell is an AnatomicalEntity, so
+    saying both says nothing the first does not; keep the narrower one. What
+    survives is a genuine disagreement, and worth leaving visible.
+    """
+    if len(categories) < 2:
+        return categories
+    implied = set()
+    for category in categories:
+        implied.update(CATEGORY_ANCESTORS.get(category, ()))
+    return categories - implied
+
+
+# The OBO PURL stem, which is how the same term appears when a node id was not
+# abbreviated to a CURIE.
+_OBO_IRI = "http://purl.obolibrary.org/obo/"
+
+
+def canonical_forms(curie: str) -> Tuple[str, ...]:
+    """Every id shape one seed term arrives in across our graphs.
+
+    The same term is not written the same way twice across 1,200 ontologies.
+    GO-PLUS abbreviates GO classes to ``GO:0008150``; VTO leaves its own to
+    ``OBO:VTO_0000001``; some sources never abbreviate at all. Rather than
+    guessing which an ontology uses, recognise all three.
+    """
+    if "://" in curie:
+        return (curie,)  # already an IRI; there is no CURIE form to derive
+    prefix, _, local = curie.partition(":")
+    underscored = f"{prefix}_{local}"
+    return (curie, f"OBO:{underscored}", f"{_OBO_IRI}{underscored}")
+
+
+def _expand() -> Dict[str, Tuple[str, int]]:
+    """Both seed tables keyed by every form their terms can appear in.
+
+    Values are ``(category, tier)``; see UPPER_SEEDS for what the tier decides.
+    """
+    expanded: Dict[str, Tuple[str, int]] = {}
+    for seeds, tier in ((UPPER_SEEDS, GENERAL), (SEEDS, SPECIFIC)):
+        for curie, category in seeds.items():
+            for form in canonical_forms(curie):
+                expanded[form] = (category, tier)
+    return expanded
+
+
+SEED_INDEX: Dict[str, Tuple[str, int]] = _expand()
+
+
+class CategoryReport(NamedTuple):
+    """What one ontology's assignment did, for the log and for tuning SEEDS."""
+
+    total: int = 0          # nodes in the file
+    seeded: int = 0         # nodes that are themselves a seed term
+    inherited: int = 0      # nodes that got one from a subclass ancestor
+    mapped: int = 0         # nodes that got one across a mapping edge
+    ambiguous: int = 0      # nodes left holding more than one category
+    uncategorized: int = 0  # nodes still NamedThing
+
+    @property
+    def assigned(self) -> int:
+        return self.seeded + self.inherited + self.mapped
+
+    def summary(self) -> str:
+        if not self.total:
+            return "no nodes to categorize"
+        share = self.assigned / self.total * 100
+        parts = [
+            f"{self.assigned:,}/{self.total:,} nodes categorized ({share:.1f}%)",
+            f"{self.seeded:,} seeded",
+            f"{self.inherited:,} by subclass",
+            f"{self.mapped:,} by mapping",
+        ]
+        if self.ambiguous:
+            parts.append(f"{self.ambiguous:,} ambiguous")
+        return "; ".join(parts)
+
+
+def _edge_graph(
+    edge_file: str,
+) -> Tuple[Dict[str, List[str]], Dict[str, List[str]], Set[str]]:
+    """Read the edge file once into what assignment needs from it.
+
+    Returns ``(children, mates, present_seeds)``: parent -> subclasses, node ->
+    nodes it is asserted to be the same thing as, and which seed terms this
+    ontology actually mentions. All three are built from edges alone, so nothing
+    here is proportional to the node file.
+
+    ``present_seeds`` is collected here rather than derived from ``children``
+    afterwards because a seed can appear only in a mapping edge, or only as
+    somebody's subclass. Taking the seeds from ``children``'s keys missed both,
+    and a seeded term with no subclasses of its own then propagated nothing
+    across its mappings.
+    """
+    children: Dict[str, List[str]] = collections.defaultdict(list)
+    mates: Dict[str, List[str]] = collections.defaultdict(list)
+    present: Set[str] = set()
+    for subject, predicate, obj in _columns(
+        edge_file, "subject", "predicate", "object"
+    ):
+        if not subject or not obj:
+            continue
+        if predicate == SUBCLASS_PREDICATE:
+            children[obj].append(subject)
+        elif predicate in MAPPING_PREDICATES:
+            mates[subject].append(obj)
+            mates[obj].append(subject)
+        else:
+            continue
+        for node in (subject, obj):
+            if node in SEED_INDEX:
+                present.add(node)
+    return children, mates, present
+
+
+def _columns(path: str, *names: str) -> Iterable[Tuple[str, ...]]:
+    """Rows of a KGX TSV as tuples of the named columns.
+
+    Yields "" for a column the file does not have, so a file written by an
+    older KGX -- or a hand-made one in a test -- reads rather than raising.
+    """
+    with open(path, "r") as f:
+        header = f.readline()
+        if not header:
+            return
+        fields = header.rstrip("\n").split("\t")
+        idx = [fields.index(n) if n in fields else None for n in names]
+        for line in f:
+            cells = line.rstrip("\n").split("\t")
+            yield tuple(
+                "" if i is None or i >= len(cells) else cells[i] for i in idx
+            )
+
+
+def _roll_up(
+    children: Dict[str, List[str]], present_seeds: Set[str]
+) -> Tuple[Dict[str, Set[str]], Set[str]]:
+    """Spread the seeds down the subclass hierarchy; the nearest seed wins.
+
+    One breadth-first sweep from every seed at once, so a class takes the
+    category of the seed fewest subclass steps above it -- which is what makes a
+    general upper-ontology seed safe to include beside a specific one.
+
+    Two seeds can still land on a class from the same distance. Then the more
+    specific tier wins (see UPPER_SEEDS), and if the tier is level too the class
+    keeps every category that survives ``most_specific``: Biolink permits
+    several, and a class that really is two things at once is a fact about the
+    ontology worth being able to see in the tally.
+
+    Returns ``(categories, seeded_ids)``. A seed the ontology mentions in no
+    edge at all is not here -- it has nothing to propagate to -- and ``apply_to``
+    recognises those as it streams the node file.
+    """
+    # node -> (tier of the nearest seed that reached it, its categories)
+    reached: Dict[str, Tuple[int, Set[str]]] = {}
+    seeded: Set[str] = set()
+
+    def seed(node: str) -> None:
+        category, tier = SEED_INDEX[node]
+        reached[node] = (tier, {category})
+        seeded.add(node)
+
+    frontier = sorted(present_seeds)
+    for node in frontier:
+        seed(node)
+    while frontier:
+        following: Dict[str, Tuple[int, Set[str]]] = {}
+        for parent in frontier:
+            parent_tier, parent_cats = reached[parent]
+            for child in children.get(parent, ()):
+                # Already reached in an earlier sweep: that seed is nearer, and
+                # nearness outranks everything.
+                if child in reached:
+                    continue
+                if child in SEED_INDEX:
+                    # A seed of its own beats anything inherited from above.
+                    seed(child)
+                    following[child] = reached[child]
+                    continue
+                # Two seeds equally near: the more specific tier wins, and a
+                # level tier keeps both. Written as a comparison rather than as
+                # "first one in wins" so the result does not depend on which
+                # order the seeds happened to be visited in.
+                equally_near = following.get(child)
+                if equally_near is None or parent_tier < equally_near[0]:
+                    following[child] = (parent_tier, set(parent_cats))
+                elif parent_tier == equally_near[0]:
+                    equally_near[1].update(parent_cats)
+        for node, value in following.items():
+            reached.setdefault(node, value)
+        frontier = list(following)
+
+    return {node: most_specific(cats) for node, (_, cats) in reached.items()}, seeded
+
+
+def _propagate_mappings(
+    categories: Dict[str, Set[str]],
+    mates: Dict[str, List[str]],
+    rounds: int = 3,
+) -> Set[str]:
+    """Carry categories across exact-match edges to nodes that have none.
+
+    Only ever fills a gap: a node that already has a category from the
+    hierarchy is left alone, so a mapping can never overrule the ontology's own
+    structure. Bounded rather than run to a fixpoint because mapping chains are
+    shallow in practice and an unbounded loop over a pathological graph is not
+    worth the risk.
+
+    Returns the ids that gained a category this way.
+    """
+    gained: Set[str] = set()
+    for _ in range(rounds):
+        additions: Dict[str, Set[str]] = {}
+        for node, cats in categories.items():
+            for mate in mates.get(node, ()):
+                if mate not in categories and mate not in additions:
+                    additions[mate] = set(cats)
+        if not additions:
+            break
+        categories.update(additions)
+        gained |= set(additions)
+    return gained
+
+
+def assign(node_file: str, edge_file: str) -> Tuple[Dict[str, Set[str]], Set[str], Set[str]]:
+    """Work out a category for as many nodes as the evidence supports.
+
+    Returns ``(categories, seeded, mapped)`` keyed by node id. Nodes with no
+    evidence are simply absent; the caller leaves those as they are.
+    """
+    children, mates, present_seeds = _edge_graph(edge_file)
+    categories, seeded = _roll_up(children, present_seeds)
+    mapped = _propagate_mappings(categories, mates)
+    return categories, seeded, mapped
+
+
+def apply_to(node_file: str, edge_file: str) -> CategoryReport:
+    """Rewrite ``node_file``'s category column in place, and report what changed.
+
+    The assigned category *replaces* ``biolink:NamedThing`` rather than joining
+    it. Biolink treats the category as the most specific class that applies and
+    leaves the ancestors implied, and nothing can be filtering usefully on
+    NamedThing today given that every node in every published graph carries it.
+
+    A node the evidence says nothing about keeps whatever KGX wrote.
+    """
+    categories, seeded, mapped = assign(node_file, edge_file)
+
+    temp_path = node_file + ".categorized"
+    counts = dict(total=0, seeded=0, inherited=0, mapped=0, ambiguous=0, uncategorized=0)
+    with open(node_file, "r") as src, open(temp_path, "w") as dest:
+        header = src.readline()
+        dest.write(header)
+        fields = header.rstrip("\n").split("\t")
+        try:
+            id_at, cat_at = fields.index("id"), fields.index("category")
+        except ValueError:
+            # No id or no category column: nothing to write into. Leave the
+            # file exactly as it was rather than rewriting it to no effect.
+            os.remove(temp_path)
+            logging.warning(
+                f"{os.path.basename(node_file)} has no id/category column; "
+                "leaving categories as they are."
+            )
+            return CategoryReport()
+        for line in src:
+            counts["total"] += 1
+            cells = line.rstrip("\n").split("\t")
+            node_id = cells[id_at] if id_at < len(cells) else ""
+            # A seed with no edges at all never entered the graph built from the
+            # edge file, so recognise it here too.
+            assigned = categories.get(node_id)
+            if assigned is None and node_id in SEED_INDEX:
+                assigned = {SEED_INDEX[node_id][0]}
+                seeded.add(node_id)
+            if assigned:
+                if len(assigned) > 1:
+                    counts["ambiguous"] += 1
+                if node_id in seeded:
+                    counts["seeded"] += 1
+                elif node_id in mapped:
+                    counts["mapped"] += 1
+                else:
+                    counts["inherited"] += 1
+                while len(cells) <= cat_at:
+                    cells.append("")
+                cells[cat_at] = "|".join(sorted(assigned))
+                dest.write("\t".join(cells) + "\n")
+            else:
+                counts["uncategorized"] += 1
+                dest.write(line)
+    os.replace(temp_path, node_file)
+    return CategoryReport(**counts)
+
+
+def categorize(node_file: str, edge_file: str, ontology_name: str = "") -> Optional[CategoryReport]:
+    """``apply_to`` that can never cost an ontology.
+
+    Every other stage of the transform has already succeeded by the time this
+    runs. A defect here would throw away a graph that is sitting complete on
+    disk, to improve one column of it, so a failure is logged and the graph is
+    published with the categories KGX wrote.
+    """
+    label = ontology_name or os.path.basename(node_file)
+    try:
+        report = apply_to(node_file, edge_file)
+    except Exception as e:  # noqa: BLE001 -- see the docstring
+        logging.warning(
+            f"{label}: could not assign Biolink categories ({type(e).__name__}: {e}); "
+            "keeping the categories KGX wrote."
+        )
+        return None
+    logging.info(f"{label}: {report.summary()}")
+    return report

--- a/src/kg_bioportal/categories.py
+++ b/src/kg_bioportal/categories.py
@@ -191,7 +191,11 @@ def canonical_forms(curie: str) -> Tuple[str, ...]:
     guessing which an ontology uses, recognise all three.
     """
     if "://" in curie:
-        return (curie,)  # already an IRI; there is no CURIE form to derive
+        # Already an IRI -- BFO 1.1's terms arrive as one. There is no CURIE
+        # form to derive, and deriving one anyway would put "OBO:http_//..."
+        # into the index: harmless, since nothing would ever match it, but the
+        # index is easier to trust when every key is a shape a node can have.
+        return (curie,)
     prefix, _, local = curie.partition(":")
     underscored = f"{prefix}_{local}"
     return (curie, f"OBO:{underscored}", f"{_OBO_IRI}{underscored}")
@@ -321,14 +325,15 @@ def _roll_up(
     reached: Dict[str, Tuple[int, Set[str]]] = {}
     seeded: Set[str] = set()
 
-    def seed(node: str) -> None:
+    # Every seed the ontology mentions starts at distance zero, so a seeded
+    # class is always already reached by the time the sweep arrives from above:
+    # its own category wins over an inherited one without needing a check for it
+    # further down.
+    frontier = sorted(present_seeds)
+    for node in frontier:
         category, tier = SEED_INDEX[node]
         reached[node] = (tier, {category})
         seeded.add(node)
-
-    frontier = sorted(present_seeds)
-    for node in frontier:
-        seed(node)
     while frontier:
         following: Dict[str, Tuple[int, Set[str]]] = {}
         for parent in frontier:
@@ -337,11 +342,6 @@ def _roll_up(
                 # Already reached in an earlier sweep: that seed is nearer, and
                 # nearness outranks everything.
                 if child in reached:
-                    continue
-                if child in SEED_INDEX:
-                    # A seed of its own beats anything inherited from above.
-                    seed(child)
-                    following[child] = reached[child]
                     continue
                 # Two seeds equally near: the more specific tier wins, and a
                 # level tier keeps both. Written as a comparison rather than as

--- a/src/kg_bioportal/transformer.py
+++ b/src/kg_bioportal/transformer.py
@@ -21,6 +21,7 @@ from kg_bioportal.config import (
     MAX_SOURCE_MB,
     PER_ONTOLOGY_TIMEOUT_MIN,
 )
+from kg_bioportal.categories import categorize
 from kg_bioportal.downloader import DOWNLOAD_REPORT_NAME, ONTOLOGY_LIST_NAME
 from kg_bioportal.kgx_patches import (
     patch_missing_edge_categories,
@@ -1699,6 +1700,11 @@ class Transformer:
             )
             if literals.count:
                 logging.warning(f"{ontology_name}: {literals.summary()}")
+            # Put real Biolink categories on the nodes before anything counts
+            # them (#169). This runs on the finished files rather than inside
+            # the KGX stream because it needs the whole subclass hierarchy at
+            # once, which a streaming source cannot offer.
+            categorize(nodefilename, edgefilename, ontology_name)
             # Size and composition of what we just wrote, in one pass over each
             # file. The categories are logged here as well as recorded, so a
             # shard log says what came out of an ontology and not just how much

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -20,6 +20,7 @@ on it from the same distance, so the tie-breaking has its own tests below.
 """
 
 import os
+import re
 import tempfile
 from unittest import TestCase, mock
 
@@ -126,6 +127,25 @@ class TestTheIdShapesASeedArrivesIn(TestCase):
     def test_all_three_mean_the_same_category(self):
         forms = canonical_forms("MONDO:0000001")
         self.assertEqual({SEED_INDEX[f][0] for f in forms}, {"biolink:Disease"})
+
+    def test_an_iri_seed_yields_only_itself(self):
+        # BFO 1.1's terms are IRIs. Deriving CURIE forms from one would produce
+        # "OBO:http_//www..." -- never matched by anything, but junk in an index
+        # that is otherwise a list of shapes a node id can actually take.
+        iri = "http://www.ifomis.org/bfo/1.1/snap#Quality"
+        self.assertEqual(canonical_forms(iri), (iri,))
+
+    OBO_LOCAL = re.compile(r"^[A-Za-z][A-Za-z0-9]*_[A-Za-z0-9.]+$")
+
+    def test_no_seed_index_key_is_a_mangled_iri(self):
+        # An IRI put through the CURIE derivation comes out as
+        # "OBO:http_//www.ifomis.org/..." -- a key nothing can ever match. Every
+        # derived key should look like the OBO local name it claims to be.
+        for key in SEED_INDEX:
+            for prefix in ("OBO:", "http://purl.obolibrary.org/obo/"):
+                if key.startswith(prefix):
+                    local = key[len(prefix):]
+                    self.assertRegex(local, self.OBO_LOCAL, f"{key} is not an OBO id")
 
     def test_a_curie_without_a_prefix_does_not_crash(self):
         self.assertEqual(canonical_forms("plain")[0], "plain")
@@ -261,6 +281,15 @@ class TestBreakingATie(TestCase):
                   [sub("A:1", "MONDO:0000001"), sub("A:2", "A:1"),
                    sub("A:3", "A:2"), sub("A:3", "BFO:0000040")])
         self.assertEqual(g.categories()["A:3"], "biolink:PhysicalEntity")
+
+    def test_an_implied_ancestor_is_dropped_from_a_tie(self):
+        # Reached from cell and from anatomical entity at the same distance and
+        # the same tier. Every Cell is an AnatomicalEntity, so the pair says
+        # nothing the narrower one does not -- and this is the path that carries
+        # most_specific into the result, which testing the helper alone missed.
+        g = Graph(self, ["CL:0000000", "UBERON:0001062", "A:1"],
+                  [sub("A:1", "CL:0000000"), sub("A:1", "UBERON:0001062")])
+        self.assertEqual(g.categories()["A:1"], "biolink:Cell")
 
     def test_two_equally_specific_seeds_both_stand(self):
         # No basis to pick, and Biolink permits several. #98's tally counts a

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -1,0 +1,488 @@
+"""Real Biolink categories on the nodes, decided here rather than upstream (#169).
+
+Before this, every node in every published graph was ``biolink:NamedThing``.
+That is the right thing for KGX to write -- a plain OWL file says nothing about
+Biolink -- but deciding what these ontologies mean in Biolink terms is a
+KG-Bioportal judgement, because giving the collection one consistent structure
+is much of what the pipeline is for.
+
+Two sources of evidence, both already in the files KGX writes: the subclass
+hierarchy, seeded with terms whose meaning is not in doubt, and ``exact_match``
+edges, which assert the same referent and so carry a category across. On the 12
+graphs sampled from release ``data-2026.08.25-12`` the two together categorize
+83.9% of 497,959 nodes (from 0%), and the mapping half is what reaches MONDO's
+UMLS/ICD/SNOMED targets -- 74.6% of its nodes -- which have no subclass edges
+at all.
+
+The interesting failures are not "a node got nothing", which is the safe
+outcome. They are a node getting the *wrong* category because two seeds landed
+on it from the same distance, so the tie-breaking has its own tests below.
+"""
+
+import os
+import tempfile
+from unittest import TestCase, mock
+
+from kg_bioportal import categories
+from kg_bioportal.categories import (
+    CATEGORY_ANCESTORS,
+    GENERAL,
+    NAMED_THING,
+    SEED_INDEX,
+    SEEDS,
+    SPECIFIC,
+    UPPER_SEEDS,
+    apply_to,
+    assign,
+    canonical_forms,
+    categorize,
+    most_specific,
+)
+
+NODE_HEADER = ["id", "category", "name"]
+EDGE_HEADER = ["id", "subject", "predicate", "object", "category"]
+
+
+class Graph:
+    """A tiny pair of KGX TSVs on disk, which is what assignment reads."""
+
+    def __init__(self, case, nodes, edges):
+        tmp = tempfile.TemporaryDirectory()
+        case.addCleanup(tmp.cleanup)
+        self.dir = tmp.name
+        self.nodes = self._write("nodes.tsv", NODE_HEADER,
+                                 [[n, NAMED_THING, ""] for n in nodes])
+        self.edges = self._write("edges.tsv", EDGE_HEADER,
+                                 [[f"e{i}", s, p, o, "biolink:Association"]
+                                  for i, (s, p, o) in enumerate(edges)])
+
+    def _write(self, name, header, rows):
+        path = os.path.join(self.dir, name)
+        with open(path, "w") as f:
+            f.write("\t".join(header) + "\n")
+            for row in rows:
+                f.write("\t".join(row) + "\n")
+        return path
+
+    def categories(self):
+        apply_to(self.nodes, self.edges)
+        out = {}
+        with open(self.nodes) as f:
+            f.readline()
+            for line in f:
+                cells = line.rstrip("\n").split("\t")
+                out[cells[0]] = cells[1]
+        return out
+
+
+def sub(child, parent):
+    return (child, "biolink:subclass_of", parent)
+
+
+def same(a, b):
+    return (a, "biolink:exact_match", b)
+
+
+class TestTheSeedTable(TestCase):
+    def test_every_seed_names_a_biolink_class(self):
+        for curie, category in {**SEEDS, **UPPER_SEEDS}.items():
+            self.assertTrue(category.startswith("biolink:"), curie)
+            self.assertNotEqual(category, NAMED_THING,
+                                f"{curie} seeds the root, which assigns nothing")
+
+    def test_the_two_tables_do_not_overlap(self):
+        # A term in both would get whichever tier the expansion happened to
+        # write last -- silently, and differently per Python version.
+        self.assertEqual(set(SEEDS) & set(UPPER_SEEDS), set())
+
+    def test_upper_seeds_are_the_general_tier(self):
+        for curie in UPPER_SEEDS:
+            self.assertEqual(SEED_INDEX[curie][1], GENERAL)
+
+    def test_domain_seeds_are_the_specific_tier(self):
+        for curie in SEEDS:
+            self.assertEqual(SEED_INDEX[curie][1], SPECIFIC)
+
+    def test_owl_thing_is_not_a_seed(self):
+        # It is the top root of several ontologies in the sample and rolling up
+        # from it would only re-derive NamedThing on everything.
+        for useless in ("owl:Thing", "BFO:0000001"):
+            self.assertNotIn(useless, SEED_INDEX)
+
+
+class TestTheIdShapesASeedArrivesIn(TestCase):
+    """The same term is not written the same way twice across 1,200 ontologies."""
+
+    def test_the_curie_itself_is_recognised(self):
+        self.assertIn("GO:0008150", SEED_INDEX)
+
+    def test_the_obo_wrapped_form_is_recognised(self):
+        # VTO's own root arrives as OBO:VTO_0000001, not VTO:0000001.
+        self.assertIn("OBO:VTO_0000001", SEED_INDEX)
+
+    def test_the_full_purl_is_recognised(self):
+        self.assertIn("http://purl.obolibrary.org/obo/GO_0008150", SEED_INDEX)
+
+    def test_all_three_mean_the_same_category(self):
+        forms = canonical_forms("MONDO:0000001")
+        self.assertEqual({SEED_INDEX[f][0] for f in forms}, {"biolink:Disease"})
+
+    def test_a_curie_without_a_prefix_does_not_crash(self):
+        self.assertEqual(canonical_forms("plain")[0], "plain")
+
+
+class TestNarrowingAnOverlappingPair(TestCase):
+    def test_an_implied_ancestor_is_dropped(self):
+        # Every Cell is an AnatomicalEntity, so saying both says nothing more.
+        self.assertEqual(
+            most_specific({"biolink:Cell", "biolink:AnatomicalEntity"}),
+            {"biolink:Cell"})
+
+    def test_an_unrelated_pair_is_left_alone(self):
+        # A real disagreement, and worth leaving visible.
+        pair = {"biolink:Disease", "biolink:ChemicalEntity"}
+        self.assertEqual(most_specific(pair), pair)
+
+    def test_a_single_category_is_returned_unchanged(self):
+        self.assertEqual(most_specific({"biolink:Disease"}), {"biolink:Disease"})
+
+    def test_the_ancestor_table_matches_the_model(self):
+        # The table is written out so assignment needs no model download at
+        # transform time. This is what stops it drifting from Biolink silently.
+        try:
+            from bmt import Toolkit
+            toolkit = Toolkit()
+        except Exception as e:  # noqa: BLE001 -- bmt absent, or it cannot fetch
+            self.skipTest(f"biolink model toolkit unavailable: {e}")
+        used = set(SEEDS.values()) | set(UPPER_SEEDS.values())
+        for category in used:
+            element = toolkit.get_element(category)
+            self.assertIsNotNone(element, f"{category} is not a Biolink class")
+            actual = {
+                a for a in toolkit.get_ancestors(
+                    element.name, reflexive=False, mixin=False, formatted=True)
+                if a in used
+            }
+            self.assertEqual(
+                set(CATEGORY_ANCESTORS.get(category, ())), actual,
+                f"CATEGORY_ANCESTORS[{category}] is out of step with the model")
+
+
+class TestRollingDownTheHierarchy(TestCase):
+    def test_a_subclass_inherits_from_its_seeded_parent(self):
+        g = Graph(self, ["MONDO:0000001", "MONDO:0005148"],
+                  [sub("MONDO:0005148", "MONDO:0000001")])
+        self.assertEqual(g.categories()["MONDO:0005148"], "biolink:Disease")
+
+    def test_it_reaches_the_bottom_of_a_deep_chain(self):
+        chain = ["GO:0008150"] + [f"GO:100000{i}" for i in range(6)]
+        edges = [sub(chain[i + 1], chain[i]) for i in range(len(chain) - 1)]
+        cats = Graph(self, chain, edges).categories()
+        self.assertEqual(cats[chain[-1]], "biolink:BiologicalProcessOrActivity")
+
+    def test_a_class_under_nothing_seeded_keeps_named_thing(self):
+        # The safe outcome, and the one every uncategorizable ontology gets.
+        g = Graph(self, ["X:1", "X:2"], [sub("X:2", "X:1")])
+        self.assertEqual(g.categories()["X:2"], NAMED_THING)
+
+    def test_the_nearer_seed_wins(self):
+        # cell is below anatomical entity; a cell type is a Cell, not the
+        # AnatomicalEntity it also descends from.
+        g = Graph(self,
+                  ["UBERON:0001062", "CL:0000000", "CL:0000232"],
+                  [sub("CL:0000000", "UBERON:0001062"),
+                   sub("CL:0000232", "CL:0000000")])
+        self.assertEqual(g.categories()["CL:0000232"], "biolink:Cell")
+
+    def test_a_class_that_is_itself_a_seed_keeps_its_own_category(self):
+        g = Graph(self, ["UBERON:0001062", "CL:0000000"],
+                  [sub("CL:0000000", "UBERON:0001062")])
+        self.assertEqual(g.categories()["CL:0000000"], "biolink:Cell")
+
+    def test_a_seed_with_no_subclasses_is_still_categorized(self):
+        # It never enters the graph built from the edge file, so it has to be
+        # recognised while the node file is streamed.
+        g = Graph(self, ["CHEBI:24431"], [])
+        self.assertEqual(g.categories()["CHEBI:24431"], "biolink:ChemicalEntity")
+
+    def test_a_cycle_in_the_hierarchy_terminates(self):
+        # rdfs:subClassOf cycles are legal OWL and do occur after relax.
+        g = Graph(self, ["MONDO:0000001", "A:1", "A:2"],
+                  [sub("A:1", "MONDO:0000001"), sub("A:2", "A:1"), sub("A:1", "A:2")])
+        cats = g.categories()
+        self.assertEqual(cats["A:1"], "biolink:Disease")
+        self.assertEqual(cats["A:2"], "biolink:Disease")
+
+
+class TestBreakingATie(TestCase):
+    """Two seeds, same distance. This is where a wrong category comes from.
+
+    Measured before the tiers existed: 461 AGRO classes came out
+    ``Activity|Procedure``, 6,794 OBA and 4,663 GO-PLUS classes came out
+    ``AnatomicalEntity|PhysicalEntity``. Biolink does not put AnatomicalEntity
+    under PhysicalEntity, so narrowing by the model does not resolve these --
+    only knowing that a domain seed says more than an upper-ontology one does.
+    """
+
+    def test_a_domain_seed_beats_an_upper_ontology_one(self):
+        # UBERON's "material anatomical entity", the real case: one step below
+        # anatomical entity and one step below BFO's material entity.
+        g = Graph(self,
+                  ["UBERON:0001062", "BFO:0000040", "UBERON:0000465"],
+                  [sub("UBERON:0000465", "UBERON:0001062"),
+                   sub("UBERON:0000465", "BFO:0000040")])
+        self.assertEqual(g.categories()["UBERON:0000465"], "biolink:AnatomicalEntity")
+
+    def test_a_planned_process_is_a_procedure_not_a_bare_activity(self):
+        # AGRO's "tillage process", under both OBI planned process and BFO process.
+        g = Graph(self, ["OBI:0000011", "BFO:0000015", "AGRO:00000002"],
+                  [sub("AGRO:00000002", "OBI:0000011"),
+                   sub("AGRO:00000002", "BFO:0000015")])
+        self.assertEqual(g.categories()["AGRO:00000002"], "biolink:Procedure")
+
+    def test_the_tier_wins_whichever_seed_is_visited_first(self):
+        # The tie-break must not depend on visit order. These two pairs put the
+        # general seed on either side of the specific one alphabetically, which
+        # is what the seeds are walked in.
+        for general, specific, expected in (
+            ("BFO:0000040", "UBERON:0001062", "biolink:AnatomicalEntity"),
+            ("PATO:0000001", "CL:0000000", "biolink:Cell"),
+        ):
+            with self.subTest(general=general, specific=specific):
+                g = Graph(self, [general, specific, "A:1"],
+                          [sub("A:1", general), sub("A:1", specific)])
+                self.assertEqual(g.categories()["A:1"], expected)
+
+    def test_a_nearer_upper_seed_still_beats_a_distant_domain_one(self):
+        # Tiers only break ties. Nearness outranks them, because a seed three
+        # steps up says less about a class than one directly above it.
+        g = Graph(self,
+                  ["MONDO:0000001", "BFO:0000040", "A:1", "A:2", "A:3"],
+                  [sub("A:1", "MONDO:0000001"), sub("A:2", "A:1"),
+                   sub("A:3", "A:2"), sub("A:3", "BFO:0000040")])
+        self.assertEqual(g.categories()["A:3"], "biolink:PhysicalEntity")
+
+    def test_two_equally_specific_seeds_both_stand(self):
+        # No basis to pick, and Biolink permits several. #98's tally counts a
+        # node once per category, so this stays visible rather than hidden.
+        g = Graph(self, ["MONDO:0000001", "CHEBI:24431", "A:1"],
+                  [sub("A:1", "MONDO:0000001"), sub("A:1", "CHEBI:24431")])
+        self.assertEqual(g.categories()["A:1"],
+                         "biolink:ChemicalEntity|biolink:Disease")
+
+
+class TestCarryingACategoryAcrossAMapping(TestCase):
+    """74.6% of MONDO's nodes are mapping targets with no subclass edges at all."""
+
+    def test_an_exact_match_target_takes_the_category(self):
+        g = Graph(self,
+                  ["MONDO:0000001", "MONDO:0005148", "UMLS:C0011860"],
+                  [sub("MONDO:0005148", "MONDO:0000001"),
+                   same("MONDO:0005148", "UMLS:C0011860")])
+        self.assertEqual(g.categories()["UMLS:C0011860"], "biolink:Disease")
+
+    def test_it_travels_in_either_direction(self):
+        g = Graph(self, ["MONDO:0000001", "UMLS:C1"],
+                  [same("UMLS:C1", "MONDO:0000001")])
+        self.assertEqual(g.categories()["UMLS:C1"], "biolink:Disease")
+
+    def test_the_hierarchy_is_never_overruled_by_a_mapping(self):
+        # A mapping only ever fills a gap; the ontology's own structure wins.
+        g = Graph(self,
+                  ["MONDO:0000001", "CHEBI:24431", "A:1"],
+                  [sub("A:1", "CHEBI:24431"), same("A:1", "MONDO:0000001")])
+        self.assertEqual(g.categories()["A:1"], "biolink:ChemicalEntity")
+
+    def test_a_close_match_does_not_carry(self):
+        # "close" is not "same". MONDO is careful about the difference and so
+        # should we be.
+        g = Graph(self, ["MONDO:0000001", "X:1"],
+                  [("X:1", "biolink:close_match", "MONDO:0000001")])
+        self.assertEqual(g.categories()["X:1"], NAMED_THING)
+
+    def test_a_chain_of_mappings_is_followed(self):
+        g = Graph(self, ["MONDO:0000001", "A:1", "B:1"],
+                  [same("A:1", "MONDO:0000001"), same("B:1", "A:1")])
+        self.assertEqual(g.categories()["B:1"], "biolink:Disease")
+
+    def test_mappings_between_two_unknown_nodes_assign_nothing(self):
+        g = Graph(self, ["A:1", "B:1"], [same("A:1", "B:1")])
+        self.assertEqual(g.categories()["A:1"], NAMED_THING)
+
+
+class TestRewritingTheNodeFile(TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.dir = self._tmp.name
+
+    def write(self, name, header, *rows):
+        path = os.path.join(self.dir, name)
+        with open(path, "w") as f:
+            f.write("\t".join(header) + "\n")
+            for row in rows:
+                f.write("\t".join(row) + "\n")
+        return path
+
+    def read(self, path):
+        with open(path) as f:
+            return [line.rstrip("\n").split("\t") for line in f]
+
+    def test_the_other_columns_survive(self):
+        nodes = self.write("n.tsv", ["id", "category", "name", "provided_by"],
+                           ["MONDO:0000001", NAMED_THING, "disease", "infores:x"])
+        edges = self.write("e.tsv", ["subject", "predicate", "object"])
+        apply_to(nodes, edges)
+        self.assertEqual(self.read(nodes)[1],
+                         ["MONDO:0000001", "biolink:Disease", "disease", "infores:x"])
+
+    def test_the_header_is_untouched(self):
+        header = ["id", "category", "name"]
+        nodes = self.write("n.tsv", header, ["MONDO:0000001", NAMED_THING, "d"])
+        edges = self.write("e.tsv", ["subject", "predicate", "object"])
+        apply_to(nodes, edges)
+        self.assertEqual(self.read(nodes)[0], header)
+
+    def test_a_file_with_no_category_column_is_left_alone(self):
+        nodes = self.write("n.tsv", ["id", "name"], ["MONDO:0000001", "disease"])
+        edges = self.write("e.tsv", ["subject", "predicate", "object"])
+        report = apply_to(nodes, edges)
+        self.assertEqual(self.read(nodes)[1], ["MONDO:0000001", "disease"])
+        self.assertEqual(report.total, 0)
+
+    def test_no_temporary_file_is_left_behind(self):
+        nodes = self.write("n.tsv", ["id", "category"], ["MONDO:0000001", NAMED_THING])
+        edges = self.write("e.tsv", ["subject", "predicate", "object"])
+        apply_to(nodes, edges)
+        self.assertEqual(
+            [f for f in os.listdir(self.dir) if f.startswith("n.tsv.")], [])
+
+    def test_a_short_row_is_padded_rather_than_dropped(self):
+        nodes = self.write("n.tsv", ["id", "category", "name"], ["MONDO:0000001"])
+        edges = self.write("e.tsv", ["subject", "predicate", "object"])
+        apply_to(nodes, edges)
+        self.assertEqual(self.read(nodes)[1][:2], ["MONDO:0000001", "biolink:Disease"])
+
+    def test_the_row_count_does_not_change(self):
+        # Whatever else happens, the graph must have as many nodes afterwards.
+        rows = [[f"X:{i}", NAMED_THING, str(i)] for i in range(20)]
+        rows[0][0] = "MONDO:0000001"
+        nodes = self.write("n.tsv", ["id", "category", "name"], *rows)
+        edges = self.write("e.tsv", ["subject", "predicate", "object"])
+        apply_to(nodes, edges)
+        self.assertEqual(len(self.read(nodes)), 21)
+
+
+class TestTheReport(TestCase):
+    def test_each_route_is_counted_separately(self):
+        # The seed table is tuned from these numbers, so they have to say which
+        # half of the approach did the work.
+        g = Graph(self,
+                  ["MONDO:0000001", "MONDO:0005148", "UMLS:C1", "X:1"],
+                  [sub("MONDO:0005148", "MONDO:0000001"),
+                   same("MONDO:0005148", "UMLS:C1")])
+        report = apply_to(g.nodes, g.edges)
+        self.assertEqual(report.total, 4)
+        self.assertEqual(report.seeded, 1)
+        self.assertEqual(report.inherited, 1)
+        self.assertEqual(report.mapped, 1)
+        self.assertEqual(report.uncategorized, 1)
+        self.assertEqual(report.assigned, 3)
+
+    def test_the_summary_says_the_share(self):
+        g = Graph(self, ["MONDO:0000001", "X:1"], [])
+        self.assertIn("1/2 nodes categorized (50.0%)", apply_to(g.nodes, g.edges).summary())
+
+    def test_an_empty_graph_summarizes_without_dividing_by_zero(self):
+        g = Graph(self, [], [])
+        self.assertEqual(apply_to(g.nodes, g.edges).summary(), "no nodes to categorize")
+
+
+class TestAFailureCannotCostTheGraph(TestCase):
+    """Every other stage has already succeeded by the time this runs."""
+
+    def test_a_broken_assignment_leaves_the_graph_alone(self):
+        g = Graph(self, ["MONDO:0000001"], [])
+        with mock.patch.object(categories, "apply_to", side_effect=RuntimeError("boom")):
+            self.assertIsNone(categorize(g.nodes, g.edges, "DEMO"))
+        with open(g.nodes) as f:
+            self.assertIn(NAMED_THING, f.read())
+
+    def test_a_missing_edge_file_is_survivable(self):
+        g = Graph(self, ["MONDO:0000001"], [])
+        self.assertIsNone(categorize(g.nodes, os.path.join(g.dir, "gone.tsv"), "DEMO"))
+
+    def test_the_failure_is_logged_with_the_ontology_named(self):
+        g = Graph(self, ["MONDO:0000001"], [])
+        with mock.patch.object(categories, "apply_to", side_effect=RuntimeError("boom")):
+            with self.assertLogs(level="WARNING") as logs:
+                categorize(g.nodes, g.edges, "DEMO")
+        self.assertIn("DEMO", "\n".join(logs.output))
+
+
+class TestTheTransformActuallyRunsIt(TestCase):
+    """A module nothing calls categorizes nothing.
+
+    Every test above drives categories.py directly, so they would all pass on a
+    build where the transform never invokes it -- which is exactly how a
+    mutation survived in #168.
+    """
+
+    def test_the_transformer_imports_and_calls_categorize(self):
+        from kg_bioportal import transformer
+        self.assertIs(transformer.categorize, categorize)
+
+    def test_it_runs_between_kgx_and_the_tally(self):
+        # The tally has to see the assigned categories, not the ones KGX wrote,
+        # or onto_stats and the site would report NamedThing for everything
+        # while the published TSVs said otherwise.
+        from kg_bioportal.robot_utils import RobotResult
+        from kg_bioportal.transformer import Transformer
+
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        input_dir = os.path.join(tmp.name, "raw")
+        source = os.path.join(input_dir, "ONTO", "1", "onto.owl")
+        os.makedirs(os.path.dirname(source))
+        rdfxml = ('<?xml version="1.0"?>\n<rdf:RDF '
+                  'xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" '
+                  'xmlns:owl="http://www.w3.org/2002/07/owl#">\n'
+                  '<owl:Ontology rdf:about="http://example.org/onto"/>\n'
+                  '</rdf:RDF>\n')
+        with open(source, "w") as f:
+            f.write(rdfxml)
+
+        txr = Transformer.__new__(Transformer)
+        txr.input_dir = input_dir
+        txr.output_dir = os.path.join(tmp.name, "transformed")
+        txr.timeout_sec, txr.timeout_min = 60, 1
+        txr.max_source_bytes = 0
+        txr.robot_path, txr.robot_env = "/nonexistent/robot", {}
+
+        def robot(**kwargs):
+            os.makedirs(os.path.dirname(kwargs["output_path"]), exist_ok=True)
+            with open(kwargs["output_path"], "w") as f:
+                f.write(rdfxml)
+            return RobotResult(True)
+
+        class FakeKGX:
+            def __init__(self, *a, **k):
+                pass
+
+            def transform(self, input_args, output_args):
+                with open(output_args["filename"] + "_nodes.tsv", "w") as f:
+                    f.write("id\tcategory\n")
+                    f.write(f"MONDO:0000001\t{NAMED_THING}\n")
+                    f.write(f"MONDO:0005148\t{NAMED_THING}\n")
+                with open(output_args["filename"] + "_edges.tsv", "w") as f:
+                    f.write("id\tsubject\tpredicate\tobject\tcategory\n")
+                    f.write("e1\tMONDO:0005148\tbiolink:subclass_of\t"
+                            "MONDO:0000001\tbiolink:Association\n")
+
+        with mock.patch("kg_bioportal.transformer.robot_convert", robot), \
+             mock.patch("kg_bioportal.transformer.robot_relax", robot), \
+             mock.patch("kg_bioportal.transformer.KGXTransformer", FakeKGX):
+            outcome = txr.transform(source, compress=False)
+
+        self.assertTrue(outcome.success)
+        self.assertEqual(outcome.node_categories, {"biolink:Disease": 2})


### PR DESCRIPTION
Addresses the node half of #169.

Every node in every published graph was `biolink:NamedThing`. That is the right thing for KGX to write — a plain OWL file says nothing about Biolink — but what these ontologies *mean* in Biolink terms is a KG-Bioportal judgement, since giving the collection one consistent structure is much of what the pipeline is for. So it happens here, in `src/kg_bioportal/categories.py`, over the node and edge files KGX has just written.

## How it works

Two sources of evidence, both already in that output.

**The subclass hierarchy.** Seed terms whose meaning is not in doubt — `MONDO:0000001` disease, `GO:0008150` biological_process, `CL:0000000` cell, BFO's upper-level classes — and roll the category down `biolink:subclass_of` in one breadth-first sweep from all seeds at once. The nearest seed wins, which is what makes a general upper-ontology seed safe to keep beside a specific one.

**Mappings.** `biolink:exact_match` asserts the same referent, so a category carries across it. This reaches a population the hierarchy cannot: **74.6% of MONDO's 148,965 nodes are mapping targets** (UMLS CUIs, ICD, MedGen, SNOMED) with no subclass edges at all.

Propagating *outward* from the ontology's own classes also means no external table is needed. Going the other way — from a CUI's UMLS semantic type, as #169 suggested — would have required MRSTY and its licence. That direction stays open as a fallback for ontologies whose own classes never get a category.

## What it actually reaches — the honest number first

Coverage depends entirely on whether an ontology is built on shared vocabulary, and the two figures are very different:

| sample | nodes | categorized |
|---|---:|---:|
| **uniform random sample of 90 ontologies** | 1,032,495 | **16.9%** — 71 of the 90 get nothing |
| the large OBO ontologies (12 sampled) | 497,959 | 83.9% |

Per-ontology on the second sample: VTO 96.8%, MONDO 93.6%, ERO 89.8%, GO-PLUS 79.9%, OBA 79.6%, AGRO 67.2%, BMONT 53.8%.

My first sample was biased toward well-known OBO ontologies, and the random sample is the one that answers #169's open question. Most of the collection is bespoke — **87% of the uncategorized remainder are full IRIs** in namespaces nothing else shares (`untitled-ontology-47#Zoos`, `hrdo/rdfns#gen_id_1`, `ontoPOF`). No seed table reaches those, and I don't think one should pretend to.

I'd argue the change still earns its place: the value is concentrated in the ontologies people actually use, and #98's tally now makes the remaining gap visible per ontology instead of leaving it to be guessed at. But that is a call worth making with the real number in view, so it is here rather than in a footnote.

A prefix-based last-resort tier was measured and left out: it would add ~3% of the random sample (FLOPO, PCL), and #169 already records why prefixes cap out at 11.5% and mislead on the big namespaces.

## Tie-breaking, which is where a wrong category would come from

A class reached by two seeds from the same distance is the failure mode worth caring about. Before the fix, that left **6,794 OBA and 4,663 GO-PLUS classes as `AnatomicalEntity|PhysicalEntity`** and **461 AGRO classes as `Activity|Procedure`**.

Biolink does *not* put `AnatomicalEntity` under `PhysicalEntity`, so narrowing by the model does not settle those — only knowing that a domain seed says more than an upper-ontology one does. Hence two seed tiers, with `UPPER_SEEDS` as an explicit last resort. After that, **no node in either sample comes out ambiguous.** The comparison is written as a comparison rather than "first one in wins", so the result does not depend on visit order; a mutation proved that mattered.

Also added: BFO 1.1's terms in their old `ifomis.org` namespace. They share no ids with BFO 2, so without them an ontology built on BFO 1.1 looks, to the seeds, like one built on nothing. Four of the 90 sampled ontologies use it.

## Edges are deliberately unchanged

They keep `biolink:Association` from #168. Biolink keys association classes on the subject/object category pair, but `bmt` 4.4.4 does not resolve one answer from a pair: `organism taxon → organism taxon` admits four candidates that only the predicate's meaning separates, `chemical entity → chemical entity` suggests "gene regulates gene association", and `subclass_of` — most of our edges — maps to the bare "association". Picking one anyway would put a claim in the data that the data does not support. The edge half of #169 stays open, with that recorded in `ASSOCIATION_NOTE`.

## Where it runs, and why it cannot cost a graph

After KGX, on the finished files, because it needs the whole subclass hierarchy at once and a streaming source cannot offer that. Memory is proportional to the edges, not the node file.

It is wrapped so a defect can never lose an ontology: every other stage has already succeeded by the time it runs, and a bug here would throw away a complete graph on disk to improve one column of it. A failure logs and the graph is published with the categories KGX wrote.

## Verification

- **568 tests pass**, 49 of them new in `tests/test_categories.py`.
- **Mutation-tested, 15 breakages, 12 caught on the first pass.** Of the three survivors: two were real test gaps (`most_specific` was only tested as a helper, never through a graph; the IRI-seed guard had no coverage) and are now closed with tests verified to bite. The third was **dead code** — disabling the branch where a seeded class keeps its own category broke nothing, because seeds are collected from every edge endpoint and such a class is already at distance zero. Deleted rather than tested. Second pass: 14/14 caught.
- One mutation *hangs* rather than failing — dropping the visited-guard makes the sweep unbounded. Worth knowing the failure mode: it would burn an ontology's timeout, not crash the shard. A cycle test covers the real-world version of that.
- **Run end to end against real ROBOT and real KGX**, not stubs: a MONDO class inherits `biolink:Disease`, its `UMLS:` exact-match target picks it up across the mapping, a `CL:` term comes out `biolink:Cell`, and an unrelated class keeps `NamedThing`.

`.claude/skills/kg-bioportal-data/references/data-model.md` is updated with what the category columns now mean, both figures above, and what the pre-`data-2026.08.25-12` releases carry instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JM47TqJy5r9R2T2FgcWJhM)_