### PR TITLE
Seed the roots the big remaining ontologies actually hang off (#169)

### DIFF
--- a/.claude/skills/kg-bioportal-data/references/data-model.md
+++ b/.claude/skills/kg-bioportal-data/references/data-model.md
@@ -159,7 +159,7 @@ are exempt. A default is a claim about an ontology rather than a fact read out o
 weaker signal than the rest — treat those four accordingly.
 
 How much of an ontology this reaches depends on whether it is built on shared vocabulary.
-Collection-wide it is **37.3%** of 8.27M nodes. On the large OBO ontologies it is most of the
+Collection-wide it is **41.1%** of 8.27M nodes. On the large OBO ontologies it is most of the
 graph — VTO 96.8%, MONDO 93.6%, ERO 89.8%, GO-PLUS and OBA ~80% — while much of the rest of the
 collection is bespoke, rooted in one-off project IRIs that no seed table reaches.
 A node may carry more than one category, pipe-delimited, where two equally specific seeds apply.

--- a/src/kg_bioportal/categories.py
+++ b/src/kg_bioportal/categories.py
@@ -117,6 +117,39 @@ SEEDS: Dict[str, str] = {
     # OMIT's root carries no label of its own; its subclasses are gene symbols
     # (A1BG, A2M, NAT1, NAT2 ...), which is what identifies it.
     "NCRO:0000025": "biolink:Gene",                  #                    59,874
+    # SIO's real top level, read from the published SIO graph. (SIO:000000
+    # "entity" is deliberately absent: it is the top, and seeding the top only
+    # re-derives NamedThing.)
+    "SIO:000776": "biolink:PhysicalEntity",          # object
+    "SIO:000614": "biolink:Attribute",               # attribute
+    "SIO:000006": "biolink:Activity",                # process
+    # Roots identified from another published graph rather than from a label of
+    # their own, then confirmed against their subclasses. The reach noted is
+    # measured on data-2026.08.26-16.
+    #
+    # FMA's anatomical entity, under the IRI the OWL API rewrote it to. Its two
+    # subclasses are "Physical anatomical entity" and "Non-physical anatomical
+    # entity", which is what identifies it.
+    "http://purl.org/obo/owlapi/fma#FMA_62955": "biolink:AnatomicalEntity",  # 78,558
+    # CCF, whose classes carry no label inside HRA but do inside CCF itself.
+    "http://purl.org/ccf/AnatomicalStructure": "biolink:AnatomicalEntity",   #  7,838
+    "http://purl.org/ccf/CellType": "biolink:Cell",                          #  1,831
+    # (ccf/Biomarker is deliberately absent: its subclasses mix gene symbols
+    # with peptides, so no one category is true of them.)
+    "https://identifiers.org/ito:Process": "biolink:Activity",               # 14,351
+    # HOOM keeps its HPO and Orphanet identifiers under classes of their own.
+    "http://www.semanticweb.org/ontology/HOOM#HPO_id": "biolink:PhenotypicFeature",  # 8,763
+    "http://www.semanticweb.org/ontology/HOOM#OrphaCode": "biolink:Disease",         # 4,362
+    # Read Codes are chaptered, and each chapter is coherent even though the
+    # ontology as a whole is not. Checked by reading each chapter's subclasses:
+    # "Artery and vein operations" under 7, "Fracture of skull" under S.
+    # Chapter T, "Causes of injury and poisoning", is absent on purpose -- its
+    # subclasses are accidents ("Railway accidents"), which is not a disease and
+    # not clearly anything else in Biolink either.
+    "http://purl.bioontology.org/ontology/RCTV2/7....00": "biolink:Procedure",  # 14,984
+    "http://purl.bioontology.org/ontology/RCTV2/4....00": "biolink:Procedure",  #  5,992
+    "http://purl.bioontology.org/ontology/RCTV2/3....00": "biolink:Procedure",
+    "http://purl.bioontology.org/ontology/RCTV2/S....00": "biolink:Disease",    #  7,013
 }
 
 # Upper-ontology terms, kept apart because they are a *last resort*. Nearly

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -170,7 +170,43 @@ class TestTheSeedsMatchIdsThatOccur(TestCase):
         ("NCRO:0000025", "OBO:NCRO_0000025", 59874),
         ("MONDO:0000001", "MONDO:0000001", 31550),
         ("VTO:0000001", "OBO:VTO_0000001", 106998),
+        # SIO's real top level. Its own root, SIO:000000 "entity", is useless as
+        # a seed, but these three sit directly under it and carry most of the
+        # SIO-built ontologies between them.
+        ("SIO:000776", "SIO:000776", 0),
+        ("SIO:000614", "SIO:000614", 0),
+        ("SIO:000006", "SIO:000006", 0),
     ]
