### PR TITLE
Expand category coverage from 21.3% to 37.3% of nodes (#169)

### DIFF
--- a/.claude/skills/kg-bioportal-data/references/data-model.md
+++ b/.claude/skills/kg-bioportal-data/references/data-model.md
@@ -143,10 +143,18 @@ Terms whose meaning is not in doubt (`MONDO:0000001` disease, `GO:0008150` biolo
 from a MONDO class gets one. A node with no such evidence keeps `biolink:NamedThing`, so that
 value means "we could not establish anything more specific", not "this is typed as the root".
 
-How much of an ontology this reaches depends entirely on whether it is built on shared vocabulary.
-On a uniform random sample of 90 ontologies it is **16.9%** of nodes, with 71 of the 90 getting
-nothing — most of the collection is bespoke, rooted in one-off project IRIs. On the large OBO
-ontologies it is most of the graph: VTO 96.8%, MONDO 93.6%, ERO 89.8%, GO-PLUS and OBA ~80%.
+A handful of ontologies are one kind of thing end to end and say so nowhere a machine can read —
+their hierarchy is rooted at `owl:Thing` or `skos:Concept`, which the seeding deliberately refuses.
+Those carry a **whole-ontology default**, applied only where nothing in the file establishes
+anything: GNO and LION → `biolink:ChemicalEntity`, ROR → `biolink:Agent`, FAST-TITLE →
+`biolink:InformationContentEntity`. Structural terms inside them (`owl:`, `skos:`, `BFO:`, `RO:` …)
+are exempt. A default is a claim about an ontology rather than a fact read out of it, so it is a
+weaker signal than the rest — treat those four accordingly.
+
+How much of an ontology this reaches depends on whether it is built on shared vocabulary.
+Collection-wide it is **37.3%** of 8.27M nodes. On the large OBO ontologies it is most of the
+graph — VTO 96.8%, MONDO 93.6%, ERO 89.8%, GO-PLUS and OBA ~80% — while much of the rest of the
+collection is bespoke, rooted in one-off project IRIs that no seed table reaches.
 A node may carry more than one category, pipe-delimited, where two equally specific seeds apply.
 
 **Edges** all carry `biolink:Association`, the root of the association hierarchy. Biolink keys its

--- a/src/kg_bioportal/categories.py
+++ b/src/kg_bioportal/categories.py
@@ -99,8 +99,24 @@ SEEDS: Dict[str, str] = {
     "FOODON:00001002": "biolink:Food",               # food material
     # -- information, publications, samples
     "IAO:0000013": "biolink:Publication",            # journal article
+    "IAO:0000310": "biolink:Publication",            # document
     "OBI:0000011": "biolink:Procedure",              # planned process
     "OBI:0100051": "biolink:MaterialSample",         # specimen
+    "ECO:0000000": "biolink:EvidenceType",           # evidence
+    # -- roots that carry a large ontology on their own, found by looking at
+    #    where the uncategorized nodes actually were after the first pass. Each
+    #    reaches the number of nodes noted, measured on data-2026.08.26-16.
+    "GNO:00000001": "biolink:ChemicalEntity",        # glycan            191,529
+    "CAT:0000000": "biolink:ChemicalEntity",         # lipid classification 63,306
+    "SO:0000704": "biolink:Gene",                    # gene
+    "SO:0000340": "biolink:NucleicAcidEntity",       # chromosome
+    "PW:0000001": "biolink:Pathway",                 # pathway
+    "CLO:0000031": "biolink:CellLine",               # cell line
+    "CHEBI:23367": "biolink:MolecularEntity",        # molecular entity
+    "NCBITaxon:131567": "biolink:OrganismTaxon",     # cellular organisms
+    # OMIT's root carries no label of its own; its subclasses are gene symbols
+    # (A1BG, A2M, NAT1, NAT2 ...), which is what identifies it.
+    "NCRO:0000025": "biolink:Gene",                  #                    59,874
 }
 
 # Upper-ontology terms, kept apart because they are a *last resort*. Nearly
@@ -138,7 +154,76 @@ UPPER_SEEDS: Dict[str, str] = {
     "http://www.ifomis.org/bfo/1.1/span#Process": "biolink:Activity",
     "http://www.ifomis.org/bfo/1.1/span#ProcessAggregate": "biolink:Activity",
     "http://www.ifomis.org/bfo/1.1/span#FiatProcessPart": "biolink:Activity",
+    # BioTop, in the bioonto.de namespace BIOMODELS is built on. Same shape as
+    # the BFO seeds above -- an upper ontology whose top classes are the only
+    # thing a large ontology shares with anything else.
+    "http://bioonto.de/ro2.owl#Continuant": "biolink:PhysicalEntity",
+    "http://bioonto.de/ro2.owl#Process": "biolink:Activity",
+    "http://bioonto.de/ro2.owl#Function": "biolink:Attribute",
+    "http://bioonto.de/ro2.owl#Quality": "biolink:Attribute",
+    "http://purl.org/biotop/biotop.owl#Particular": "biolink:PhysicalEntity",
 }
+
+# A category for a whole ontology, used only where nothing else establishes one.
+#
+# Some ontologies are one kind of thing end to end, and say so nowhere a machine
+# can read: their hierarchy is rooted at owl:Thing or skos:Concept, which the
+# seeds above deliberately refuse. GNO is 580,716 glycan structures; LION is
+# lipid species; ROR is research organizations; FAST-TITLE is bibliographic
+# records for works. Naming those four is worth more than any amount of
+# traversal, because there is nothing in the file to traverse *to*.
+#
+# Every entry here is a judgement about an ontology rather than a fact read out
+# of it, so the bar is: the labels have to show it. Checked by sampling, which
+# is also why ICD10PCS and SNMI are absent despite being obvious candidates --
+# they have four labelled nodes between them (#173), so there is nothing to
+# check. NATPRO, HRA and RDL were considered and rejected: their labels show
+# mixed content (NATPRO's are DOID diseases, RDL's run from "IRON" to "PRESSED
+# GLASS LAMP").
+ONTOLOGY_DEFAULTS: Dict[str, str] = {
+    "GNO": "biolink:ChemicalEntity",
+    "LION": "biolink:ChemicalEntity",
+    "ROR": "biolink:Agent",
+    "FAST-TITLE": "biolink:InformationContentEntity",
+}
+
+# Prefixes that are never an ontology's own subject matter: the structural
+# vocabulary and upper-ontology terms that ride along inside any OWL file. A
+# whole-ontology default must not claim that skos:Concept is a glycan.
+#
+# RO and SIO are here for the same reason, having arrived by a different route:
+# KGX materialises the relations an ontology uses as nodes of their own, so
+# ROR's graph contains RO:0001025 "located in" alongside its 377,491
+# organizations. A relation is not an organization.
+#
+# Only consulted for ONTOLOGY_DEFAULTS. The seeds and the roll-up need no such
+# list, because they only ever assign what the hierarchy actually says.
+STRUCTURAL_PREFIXES = (
+    "owl:", "rdf:", "rdfs:", "xsd:", "skos:", "dc:", "dct:", "dcterms:",
+    "foaf:", "schema:", "prov:", "OIO:", "IAO:", "BFO:", "STY:", "RO:", "SIO:",
+    "http://www.w3.org/", "http://purl.org/dc/", "http://xmlns.com/foaf/",
+)
+
+
+def ontology_default(ontology_name: str, node_id: str) -> Optional[str]:
+    """The whole-ontology category for this node, if there is one.
+
+    Returns None for an ontology with no default, and for the structural terms
+    inside one that has -- see STRUCTURAL_PREFIXES.
+
+    It is a blunt instrument by design, and the residue is visible in the
+    published graphs: LION's 36 lipid *properties* ("average tail order
+    parameter") take ChemicalEntity along with its 63,546 lipids, and GNO's
+    graph carries three nodes for the ontology's own IRI. Both are the price of
+    a claim about a whole ontology, and both are small enough to be worth it --
+    but the report counts defaults apart from evidence-backed assignments
+    precisely so this can be watched rather than assumed.
+    """
+    category = ONTOLOGY_DEFAULTS.get(ontology_name.strip().upper())
+    if not category or node_id.startswith(STRUCTURAL_PREFIXES):
+        return None
+    return category
+
 
 SPECIFIC, GENERAL = 0, 1
 
@@ -153,11 +238,13 @@ SPECIFIC, GENERAL = 0, 1
 CATEGORY_ANCESTORS: Dict[str, Tuple[str, ...]] = {
     "biolink:Cell": ("biolink:AnatomicalEntity",),
     "biolink:CellularComponent": ("biolink:AnatomicalEntity",),
-    "biolink:Protein": ("biolink:Polypeptide",),
-    "biolink:NucleicAcidEntity": ("biolink:ChemicalEntity",),
     "biolink:Food": ("biolink:ChemicalEntity",),
-    "biolink:Publication": ("biolink:InformationContentEntity",),
     "biolink:MaterialSample": ("biolink:PhysicalEntity",),
+    "biolink:MolecularEntity": ("biolink:ChemicalEntity",),
+    "biolink:NucleicAcidEntity": ("biolink:ChemicalEntity", "biolink:MolecularEntity"),
+    "biolink:Pathway": ("biolink:BiologicalProcessOrActivity",),
+    "biolink:Protein": ("biolink:Polypeptide",),
+    "biolink:Publication": ("biolink:InformationContentEntity",),
 }
 
 
@@ -224,12 +311,13 @@ class CategoryReport(NamedTuple):
     seeded: int = 0         # nodes that are themselves a seed term
     inherited: int = 0      # nodes that got one from a subclass ancestor
     mapped: int = 0         # nodes that got one across a mapping edge
+    defaulted: int = 0      # nodes that fell back to what the ontology is
     ambiguous: int = 0      # nodes left holding more than one category
     uncategorized: int = 0  # nodes still NamedThing
 
     @property
     def assigned(self) -> int:
-        return self.seeded + self.inherited + self.mapped
+        return self.seeded + self.inherited + self.mapped + self.defaulted
 
     def summary(self) -> str:
         if not self.total:
@@ -241,6 +329,8 @@ class CategoryReport(NamedTuple):
             f"{self.inherited:,} by subclass",
             f"{self.mapped:,} by mapping",
         ]
+        if self.defaulted:
+            parts.append(f"{self.defaulted:,} by the ontology default")
         if self.ambiguous:
             parts.append(f"{self.ambiguous:,} ambiguous")
         return "; ".join(parts)
@@ -400,7 +490,7 @@ def assign(node_file: str, edge_file: str) -> Tuple[Dict[str, Set[str]], Set[str
     return categories, seeded, mapped
 
 
-def apply_to(node_file: str, edge_file: str) -> CategoryReport:
+def apply_to(node_file: str, edge_file: str, ontology_name: str = "") -> CategoryReport:
     """Rewrite ``node_file``'s category column in place, and report what changed.
 
     The assigned category *replaces* ``biolink:NamedThing`` rather than joining
@@ -408,12 +498,16 @@ def apply_to(node_file: str, edge_file: str) -> CategoryReport:
     leaves the ancestors implied, and nothing can be filtering usefully on
     NamedThing today given that every node in every published graph carries it.
 
-    A node the evidence says nothing about keeps whatever KGX wrote.
+    A node the evidence the ontology itself carries says nothing about falls back
+    to ONTOLOGY_DEFAULTS, if this ontology has one; failing that it keeps
+    whatever KGX wrote.
     """
     categories, seeded, mapped = assign(node_file, edge_file)
+    defaulted: Set[str] = set()
 
     temp_path = node_file + ".categorized"
-    counts = dict(total=0, seeded=0, inherited=0, mapped=0, ambiguous=0, uncategorized=0)
+    counts = dict(total=0, seeded=0, inherited=0, mapped=0, defaulted=0,
+                  ambiguous=0, uncategorized=0)
     with open(node_file, "r") as src, open(temp_path, "w") as dest:
         header = src.readline()
         dest.write(header)
@@ -439,6 +533,13 @@ def apply_to(node_file: str, edge_file: str) -> CategoryReport:
             if assigned is None and node_id in SEED_INDEX:
                 assigned = {SEED_INDEX[node_id][0]}
                 seeded.add(node_id)
+            # Last resort, and only for the few ontologies that have one: what
+            # this whole ontology is. Never overrules evidence from the file.
+            if not assigned:
+                fallback = ontology_default(ontology_name, node_id)
+                if fallback:
+                    assigned = {fallback}
+                    defaulted.add(node_id)
             if assigned:
                 if len(assigned) > 1:
                     counts["ambiguous"] += 1
@@ -446,6 +547,8 @@ def apply_to(node_file: str, edge_file: str) -> CategoryReport:
                     counts["seeded"] += 1
                 elif node_id in mapped:
                     counts["mapped"] += 1
+                elif node_id in defaulted:
+                    counts["defaulted"] += 1
                 else:
                     counts["inherited"] += 1
                 while len(cells) <= cat_at:
@@ -469,7 +572,7 @@ def categorize(node_file: str, edge_file: str, ontology_name: str = "") -> Optio
     """
     label = ontology_name or os.path.basename(node_file)
     try:
-        report = apply_to(node_file, edge_file)
+        report = apply_to(node_file, edge_file, ontology_name)
     except Exception as e:  # noqa: BLE001 -- see the docstring
         logging.warning(
             f"{label}: could not assign Biolink categories ({type(e).__name__}: {e}); "

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -27,6 +27,8 @@ from unittest import TestCase, mock
 from kg_bioportal import categories
 from kg_bioportal.categories import (
     CATEGORY_ANCESTORS,
+    ONTOLOGY_DEFAULTS,
+    STRUCTURAL_PREFIXES,
     GENERAL,
     NAMED_THING,
     SEED_INDEX,
@@ -38,6 +40,7 @@ from kg_bioportal.categories import (
     canonical_forms,
     categorize,
     most_specific,
+    ontology_default,
 )
 
 NODE_HEADER = ["id", "category", "name"]
@@ -149,6 +152,42 @@ class TestTheIdShapesASeedArrivesIn(TestCase):
 
     def test_a_curie_without_a_prefix_does_not_crash(self):
         self.assertEqual(canonical_forms("plain")[0], "plain")
+
+
+class TestTheSeedsMatchIdsThatOccur(TestCase):
+    """A seed whose id shape never appears in a graph reaches nothing.
+
+    Each of these was measured against a published artifact, so the CURIE in
+    SEEDS has to derive the form the artifact actually uses. LION's root is
+    written OBO:CAT_0000000, not OBO:LION_..., which is the kind of thing that
+    is only caught by looking.
+    """
+
+    # (seed CURIE, the id the published graph uses, nodes it reached)
+    MEASURED = [
+        ("GNO:00000001", "OBO:GNO_00000001", 191529),
+        ("CAT:0000000", "OBO:CAT_0000000", 63306),
+        ("NCRO:0000025", "OBO:NCRO_0000025", 59874),
+        ("MONDO:0000001", "MONDO:0000001", 31550),
+        ("VTO:0000001", "OBO:VTO_0000001", 106998),
+    ]
+
+    def test_each_measured_root_is_recognised_as_written(self):
+        for curie, as_published, _ in self.MEASURED:
+            with self.subTest(curie=curie):
+                self.assertIn(curie, SEED_INDEX, f"{curie} is not seeded")
+                self.assertIn(as_published, SEED_INDEX,
+                              f"{curie} does not derive {as_published}")
+
+    def test_the_two_forms_agree_on_the_category(self):
+        for curie, as_published, _ in self.MEASURED:
+            self.assertEqual(SEED_INDEX[curie][0], SEED_INDEX[as_published][0], curie)
+
+    def test_a_measured_root_categorizes_its_subtree(self):
+        # The end of the chain: seeded id -> published id -> the graph.
+        g = Graph(self, ["OBO:GNO_00000001", "OBO:GNO_G1"],
+                  [sub("OBO:GNO_G1", "OBO:GNO_00000001")])
+        self.assertEqual(g.categories()["OBO:GNO_G1"], "biolink:ChemicalEntity")
 
 
 class TestNarrowingAnOverlappingPair(TestCase):
@@ -337,6 +376,119 @@ class TestCarryingACategoryAcrossAMapping(TestCase):
     def test_mappings_between_two_unknown_nodes_assign_nothing(self):
         g = Graph(self, ["A:1", "B:1"], [same("A:1", "B:1")])
         self.assertEqual(g.categories()["A:1"], NAMED_THING)
+
+
+class TestTheWholeOntologyFallback(TestCase):
+    """Some ontologies are one thing end to end and say so nowhere machine-readable.
+
+    GNO is 580,716 glycan structures rooted under terms the seeds refuse to
+    touch; ROR is 377,491 research organizations with 7 subclass edges in the
+    whole file. No amount of traversal reaches those, because there is nothing
+    in the file to traverse. Naming the ontology is the only thing that does.
+
+    It is the last resort on purpose: an assertion about an ontology rather than
+    a fact read out of it, so anything the file actually says outranks it.
+    """
+
+    def graph(self, acr, nodes, edges=()):
+        g = Graph(self, nodes, list(edges))
+        apply_to(g.nodes, g.edges, acr)
+        out = {}
+        with open(g.nodes) as f:
+            f.readline()
+            for line in f:
+                cells = line.rstrip("\n").split("\t")
+                out[cells[0]] = cells[1]
+        return out
+
+    def test_an_ontology_with_a_default_uses_it(self):
+        cats = self.graph("GNO", ["OBO:GNO_G21587JI", "OBO:GNO_G50730KL"])
+        self.assertEqual(cats["OBO:GNO_G21587JI"], "biolink:ChemicalEntity")
+
+    def test_the_acronym_match_is_case_insensitive(self):
+        # onto_stats and the input list do not always agree on case.
+        self.assertEqual(ontology_default("gno", "OBO:GNO_1"), "biolink:ChemicalEntity")
+
+    def test_an_ontology_without_a_default_gets_nothing(self):
+        cats = self.graph("SOMETHINGELSE", ["X:1"])
+        self.assertEqual(cats["X:1"], NAMED_THING)
+
+    def test_the_hierarchy_still_wins(self):
+        # The default must never overrule what the ontology itself says. A
+        # disease inside GNO is a disease, whatever GNO mostly contains.
+        cats = self.graph("GNO", ["MONDO:0000001", "A:1", "OBO:GNO_G1"],
+                          [sub("A:1", "MONDO:0000001")])
+        self.assertEqual(cats["A:1"], "biolink:Disease")
+        self.assertEqual(cats["MONDO:0000001"], "biolink:Disease")
+        self.assertEqual(cats["OBO:GNO_G1"], "biolink:ChemicalEntity")
+
+    def test_a_mapping_still_wins(self):
+        cats = self.graph("GNO", ["MONDO:0000001", "UMLS:C1", "OBO:GNO_G1"],
+                          [same("UMLS:C1", "MONDO:0000001")])
+        self.assertEqual(cats["UMLS:C1"], "biolink:Disease")
+
+    def test_structural_terms_are_left_alone(self):
+        # Every OWL file carries these. Calling skos:Concept a glycan would be
+        # the most visible possible way to get this wrong.
+        cats = self.graph("GNO", ["owl:Thing", "skos:Concept", "rdfs:label",
+                                  "BFO:0000001", "IAO:0000030", "OBO:GNO_G1"])
+        for structural in ("owl:Thing", "skos:Concept", "rdfs:label", "BFO:0000001"):
+            self.assertEqual(cats[structural], NAMED_THING, structural)
+        self.assertEqual(cats["OBO:GNO_G1"], "biolink:ChemicalEntity")
+
+    def test_a_w3_iri_is_structural_too(self):
+        self.assertIsNone(ontology_default("GNO", "http://www.w3.org/2002/07/owl#Thing"))
+
+    def test_xref_targets_in_the_same_ontology_are_covered(self):
+        # ROR's ids are mostly GRID/ISNI/Wikidata identifiers for the same
+        # organizations, not ror.org URLs. A prefix allow-list keyed on the
+        # ontology's "own" namespace would have missed 239,710 of its 377,491
+        # nodes; the deny-list of structural terms is what makes that work.
+        cats = self.graph("ROR", ["https://ror.org/00tk6s776",
+                                  "https://www.grid.ac/institutes/grid.1",
+                                  "http://www.wikidata.org/entity/Q1"])
+        for node in cats:
+            self.assertEqual(cats[node], "biolink:Agent", node)
+
+    def test_the_report_counts_defaults_apart(self):
+        # They are a weaker claim than the rest, so the log has to distinguish
+        # them -- this is the number to look at when one turns out to be wrong.
+        g = Graph(self, ["MONDO:0000001", "A:1", "OBO:GNO_G1"],
+                  [sub("A:1", "MONDO:0000001")])
+        report = apply_to(g.nodes, g.edges, "GNO")
+        self.assertEqual(report.defaulted, 1)
+        self.assertEqual(report.seeded, 1)
+        self.assertEqual(report.inherited, 1)
+        self.assertEqual(report.uncategorized, 0)
+        # ...but they are still assigned. Counting them apart must not mean
+        # leaving them out of the total the summary reports.
+        self.assertEqual(report.assigned, 3)
+        self.assertIn("3/3 nodes categorized (100.0%)", report.summary())
+        self.assertIn("1 by the ontology default", report.summary())
+
+    def test_categorize_passes_the_ontology_name_through(self):
+        # apply_to takes the acronym, categorize is what supplies it. Every
+        # other test here calls apply_to directly, so they all pass on a build
+        # where categorize forgets to hand it over.
+        g = Graph(self, ["OBO:GNO_G1"], [])
+        report = categorize(g.nodes, g.edges, "GNO")
+        self.assertIsNotNone(report)
+        self.assertEqual(report.defaulted, 1)
+
+    def test_every_default_names_a_biolink_class(self):
+        for acr, category in ONTOLOGY_DEFAULTS.items():
+            self.assertTrue(category.startswith("biolink:"), acr)
+            self.assertNotEqual(category, NAMED_THING, acr)
+
+    def test_every_default_key_is_upper_case(self):
+        # ontology_default() upper-cases what it is given, so a lower-case key
+        # here would simply never match.
+        for acr in ONTOLOGY_DEFAULTS:
+            self.assertEqual(acr, acr.upper())
+
+    def test_the_deny_list_covers_the_common_structural_prefixes(self):
+        for prefix in ("owl:", "rdfs:", "skos:", "BFO:", "IAO:"):
+            self.assertIn(prefix, STRUCTURAL_PREFIXES)
 
 
 class TestRewritingTheNodeFile(TestCase):


### PR DESCRIPTION
Toward #169. The first pass categorized 1,758,075 of 8,267,485 nodes; this takes it to **3,081,890 (37.3%)**.

## Finding where the gap was

The index now carries a per-ontology tally (#98), so this needed no downloads. The uncategorized nodes are **concentrated**:

- top 25 ontologies hold **67%** of them, top 50 hold **79.5%**
- of the 858 ontologies at 0% coverage, **nine hold 2.68M nodes** between them

Not a long tail needing a thousand hand-written seeds.

## Two mechanisms, both measured before writing code

### More seeds — same mechanism, no new code

| root | reaches | category |
|---|---:|---|
| GNO `glycan` | 191,529 | ChemicalEntity |
| LION `lipid classification` | 63,306 | ChemicalEntity |
| OMIT root | 59,874 | Gene |
| BIOMODELS BioTop `Continuant` / `Process` / `Function` | 81,920 | PhysicalEntity / Activity / Attribute |

Also adopted the terms in **KGX's own `top_level_terms`** that were missing here (CHEBI molecular entity, SO gene and chromosome, PW pathway, ECO evidence, CLO cell line, IAO document, NCBITaxon cellular organisms). Worth knowing: KGX ships the same seed-plus-traversal design in `infer_category` — it is simply never called on the OWL path.

**Two seed ids were wrong until measured against the artifacts.** LION's root is published as `OBO:CAT_0000000`, not `OBO:LION_*`. OMIT's root carries no label at all and is identifiable only from its subclasses, which are gene symbols (A1BG, A2M, NAT1) — making it `biolink:Gene`, not anything miRNA-specific. There are now tests holding each declared seed against the id shape the published graph actually uses.

### A whole-ontology default

Four ontologies are one kind of thing end to end and say so nowhere machine-readable — their hierarchies are rooted at `owl:Thing` or `skos:Concept`, which the seeding refuses on purpose because rolling up from the top only re-derives `NamedThing`.

| ontology | nodes | category | what the labels show |
|---|---:|---|---|
| GNO | 580,716 | ChemicalEntity | glycan structures (`G21587JI`) |
| ROR | 377,491 | Agent | "Texas Tech University", "Ministry of Environment" |
| FAST-TITLE | 192,830 | InformationContentEntity | operas, journals, choreographic works |
| LION | 63,579 | ChemicalEntity | lipid species (`PE(21:4/22:1)`) |

The bar for an entry is **that the labels show it**, checked by sampling. Which is why **ICD10PCS and SNMI are absent** despite being obvious candidates — they have four labelled nodes between them (#173), so there is nothing to check. **NATPRO, HRA and RDL were considered and rejected**: their labels show mixed content (NATPRO's are DOID *diseases*; RDL's run from "IRON" to "PRESSED GLASS LAMP").

A default never overrules the file — it applies only where seeds, hierarchy and mappings have all found nothing, and never to the structural vocabulary every OWL file carries. **A deny-list rather than a per-ontology allow-list is what makes ROR work**: its ids are mostly GRID, ISNI and Wikidata identifiers for the same organizations, so keying on "ROR's own namespace" would have missed 239,710 of its 377,491 nodes. `RO:` and `SIO:` are on the list because KGX materialises an ontology's relations as nodes, and a relation is not an organization.

Defaults are **counted apart** from evidence-backed assignments, in the report and the log, because they are a weaker claim and the residue is real: LION's 36 lipid *properties* ("average tail order parameter") take ChemicalEntity along with its 63,546 lipids, and GNO carries three nodes for its own IRI. Both are documented rather than hidden.

## Rejected on measurement

**Treating other predicates as hierarchy.** I proposed this earlier on the strength of RDL's 66,591 ISO-15926 `hasSubclass` edges. Measured: the best root reaches **13 nodes**. IOBC gains 1,396, NLMVS 23,069. Not worth the code — and RDL's labels show it would not have helped anyway.

## Effect

```
                       before      after
GNO                         0    580,709
ROR                         0    377,474
FAST-TITLE                  0    192,814
LION                        0     63,568
OMIT                   27,940     87,815
BIOMODELS              32,486     81,862

collection-wide     1,758,075  3,081,890  of 8,267,485
                        21.3%      37.3%
```

No ontology went backwards — checked against the previous run on all 12 originally-sampled graphs.

## Verification

- 584 tests pass, 65 in `tests/test_categories.py` (24 new).
- Mutation-tested: 12 deliberate breakages, all caught — but **three needed new tests first**: the default silently outranking the hierarchy, `categorize` dropping the ontology name on the way to `apply_to`, and a mangled seed id reaching nothing. The ancestor-table cross-check against `bmt` also fired on its own when the new categories were added, which is what it exists for.
- Run end to end against **real ROBOT and real KGX**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JM47TqJy5r9R2T2FgcWJhM)_