### PR TITLE
Take names from skos:prefLabel where there is no rdfs:label (#173)

### DIFF
--- a/.claude/skills/kg-bioportal-data/references/data-model.md
+++ b/.claude/skills/kg-bioportal-data/references/data-model.md
@@ -105,10 +105,17 @@ transform_date: 2026-07-31
 |--------|---------|---------|
 | `id` | node CURIE | `OBO:AGRO_00000002` |
 | `category` | Biolink category | `biolink:NamedThing` |
-| `name` | label | `tillage process` |
+| `name` | label — `rdfs:label`, or `skos:prefLabel` where there is no `rdfs:label` | `tillage process` |
 | `description` | definition | `A planned process in which soil is …` |
 | `provided_by` | source ontology, as an infores | `infores:bioportal.agro` |
-| `synonym`, `exact_synonym`, `broad_synonym`, `narrow_synonym`, `related_synonym` | synonyms | (often blank) |
+| `synonym`, `exact_synonym`, `broad_synonym`, `narrow_synonym`, `related_synonym` | synonyms; `synonym` also carries `skos:altLabel` | (often blank) |
+
+**Releases up to and including `data-2026.08.26-16`** read labels from `rdfs:label` alone, so the
+SKOS-style and UMLS-derived vocabularies are published with no `name` at all — ICD10PCS has four
+named nodes out of 192,698, and DDSS, GEXO, NLMVS, OCHV, SNMI and XREF-FUNDER-REG are in the same
+state. From the next release those take their name from `skos:prefLabel`, their description from
+`skos:definition`, and their synonyms from `skos:altLabel`. Where a term has both an `rdfs:label`
+and a `skos:prefLabel`, the `rdfs:label` wins, so no existing name changes.
 
 **Edges** — `<ID>_edges.tsv`:
 

--- a/src/kg_bioportal/transformer.py
+++ b/src/kg_bioportal/transformer.py
@@ -982,6 +982,79 @@ class TransformOutcome(NamedTuple):
         )
 
 
+# SKOS vocabularies label with skos:prefLabel, and KGX reads only the properties
+# the Biolink model names -- where `name` is rdfs:label and nothing else. So an
+# ontology that labels the SKOS way loses every label silently: ICD10PCS ships
+# 192,698 procedure codes and four names, and six other ontologies in the twenty
+# holding the most uncategorized nodes are in the same state, 1,009,910 nodes
+# between them (#173).
+#
+# KGX can be told about the extra predicates -- Transformer.transform forwards
+# both keys to RdfSource -- but prefLabel must NOT be mapped straight to `name`.
+# `name` is single-valued, so where a term carries rdfs:label *and* a differing
+# prefLabel the winner is whichever the parser reaches last, and that order comes
+# out of a set: measured across PYTHONHASHSEED 0-7, the same file produced the
+# rdfs:label three times and the prefLabel five. A published name that flips
+# between releases with no change to the source is worse than a missing one.
+#
+# So prefLabel is given a column to itself, where it can race nothing, and
+# adopt_pref_labels folds it into `name` afterwards -- only where rdfs:label left
+# `name` empty. Deterministic, and rdfs:label always wins.
+SKOS = "http://www.w3.org/2004/02/skos/core#"
+PREF_LABEL_COLUMN = "pref_label"
+SKOS_PROPERTY_MAP = {
+    SKOS + "prefLabel": PREF_LABEL_COLUMN,
+    SKOS + "altLabel": "synonym",
+    SKOS + "definition": "description",
+}
+
+# What we ask KGX to write: the published columns plus the scratch one that
+# adopt_pref_labels consumes and removes. dcterms:title needs no entry -- Biolink
+# already maps it to `name`.
+KGX_NODE_COLUMNS = NODE_COLUMNS + [PREF_LABEL_COLUMN]
+
+
+def adopt_pref_labels(node_file: str) -> int:
+    """Fill an empty ``name`` from ``skos:prefLabel``, and drop the scratch column.
+
+    Runs over the finished node file, so the choice is made per node against
+    what was actually written rather than against whatever order a parser
+    happened to visit two triples in.
+
+    A file without the scratch column -- one written before this existed, or by
+    a test -- is left exactly as it is.
+
+    Returns:
+        How many nodes took their name from a prefLabel.
+    """
+    with open(node_file, "r") as f:
+        header = f.readline()
+    if not header:
+        return 0
+    fields = header.rstrip("\n").split("\t")
+    if PREF_LABEL_COLUMN not in fields:
+        return 0
+    pref_at = fields.index(PREF_LABEL_COLUMN)
+    name_at = fields.index("name") if "name" in fields else None
+    keep = [i for i in range(len(fields)) if i != pref_at]
+
+    adopted = 0
+    temp_path = node_file + ".labelled"
+    with open(node_file, "r") as src, open(temp_path, "w") as dest:
+        src.readline()
+        dest.write("\t".join(fields[i] for i in keep) + "\n")
+        for line in src:
+            cells = line.rstrip("\n").split("\t")
+            while len(cells) < len(fields):
+                cells.append("")
+            if name_at is not None and not cells[name_at].strip() and cells[pref_at].strip():
+                cells[name_at] = cells[pref_at]
+                adopted += 1
+            dest.write("\t".join(cells[i] for i in keep) + "\n")
+    os.replace(temp_path, node_file)
+    return adopted
+
+
 # Recorded in place of an empty category cell, so "how many of these carry no
 # category at all" is a number in the report rather than a blank key.
 UNCATEGORIZED = "(none)"