+
+    # Roots that arrive only as a full IRI, so no CURIE form is derived.
+    IRI_SEEDS = [
+        "http://purl.org/obo/owlapi/fma#FMA_62955",
+        "http://purl.org/ccf/AnatomicalStructure",
+        "http://purl.org/ccf/CellType",
+        "https://identifiers.org/ito:Process",
+        "http://www.semanticweb.org/ontology/HOOM#HPO_id",
+        "http://www.semanticweb.org/ontology/HOOM#OrphaCode",
+        "http://purl.bioontology.org/ontology/RCTV2/7....00",
+    ]
+
+    def test_the_iri_roots_are_seeded_verbatim(self):
+        # These carry no label in the graph that uses them; each was identified
+        # from another published graph or from its own subclasses, so the exact
+        # string is the whole of what makes them work.
+        for iri in self.IRI_SEEDS:
+            with self.subTest(iri=iri):
+                self.assertIn(iri, SEED_INDEX)
+                self.assertEqual(canonical_forms(iri), (iri,))
+
+    def test_the_ambiguous_roots_stayed_out(self):
+        # Rejected on evidence, and each would have been wrong:
+        #   ccf/Biomarker      subclasses mix gene symbols with peptides
+        #   RCTV2 chapter T    subclasses are accidents, not diseases
+        #   SIO:000000         "entity" -- seeding the top re-derives NamedThing
+        for rejected in ("http://purl.org/ccf/Biomarker",
+                         "http://purl.bioontology.org/ontology/RCTV2/T....00",
+                         "SIO:000000"):
+            self.assertNotIn(rejected, SEED_INDEX, rejected)
 
     def test_each_measured_root_is_recognised_as_written(self):
         for curie, as_published, _ in self.MEASURED:


### PR DESCRIPTION
Toward #169. Coverage **37.3% → 41.1%** of nodes (+313k), all from the existing mechanism — **no new code**, only roots found by looking at where the uncategorized nodes still were.

```
BIOMODELS  +127,918     GEXO  +63,284     RCTV2  +29,394
REXO        +58,714     RETO  +51,606     ITO    +14,352
HOOM        +13,126     HRA    +4,514     SIO     +1,583
```

## Two needed a second published graph to identify

The root carries no label in the ontology that *uses* it, but does in the ontology that *defines* it — and both definers are published, so this needed no new sources.

**SIO.** GEXO, REXO and RETO are rooted at `SIO:000000`, which is `entity` and therefore refused. Reading the published SIO graph gives the three classes directly beneath it — `object`, `attribute`, `process` — which is where those ontologies actually hang their content.

I had written this family off as blocked on #173's label fix. **That was wrong**: they were reachable all along, and seeding those three reaches **173,604 nodes** across the three.

**CCF.** HRA's roots are `ccf/AnatomicalStructure` and `ccf/CellType`, unlabelled inside HRA. CCF is published separately and labels them.

## The rest came from their own subclasses

| root | identified by |
|---|---|
| FMA's anatomical entity in BIOMODELS, under the IRI the OWL API rewrote it to | subclasses "Physical anatomical entity", "Non-physical anatomical entity" |
| `HOOM#HPO_id`, `HOOM#OrphaCode` | subclasses are `HP:…` and `ORPHA:…` |
| RCTV2 chapters 7, 4, 3, S | "Artery and vein operations" under 7; "Fracture of skull" under S |

Read Codes are chaptered, and each chapter is coherent even though RCTV2 as a whole is not — which is why it gets four seeds rather than a whole-ontology default.

## Three rejected, and the tests hold them out

| candidate | why not |
|---|---|
| `ccf/Biomarker` | subclasses mix gene symbols with peptides — no one category is true of them |
| RCTV2 chapter T | subclasses are accidents ("Railway accidents", "Motor vehicle traffic accidents") — not a disease, and not clearly anything else in Biolink |
| `SIO:000000` | `entity` — the top, and seeding the top only re-derives `NamedThing` |

**IOBC** (233,915 nodes) is untouched for the same reason: its largest root is labelled "General".

## Verification

- 606 tests pass; `tests/test_categories.py` gains coverage for the IRI-only roots and an explicit test that each rejected candidate stayed out.
- Mutation-tested: 6 breakages, all caught — including adding either rejected root back, and seeding SIO's useless top.
- No ontology went backwards, checked against the twelve originally sampled.

## Still open on #169

- **Edges** remain at `biolink:Association`; Biolink's association classes cannot be resolved from a subject/object category pair.
- **~800k nodes stay blocked on labels** — ICD10PCS, SNMI, OCHV, NLMVS, XREF-FUNDER-REG, DDSS. #175 fixes that in the code, but their labels only exist after the next transform run.
- **RDL** (617,934) and **NATPRO** stay rejected as genuinely mixed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JM47TqJy5r9R2T2FgcWJhM)_