@@ -1676,11 +1749,16 @@ class Transformer:
             "provided_by": ontology_infores(ontology_name),
             "primary_knowledge_source": ontology_infores(ontology_name),
             "aggregator_knowledge_source": AGGREGATOR_INFORES,
+            # Teach KGX the SKOS properties the Biolink model does not name, so
+            # a vocabulary that labels the SKOS way is not published nameless
+            # (#173). See SKOS_PROPERTY_MAP for why prefLabel is kept apart.
+            "predicate_mappings": dict(SKOS_PROPERTY_MAP),
+            "node_property_predicates": list(SKOS_PROPERTY_MAP),
         }
         output_args = {
             "format": "tsv",
             "filename": outfilename,
-            "node_properties": NODE_COLUMNS,
+            "node_properties": KGX_NODE_COLUMNS,
             "edge_properties": EDGE_COLUMNS,
         }
         logging.info("Doing KGX transform.")
@@ -1700,6 +1778,14 @@ class Transformer:
             )
             if literals.count:
                 logging.warning(f"{ontology_name}: {literals.summary()}")
+            # Take names from skos:prefLabel where rdfs:label left none, and
+            # drop the scratch column, before anything else reads this file.
+            adopted = adopt_pref_labels(nodefilename)
+            if adopted:
+                logging.info(
+                    f"{ontology_name}: {adopted:,} nodes took their name from "
+                    "skos:prefLabel"
+                )
             # Put real Biolink categories on the nodes before anything counts
             # them (#169). This runs on the finished files rather than inside
             # the KGX stream because it needs the whole subclass hierarchy at

--- a/tests/test_edge_ids_and_provenance.py
+++ b/tests/test_edge_ids_and_provenance.py
@@ -42,6 +42,7 @@ from kg_bioportal import kgx_patches
 from kg_bioportal.transformer import (
     AGGREGATOR_INFORES,
     EDGE_COLUMNS,
+    KGX_NODE_COLUMNS,
     NODE_COLUMNS,
     ontology_infores,
 )
@@ -296,8 +297,15 @@ class TestTheProvenanceIsWiredWhereKgxReadsIt(TestCase):
     def test_the_columns_are_declared_on_output_args(self):
         # Streaming sinks fix their columns before the first record, so without
         # this the provenance is on every record and in no file.
+        #
+        # KGX is asked for one column more than we publish: the scratch column
+        # skos:prefLabel is read into, which adopt_pref_labels folds into `name`
+        # and removes afterwards (#173). Every published column still has to be
+        # declared here, and in the same order.
         self.assertEqual(self.captured["output"]["edge_properties"], EDGE_COLUMNS)
-        self.assertEqual(self.captured["output"]["node_properties"], NODE_COLUMNS)
+        self.assertEqual(self.captured["output"]["node_properties"], KGX_NODE_COLUMNS)
+        declared = self.captured["output"]["node_properties"]
+        self.assertEqual(declared[: len(NODE_COLUMNS)], NODE_COLUMNS)
 
 
 class TestTheColumnsExistToWriteItInto(TestCase):

--- a/tests/test_skos_labels.py
+++ b/tests/test_skos_labels.py
@@ -1,0 +1,248 @@
+"""SKOS vocabularies get their names back (#173).
+
+KGX reads the node properties the Biolink model names, where `name` is
+`rdfs:label` and nothing else. A vocabulary that labels with `skos:prefLabel` --
+which is what SKOS is for -- therefore came out with no names at all. Measured
+on release ``data-2026.08.26-16``, over the twenty ontologies holding the most
+uncategorized nodes:
+
+    DDSS               89,369 nodes        0 named
+    GEXO              166,291 nodes        0 named
+    ICD10PCS          192,698 nodes        4 named
+    NLMVS              75,182 nodes        1 named
+    OCHV              171,288 nodes        1 named
+    SNMI              109,166 nodes       10 named
+    XREF-FUNDER-REG   205,916 nodes        1 named
+
+1,009,910 nodes, published as if fine. ICD-10-PCS ships 192,698 procedure codes
+and four names, three of which are metadata properties rather than codes.
+
+The fix is configuration -- ``Transformer.transform`` already forwards
+``predicate_mappings`` and ``node_property_predicates`` to ``RdfSource`` -- with
+one trap in it, which is what most of these tests are about. Mapping
+``skos:prefLabel`` straight onto ``name`` is *not safe*: ``name`` is
+single-valued, so for a term carrying both ``rdfs:label`` and a differing
+``prefLabel`` the winner is whichever the parser reaches last, and that order
+comes out of a set. Across ``PYTHONHASHSEED`` 0-7 the same file yielded the
+rdfs:label three times and the prefLabel five. So prefLabel gets a column of its
+own and is folded into `name` afterwards, where the choice can be made against
+what was written rather than against parse order.
+"""
+
+import os
+import tempfile
+from unittest import TestCase, mock
+
+from kg_bioportal.transformer import (
+    KGX_NODE_COLUMNS,
+    NODE_COLUMNS,
+    PREF_LABEL_COLUMN,
+    SKOS,
+    SKOS_PROPERTY_MAP,
+    adopt_pref_labels,
+)
+
+
+class NodeFile:
+    """A node TSV on disk, which is what the pass reads."""
+
+    def __init__(self, case, header, *rows):
+        tmp = tempfile.TemporaryDirectory()
+        case.addCleanup(tmp.cleanup)
+        self.dir = tmp.name
+        self.path = os.path.join(tmp.name, "nodes.tsv")
+        with open(self.path, "w") as f:
+            f.write("\t".join(header) + "\n")
+            for row in rows:
+                f.write("\t".join(row) + "\n")
+
+    def read(self):
+        with open(self.path) as f:
+            return [line.rstrip("\n").split("\t") for line in f]
+
+    def rows(self):
+        out = self.read()
+        return [dict(zip(out[0], r)) for r in out[1:]]
+
+
+HEADER = ["id", "category", "name", "description", PREF_LABEL_COLUMN]
+
+
+class TestAdoptingAPrefLabel(TestCase):
+    def test_an_empty_name_takes_the_pref_label(self):
+        f = NodeFile(self, HEADER, ["A:1", "biolink:NamedThing", "", "", "aspirin tablet"])
+        self.assertEqual(adopt_pref_labels(f.path), 1)
+        self.assertEqual(f.rows()[0]["name"], "aspirin tablet")
+
+    def test_an_existing_name_is_kept(self):
+        # rdfs:label always wins. This is the whole reason for the extra column.
+        f = NodeFile(self, HEADER, ["A:1", "biolink:NamedThing", "from rdfs", "", "from skos"])
+        self.assertEqual(adopt_pref_labels(f.path), 0)
+        self.assertEqual(f.rows()[0]["name"], "from rdfs")
+
+    def test_a_whitespace_only_name_counts_as_empty(self):
+        f = NodeFile(self, HEADER, ["A:1", "biolink:NamedThing", "   ", "", "real label"])
+        adopt_pref_labels(f.path)
+        self.assertEqual(f.rows()[0]["name"], "real label")
+
+    def test_a_whitespace_only_pref_label_is_not_adopted(self):
+        f = NodeFile(self, HEADER, ["A:1", "biolink:NamedThing", "", "", "  "])
+        self.assertEqual(adopt_pref_labels(f.path), 0)
+        self.assertEqual(f.rows()[0]["name"], "")
+
+    def test_the_scratch_column_is_dropped(self):
+        # It exists only to keep prefLabel from racing rdfs:label; publishing it
+        # would put the same string in two columns of every SKOS graph.
+        f = NodeFile(self, HEADER, ["A:1", "biolink:NamedThing", "", "", "x"])
+        adopt_pref_labels(f.path)
+        self.assertNotIn(PREF_LABEL_COLUMN, f.read()[0])
+
+    def test_the_other_columns_survive_in_order(self):
+        f = NodeFile(self, HEADER, ["A:1", "biolink:Disease", "", "a def", "x"])
+        adopt_pref_labels(f.path)
+        self.assertEqual(f.read()[0], ["id", "category", "name", "description"])
+        self.assertEqual(f.rows()[0],
+                         {"id": "A:1", "category": "biolink:Disease",
+                          "name": "x", "description": "a def"})
+
+    def test_the_row_count_does_not_change(self):
+        rows = [[f"X:{i}", "biolink:NamedThing", "", "", f"label {i}"] for i in range(25)]
+        f = NodeFile(self, HEADER, *rows)
+        self.assertEqual(adopt_pref_labels(f.path), 25)
+        self.assertEqual(len(f.read()), 26)
+
+    def test_a_short_row_is_padded_rather_than_dropped(self):
+        f = NodeFile(self, HEADER, ["A:1"])
+        adopt_pref_labels(f.path)
+        self.assertEqual(f.rows()[0]["id"], "A:1")
+        self.assertEqual(len(f.read()), 2)
+
+    def test_a_file_without_the_column_is_left_alone(self):
+        # Written by an older run, or by a test. Must not be rewritten to no
+        # effect, and must not lose a column.
+        f = NodeFile(self, ["id", "category", "name"], ["A:1", "biolink:NamedThing", "n"])
+        self.assertEqual(adopt_pref_labels(f.path), 0)
+        self.assertEqual(f.read(), [["id", "category", "name"],
+                                    ["A:1", "biolink:NamedThing", "n"]])
+
+    def test_an_empty_file_does_not_raise(self):
+        path = os.path.join(tempfile.mkdtemp(), "empty.tsv")
+        open(path, "w").close()
+        self.assertEqual(adopt_pref_labels(path), 0)
+
+    def test_a_header_only_file_keeps_its_trimmed_header(self):
+        f = NodeFile(self, HEADER)
+        self.assertEqual(adopt_pref_labels(f.path), 0)
+        self.assertEqual(f.read(), [["id", "category", "name", "description"]])
+
+    def test_no_temporary_file_is_left_behind(self):
+        f = NodeFile(self, HEADER, ["A:1", "biolink:NamedThing", "", "", "x"])
+        adopt_pref_labels(f.path)
+        self.assertEqual([n for n in os.listdir(f.dir) if n != "nodes.tsv"], [])
+
+
+class TestTheMappingItself(TestCase):
+    """The trap: prefLabel must not be handed straight to `name`."""
+
+    def test_pref_label_is_not_mapped_onto_name(self):
+        # Doing so makes the published name depend on set iteration order --
+        # measured to flip across PYTHONHASHSEED 0-7 on the same input.
+        self.assertEqual(SKOS_PROPERTY_MAP[SKOS + "prefLabel"], PREF_LABEL_COLUMN)
+        self.assertNotEqual(SKOS_PROPERTY_MAP[SKOS + "prefLabel"], "name")
+
+    def test_alt_label_becomes_a_synonym(self):
+        self.assertEqual(SKOS_PROPERTY_MAP[SKOS + "altLabel"], "synonym")
+
+    def test_definition_becomes_the_description(self):
+        self.assertEqual(SKOS_PROPERTY_MAP[SKOS + "definition"], "description")
+
+    def test_every_target_is_a_column_we_write(self):
+        # A property mapped to a column KGX is not asked for is silently lost.
+        for source, target in SKOS_PROPERTY_MAP.items():
+            self.assertIn(target, KGX_NODE_COLUMNS, f"{source} -> {target}")
+
+    def test_the_scratch_column_is_asked_for_but_not_published(self):
+        self.assertIn(PREF_LABEL_COLUMN, KGX_NODE_COLUMNS)
+        self.assertNotIn(PREF_LABEL_COLUMN, NODE_COLUMNS)
+
+    def test_the_published_columns_are_otherwise_unchanged(self):
+        # 1,183 published graphs have these; a consumer must not find one moved.
+        self.assertEqual(KGX_NODE_COLUMNS[: len(NODE_COLUMNS)], NODE_COLUMNS)
+
+
+class TestItIsWiredIntoTheTransform(TestCase):
+    """A pass nothing calls renames nothing."""
+
+    def setUp(self):
+        from kg_bioportal.robot_utils import RobotResult
+        from kg_bioportal.transformer import Transformer
+
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        input_dir = os.path.join(self._tmp.name, "raw")
+        source = os.path.join(input_dir, "VOCAB", "1", "onto.owl")
+        os.makedirs(os.path.dirname(source))
+        rdfxml = ('<?xml version="1.0"?>\n<rdf:RDF '
+                  'xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" '
+                  'xmlns:owl="http://www.w3.org/2002/07/owl#">\n'
+                  '<owl:Ontology rdf:about="http://example.org/onto"/>\n'
+                  '</rdf:RDF>\n')
+        with open(source, "w") as f:
+            f.write(rdfxml)
+
+        txr = Transformer.__new__(Transformer)
+        txr.input_dir = input_dir
+        txr.output_dir = os.path.join(self._tmp.name, "transformed")
+        txr.timeout_sec, txr.timeout_min = 60, 1
+        txr.max_source_bytes = 0
+        txr.robot_path, txr.robot_env = "/nonexistent/robot", {}
+
+        def robot(**kwargs):
+            os.makedirs(os.path.dirname(kwargs["output_path"]), exist_ok=True)
+            with open(kwargs["output_path"], "w") as f:
+                f.write(rdfxml)
+            return RobotResult(True)
+
+        captured = {}
+
+        class FakeKGX:
+            def __init__(self, *a, **k):
+                pass
+
+            def transform(self, input_args, output_args):
+                captured["input"] = dict(input_args)
+                captured["output"] = dict(output_args)
+                cols = output_args["node_properties"]
+                with open(output_args["filename"] + "_nodes.tsv", "w") as f:
+                    f.write("\t".join(cols) + "\n")
+                    row = {"id": "A:1", "category": "biolink:NamedThing",
+                           PREF_LABEL_COLUMN: "from skos"}
+                    f.write("\t".join(row.get(c, "") for c in cols) + "\n")
+                with open(output_args["filename"] + "_edges.tsv", "w") as f:
+                    f.write("id\tsubject\tpredicate\tobject\tcategory\n")
+
+        with mock.patch("kg_bioportal.transformer.robot_convert", robot), \
+             mock.patch("kg_bioportal.transformer.robot_relax", robot), \
+             mock.patch("kg_bioportal.transformer.KGXTransformer", FakeKGX):
+            self.outcome = txr.transform(source, compress=False)
+        self.captured = captured
+        self.nodes = os.path.join(txr.output_dir, "VOCAB", "1", "VOCAB_nodes.tsv")
+
+    def test_the_skos_predicates_reach_input_args(self):
+        self.assertEqual(self.captured["input"]["predicate_mappings"], SKOS_PROPERTY_MAP)
+        self.assertEqual(sorted(self.captured["input"]["node_property_predicates"]),
+                         sorted(SKOS_PROPERTY_MAP))
+
+    def test_kgx_is_asked_for_the_scratch_column(self):
+        self.assertEqual(self.captured["output"]["node_properties"], KGX_NODE_COLUMNS)
+
+    def test_the_published_file_has_the_name_and_not_the_column(self):
+        with open(self.nodes) as f:
+            header = f.readline().rstrip("\n").split("\t")
+            row = dict(zip(header, f.readline().rstrip("\n").split("\t")))
+        self.assertNotIn(PREF_LABEL_COLUMN, header)
+        self.assertEqual(row["name"], "from skos")
+
+    def test_the_transform_still_succeeds(self):
+        self.assertTrue(self.outcome.success)
+        self.assertEqual(self.outcome.nodecount, 1)


### PR DESCRIPTION
Closes #173.

## The problem

KGX reads the node properties the Biolink model names, and `name` is `rdfs:label` and nothing else. A vocabulary that labels with `skos:prefLabel` — which is what SKOS is *for* — came out with no names at all. Measured on `data-2026.08.26-16`, across the twenty ontologies holding the most uncategorized nodes:

```
DDSS               89,369 nodes        0 named
GEXO              166,291 nodes        0 named
ICD10PCS          192,698 nodes        4 named
NLMVS              75,182 nodes        1 named
OCHV              171,288 nodes        1 named
SNMI              109,166 nodes       10 named
XREF-FUNDER-REG   205,916 nodes        1 named
```

**1,009,910 nodes**, published as though fine. ICD-10-PCS ships 192,698 procedure codes and four names, three of which are metadata properties rather than codes.

## The fix is configuration

`Transformer.transform` already forwards `predicate_mappings` and `node_property_predicates` to `RdfSource`, so no `kgx_patches` entry is needed — it is two keys in the `input_args` the transform already builds. `skos:altLabel` becomes a synonym and `skos:definition` a description in the same change, since the same vocabularies lose those for the same reason. `dcterms:title` needs nothing; Biolink already maps it to `name`.

## The trap, which is most of the diff

**Mapping `skos:prefLabel` straight onto `name` is not safe.** `name` is single-valued, so for a term carrying both `rdfs:label` and a differing `prefLabel`, the winner is whichever the parser reaches last — and that order comes out of a **set**. The same input across `PYTHONHASHSEED` 0–7:

```
seed 0 -> skos    seed 2 -> rdfs    seed 4 -> skos    seed 6 -> skos
seed 1 -> rdfs    seed 3 -> skos    seed 5 -> rdfs    seed 7 -> skos
```

A published name that flips between releases with no change to the source is worse than a missing one. I caught this only because a second run of an apparently-passing config disagreed with the first.

So `prefLabel` is given **a column of its own**, where it can race nothing, and `adopt_pref_labels` folds it into `name` afterwards — only where `rdfs:label` left `name` empty — then drops the scratch column before the file is published. The choice is made against what was written rather than against parse order.

Result: **deterministic**, and `rdfs:label` always wins, so **no name in the 1,183 existing graphs changes**.

## Verification

- 606 tests pass; 22 new in `tests/test_skos_labels.py`.
- One existing guard fired correctly and was updated rather than weakened — `test_the_columns_are_declared_on_output_args` asserts what KGX is asked for, which is now one column wider. It still asserts every published column is declared, in the same order.
- Mutation-tested: 10 deliberate breakages, all caught — including `prefLabel` mapped straight to `name`, the scratch column not being dropped, and the pass never being called.
- Run end to end against **real ROBOT and real KGX at several hash seeds**, confirming the same output each time.

## Follow-on

This unblocks judging **ICD10PCS** and **SNMI** for a whole-ontology default category in #169 — together another ~300k nodes — which I left out precisely because there was nothing to check them against.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JM47TqJy5r9R2T2FgcWJhM)_